### PR TITLE
Fix incorrect job input for API function artifacts path (issue #7)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -122,7 +122,7 @@ jobs:
     uses: ./.github/workflows/terraform-apply.yml
     with:
       api-functions-artifacts-key: ${{ needs.build.outputs.api-functions-artifacts-key }}
-      api-functions-artifacts-path: ${{ needs.build.outputs.api-attestation-artifacts-path }}
+      api-functions-artifacts-path: ${{ needs.build.outputs.api-functions-artifacts-path }}
       web-artifacts-key: ${{ needs.build.outputs.web-artifacts-key }}
       web-artifacts-path: ${{ needs.build.outputs.web-artifacts-path }}
       tf-plan-artifacts-key: ${{ needs.tf-plan.outputs.artifacts-key }}


### PR DESCRIPTION
Yet another follow-up fix for #26. This PR fixes an issue where the wrong path was being provided to the `tf-plan` job in the `Deploy to Staging` workflow, which is currently causing the job to fail.

This was the result of a simple typo (likely an autocomplete error on my part), so the change is minimal.