### PR TITLE
Fix typo in validate-deployment workflow (issue #7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: Continuous Integration
 
 on:
   pull_request_target: {}
-  pull_request: {} # TESTING ONLY!!!
 
 permissions:
   contents: read

--- a/.github/workflows/validate-deployment.yml
+++ b/.github/workflows/validate-deployment.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Count commits in candidate ref that are not in protected ref
         id: all-cherries
         run: |
-          $CHERRY_FILE=$(mktemp -t cherries.XXXXX)
+          CHERRY_FILE=$(mktemp -t cherries.XXXXX)
           git cherry -v "$PROTECTED_REF" "$DEPLOYMENT_REF" > $CHERRY_FILE
           echo "count=$(cat $CHERRY_FILE | wc -l)" >> $GITHUB_OUTPUT
           echo "file=$CHERRY_FILE" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR fixes an issue from #26 in which a workflow step contained a syntax error when setting an environment variable. This is currently causing the [Deploy to Staging](https://github.com/usdigitalresponse/cpf-reporter/actions/workflows/deploy-staging.yml) workflow to fail, as seen [here](https://github.com/usdigitalresponse/cpf-reporter/actions/runs/7119662306/job/19385266574#step:5:12).