### PR TITLE
Add User and Role models

### DIFF
--- a/api/db/migrations/20231207184509_add_templates_and_reporting_periods/migration.sql
+++ b/api/db/migrations/20231207184509_add_templates_and_reporting_periods/migration.sql
@@ -1,0 +1,51 @@
+-- CreateTable
+CREATE TABLE "InputTemplate" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "version" TEXT NOT NULL,
+    "effectiveDate" DATE NOT NULL,
+    "rulesGeneratedAt" TIMESTAMPTZ(6),
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "InputTemplate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OutputTemplate" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "version" TEXT NOT NULL,
+    "effectiveDate" DATE NOT NULL,
+    "rulesGeneratedAt" TIMESTAMPTZ(6),
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "OutputTemplate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ReportingPeriod" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "startDate" DATE NOT NULL,
+    "endDate" DATE NOT NULL,
+    "certifiedAt" TIMESTAMPTZ(6),
+    "certifiedById" INTEGER,
+    "inputTemplateId" INTEGER NOT NULL,
+    "outputTemplateId" INTEGER NOT NULL,
+    "isCurrentPeriod" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "ReportingPeriod_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "ReportingPeriod" ADD CONSTRAINT "ReportingPeriod_certifiedById_fkey" FOREIGN KEY ("certifiedById") REFERENCES "User"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "ReportingPeriod" ADD CONSTRAINT "ReportingPeriod_inputTemplateId_fkey" FOREIGN KEY ("inputTemplateId") REFERENCES "InputTemplate"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "ReportingPeriod" ADD CONSTRAINT "ReportingPeriod_outputTemplateId_fkey" FOREIGN KEY ("outputTemplateId") REFERENCES "OutputTemplate"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -26,17 +26,18 @@ model Organization {
 }
 
 model User {
-  id             Int          @id @default(autoincrement())
+  id             Int               @id @default(autoincrement())
   email          String
   name           String?
   agencyId       Int?
   organizationId Int
   roleId         Int?
-  createdAt      DateTime     @default(now())
+  createdAt      DateTime          @default(now())
   updatedAt      DateTime
-  agency         Agency?      @relation(fields: [agencyId], references: [id])
-  organization   Organization @relation(fields: [organizationId], references: [id])
-  role           Role?        @relation(fields: [roleId], references: [id])
+  agency         Agency?           @relation(fields: [agencyId], references: [id])
+  organization   Organization      @relation(fields: [organizationId], references: [id])
+  role           Role?             @relation(fields: [roleId], references: [id])
+  certified      ReportingPeriod[]
 }
 
 model Role {
@@ -45,4 +46,43 @@ model Role {
   createdAt DateTime @default(now())
   updatedAt DateTime
   users     User[]
+}
+
+model InputTemplate {
+  id                 Int               @id @default(autoincrement())
+  name               String
+  version            String
+  effectiveDate      DateTime          @db.Date
+  rulesGeneratedAt   DateTime?         @db.Timestamptz(6)
+  createdAt          DateTime          @default(now()) @db.Timestamptz(6)
+  updatedAt          DateTime          @db.Timestamptz(6)
+  reportingPeriods   ReportingPeriod[]
+}
+
+model OutputTemplate {
+  id                 Int               @id @default(autoincrement())
+  name               String
+  version            String
+  effectiveDate      DateTime          @db.Date
+  rulesGeneratedAt   DateTime?         @db.Timestamptz(6)
+  createdAt          DateTime          @default(now()) @db.Timestamptz(6)
+  updatedAt          DateTime          @db.Timestamptz(6)
+  reportingPeriods   ReportingPeriod[]
+}
+
+model ReportingPeriod {
+  id               Int            @id @default(autoincrement())
+  name             String
+  startDate        DateTime       @db.Date
+  endDate          DateTime       @db.Date
+  certifiedAt      DateTime?      @db.Timestamptz(6)
+  certifiedById    Int?
+  certifiedBy      User?          @relation(fields: [certifiedById], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  inputTemplateId  Int
+  inputTemplate    InputTemplate  @relation(fields: [inputTemplateId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  outputTemplateId Int
+  outputTemplate   OutputTemplate @relation(fields: [outputTemplateId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  isCurrentPeriod  Boolean        @default(false)
+  createdAt        DateTime       @default(now()) @db.Timestamptz(6)
+  updatedAt        DateTime       @db.Timestamptz(6)
 }

--- a/api/src/graphql/inputTemplates.sdl.ts
+++ b/api/src/graphql/inputTemplates.sdl.ts
@@ -1,0 +1,41 @@
+export const schema = gql`
+  type InputTemplate {
+    id: Int!
+    name: String!
+    version: String!
+    effectiveDate: DateTime!
+    rulesGeneratedAt: DateTime!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    reportingPeriods: [ReportingPeriod]!
+  }
+
+  type Query {
+    inputTemplates: [InputTemplate!]! @requireAuth
+    inputTemplate(id: Int!): InputTemplate @requireAuth
+  }
+
+  input CreateInputTemplateInput {
+    name: String!
+    version: String!
+    effectiveDate: DateTime!
+    rulesGeneratedAt: DateTime!
+  }
+
+  input UpdateInputTemplateInput {
+    name: String
+    version: String
+    effectiveDate: DateTime
+    rulesGeneratedAt: DateTime
+  }
+
+  type Mutation {
+    createInputTemplate(input: CreateInputTemplateInput!): InputTemplate!
+      @requireAuth
+    updateInputTemplate(
+      id: Int!
+      input: UpdateInputTemplateInput!
+    ): InputTemplate! @requireAuth
+    deleteInputTemplate(id: Int!): InputTemplate! @requireAuth
+  }
+`

--- a/api/src/graphql/outputTemplates.sdl.ts
+++ b/api/src/graphql/outputTemplates.sdl.ts
@@ -1,0 +1,41 @@
+export const schema = gql`
+  type OutputTemplate {
+    id: Int!
+    name: String!
+    version: String!
+    effectiveDate: DateTime!
+    rulesGeneratedAt: DateTime!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    reportingPeriods: [ReportingPeriod]!
+  }
+
+  type Query {
+    outputTemplates: [OutputTemplate!]! @requireAuth
+    outputTemplate(id: Int!): OutputTemplate @requireAuth
+  }
+
+  input CreateOutputTemplateInput {
+    name: String!
+    version: String!
+    effectiveDate: DateTime!
+    rulesGeneratedAt: DateTime!
+  }
+
+  input UpdateOutputTemplateInput {
+    name: String
+    version: String
+    effectiveDate: DateTime
+    rulesGeneratedAt: DateTime
+  }
+
+  type Mutation {
+    createOutputTemplate(input: CreateOutputTemplateInput!): OutputTemplate!
+      @requireAuth
+    updateOutputTemplate(
+      id: Int!
+      input: UpdateOutputTemplateInput!
+    ): OutputTemplate! @requireAuth
+    deleteOutputTemplate(id: Int!): OutputTemplate! @requireAuth
+  }
+`

--- a/api/src/graphql/reportingPeriods.sdl.ts
+++ b/api/src/graphql/reportingPeriods.sdl.ts
@@ -1,0 +1,55 @@
+export const schema = gql`
+  type ReportingPeriod {
+    id: Int!
+    name: String!
+    startDate: DateTime!
+    endDate: DateTime!
+    certifiedAt: DateTime
+    certifiedById: Int
+    certifiedBy: User
+    inputTemplateId: Int!
+    inputTemplate: InputTemplate!
+    outputTemplateId: Int!
+    outputTemplate: OutputTemplate!
+    isCurrentPeriod: Boolean!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+  }
+
+  type Query {
+    reportingPeriods: [ReportingPeriod!]! @requireAuth
+    reportingPeriod(id: Int!): ReportingPeriod @requireAuth
+  }
+
+  input CreateReportingPeriodInput {
+    name: String!
+    startDate: DateTime!
+    endDate: DateTime!
+    certifiedAt: DateTime
+    certifiedById: Int
+    inputTemplateId: Int!
+    outputTemplateId: Int!
+    isCurrentPeriod: Boolean!
+  }
+
+  input UpdateReportingPeriodInput {
+    name: String
+    startDate: DateTime
+    endDate: DateTime
+    certifiedAt: DateTime
+    certifiedById: Int
+    inputTemplateId: Int
+    outputTemplateId: Int
+    isCurrentPeriod: Boolean
+  }
+
+  type Mutation {
+    createReportingPeriod(input: CreateReportingPeriodInput!): ReportingPeriod!
+      @requireAuth
+    updateReportingPeriod(
+      id: Int!
+      input: UpdateReportingPeriodInput!
+    ): ReportingPeriod! @requireAuth
+    deleteReportingPeriod(id: Int!): ReportingPeriod! @requireAuth
+  }
+`

--- a/api/src/graphql/roles.sdl.ts
+++ b/api/src/graphql/roles.sdl.ts
@@ -1,0 +1,28 @@
+export const schema = gql`
+  type Role {
+    id: Int!
+    name: String!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    users: [User]!
+  }
+
+  type Query {
+    roles: [Role!]! @requireAuth
+    role(id: Int!): Role @requireAuth
+  }
+
+  input CreateRoleInput {
+    name: String!
+  }
+
+  input UpdateRoleInput {
+    name: String
+  }
+
+  type Mutation {
+    createRole(input: CreateRoleInput!): Role! @requireAuth
+    updateRole(id: Int!, input: UpdateRoleInput!): Role! @requireAuth
+    deleteRole(id: Int!): Role! @requireAuth
+  }
+`

--- a/api/src/graphql/users.sdl.ts
+++ b/api/src/graphql/users.sdl.ts
@@ -1,0 +1,43 @@
+export const schema = gql`
+  type User {
+    id: Int!
+    email: String!
+    name: String
+    agencyId: Int
+    organizationId: Int!
+    roleId: Int
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    agency: Agency
+    organization: Organization!
+    role: Role
+    certified: [ReportingPeriod]!
+  }
+
+  type Query {
+    users: [User!]! @requireAuth
+    user(id: Int!): User @requireAuth
+  }
+
+  input CreateUserInput {
+    email: String!
+    name: String
+    agencyId: Int
+    organizationId: Int!
+    roleId: Int
+  }
+
+  input UpdateUserInput {
+    email: String
+    name: String
+    agencyId: Int
+    organizationId: Int
+    roleId: Int
+  }
+
+  type Mutation {
+    createUser(input: CreateUserInput!): User! @requireAuth
+    updateUser(id: Int!, input: UpdateUserInput!): User! @requireAuth
+    deleteUser(id: Int!): User! @requireAuth
+  }
+`

--- a/api/src/services/inputTemplates/inputTemplates.scenarios.ts
+++ b/api/src/services/inputTemplates/inputTemplates.scenarios.ts
@@ -1,0 +1,27 @@
+import type { Prisma, InputTemplate } from '@prisma/client'
+import type { ScenarioData } from '@redwoodjs/testing/api'
+
+export const standard = defineScenario<Prisma.InputTemplateCreateArgs>({
+  inputTemplate: {
+    one: {
+      data: {
+        name: 'String',
+        version: 'String',
+        effectiveDate: '2023-12-07T18:17:24.389Z',
+        rulesGeneratedAt: '2023-12-07T18:17:24.389Z',
+        updatedAt: '2023-12-07T18:17:24.389Z',
+      },
+    },
+    two: {
+      data: {
+        name: 'String',
+        version: 'String',
+        effectiveDate: '2023-12-07T18:17:24.389Z',
+        rulesGeneratedAt: '2023-12-07T18:17:24.389Z',
+        updatedAt: '2023-12-07T18:17:24.389Z',
+      },
+    },
+  },
+})
+
+export type StandardScenario = ScenarioData<InputTemplate, 'inputTemplate'>

--- a/api/src/services/inputTemplates/inputTemplates.test.ts
+++ b/api/src/services/inputTemplates/inputTemplates.test.ts
@@ -1,0 +1,74 @@
+import type { InputTemplate } from '@prisma/client'
+
+import {
+  inputTemplates,
+  inputTemplate,
+  createInputTemplate,
+  updateInputTemplate,
+  deleteInputTemplate,
+} from './inputTemplates'
+import type { StandardScenario } from './inputTemplates.scenarios'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float.
+//           Please refer to the RedwoodJS Testing Docs:
+//       https://redwoodjs.com/docs/testing#testing-services
+// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+
+describe('inputTemplates', () => {
+  scenario('returns all inputTemplates', async (scenario: StandardScenario) => {
+    const result = await inputTemplates()
+
+    expect(result.length).toEqual(Object.keys(scenario.inputTemplate).length)
+  })
+
+  scenario(
+    'returns a single inputTemplate',
+    async (scenario: StandardScenario) => {
+      const result = await inputTemplate({ id: scenario.inputTemplate.one.id })
+
+      expect(result).toEqual(scenario.inputTemplate.one)
+    }
+  )
+
+  scenario('creates a inputTemplate', async () => {
+    const result = await createInputTemplate({
+      input: {
+        name: 'String',
+        version: 'String',
+        effectiveDate: '2023-12-07T18:17:24.374Z',
+        rulesGeneratedAt: '2023-12-07T18:17:24.374Z',
+        updatedAt: '2023-12-07T18:17:24.374Z',
+      },
+    })
+
+    expect(result.name).toEqual('String')
+    expect(result.version).toEqual('String')
+    expect(result.effectiveDate).toEqual(new Date('2023-12-07T18:17:24.374Z'))
+    expect(result.rulesGeneratedAt).toEqual(
+      new Date('2023-12-07T18:17:24.374Z')
+    )
+    expect(result.updatedAt).toEqual(new Date('2023-12-07T18:17:24.374Z'))
+  })
+
+  scenario('updates a inputTemplate', async (scenario: StandardScenario) => {
+    const original = (await inputTemplate({
+      id: scenario.inputTemplate.one.id,
+    })) as InputTemplate
+    const result = await updateInputTemplate({
+      id: original.id,
+      input: { name: 'String2' },
+    })
+
+    expect(result.name).toEqual('String2')
+  })
+
+  scenario('deletes a inputTemplate', async (scenario: StandardScenario) => {
+    const original = (await deleteInputTemplate({
+      id: scenario.inputTemplate.one.id,
+    })) as InputTemplate
+    const result = await inputTemplate({ id: original.id })
+
+    expect(result).toEqual(null)
+  })
+})

--- a/api/src/services/inputTemplates/inputTemplates.ts
+++ b/api/src/services/inputTemplates/inputTemplates.ts
@@ -1,0 +1,51 @@
+import type {
+  QueryResolvers,
+  MutationResolvers,
+  InputTemplateRelationResolvers,
+} from 'types/graphql'
+
+import { db } from 'src/lib/db'
+
+export const inputTemplates: QueryResolvers['inputTemplates'] = () => {
+  return db.inputTemplate.findMany()
+}
+
+export const inputTemplate: QueryResolvers['inputTemplate'] = ({ id }) => {
+  return db.inputTemplate.findUnique({
+    where: { id },
+  })
+}
+
+export const createInputTemplate: MutationResolvers['createInputTemplate'] = ({
+  input,
+}) => {
+  return db.inputTemplate.create({
+    data: input,
+  })
+}
+
+export const updateInputTemplate: MutationResolvers['updateInputTemplate'] = ({
+  id,
+  input,
+}) => {
+  return db.inputTemplate.update({
+    data: input,
+    where: { id },
+  })
+}
+
+export const deleteInputTemplate: MutationResolvers['deleteInputTemplate'] = ({
+  id,
+}) => {
+  return db.inputTemplate.delete({
+    where: { id },
+  })
+}
+
+export const InputTemplate: InputTemplateRelationResolvers = {
+  reportingPeriods: (_obj, { root }) => {
+    return db.inputTemplate
+      .findUnique({ where: { id: root?.id } })
+      .reportingPeriods()
+  },
+}

--- a/api/src/services/outputTemplates/outputTemplates.scenarios.ts
+++ b/api/src/services/outputTemplates/outputTemplates.scenarios.ts
@@ -1,0 +1,27 @@
+import type { Prisma, OutputTemplate } from '@prisma/client'
+import type { ScenarioData } from '@redwoodjs/testing/api'
+
+export const standard = defineScenario<Prisma.OutputTemplateCreateArgs>({
+  outputTemplate: {
+    one: {
+      data: {
+        name: 'String',
+        version: 'String',
+        effectiveDate: '2023-12-07T18:17:34.973Z',
+        rulesGeneratedAt: '2023-12-07T18:17:34.973Z',
+        updatedAt: '2023-12-07T18:17:34.973Z',
+      },
+    },
+    two: {
+      data: {
+        name: 'String',
+        version: 'String',
+        effectiveDate: '2023-12-07T18:17:34.973Z',
+        rulesGeneratedAt: '2023-12-07T18:17:34.973Z',
+        updatedAt: '2023-12-07T18:17:34.973Z',
+      },
+    },
+  },
+})
+
+export type StandardScenario = ScenarioData<OutputTemplate, 'outputTemplate'>

--- a/api/src/services/outputTemplates/outputTemplates.test.ts
+++ b/api/src/services/outputTemplates/outputTemplates.test.ts
@@ -1,0 +1,79 @@
+import type { OutputTemplate } from '@prisma/client'
+
+import {
+  outputTemplates,
+  outputTemplate,
+  createOutputTemplate,
+  updateOutputTemplate,
+  deleteOutputTemplate,
+} from './outputTemplates'
+import type { StandardScenario } from './outputTemplates.scenarios'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float.
+//           Please refer to the RedwoodJS Testing Docs:
+//       https://redwoodjs.com/docs/testing#testing-services
+// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+
+describe('outputTemplates', () => {
+  scenario(
+    'returns all outputTemplates',
+    async (scenario: StandardScenario) => {
+      const result = await outputTemplates()
+
+      expect(result.length).toEqual(Object.keys(scenario.outputTemplate).length)
+    }
+  )
+
+  scenario(
+    'returns a single outputTemplate',
+    async (scenario: StandardScenario) => {
+      const result = await outputTemplate({
+        id: scenario.outputTemplate.one.id,
+      })
+
+      expect(result).toEqual(scenario.outputTemplate.one)
+    }
+  )
+
+  scenario('creates a outputTemplate', async () => {
+    const result = await createOutputTemplate({
+      input: {
+        name: 'String',
+        version: 'String',
+        effectiveDate: '2023-12-07T18:17:34.958Z',
+        rulesGeneratedAt: '2023-12-07T18:17:34.958Z',
+        updatedAt: '2023-12-07T18:17:34.958Z',
+      },
+    })
+
+    expect(result.name).toEqual('String')
+    expect(result.version).toEqual('String')
+    expect(result.effectiveDate).toEqual(new Date('2023-12-07T18:17:34.958Z'))
+    expect(result.rulesGeneratedAt).toEqual(
+      new Date('2023-12-07T18:17:34.958Z')
+    )
+    expect(result.updatedAt).toEqual(new Date('2023-12-07T18:17:34.958Z'))
+  })
+
+  scenario('updates a outputTemplate', async (scenario: StandardScenario) => {
+    const original = (await outputTemplate({
+      id: scenario.outputTemplate.one.id,
+    })) as OutputTemplate
+    const result = await updateOutputTemplate({
+      id: original.id,
+      input: { name: 'String2' },
+    })
+
+    expect(result.name).toEqual('String2')
+  })
+
+  scenario('deletes a outputTemplate', async (scenario: StandardScenario) => {
+    const original = (await deleteOutputTemplate({
+      id: scenario.outputTemplate.one.id,
+    })) as OutputTemplate
+    const result = await outputTemplate({ id: original.id })
+
+    expect(result).toEqual(null)
+  })
+})

--- a/api/src/services/outputTemplates/outputTemplates.ts
+++ b/api/src/services/outputTemplates/outputTemplates.ts
@@ -1,0 +1,47 @@
+import type {
+  QueryResolvers,
+  MutationResolvers,
+  OutputTemplateRelationResolvers,
+} from 'types/graphql'
+
+import { db } from 'src/lib/db'
+
+export const outputTemplates: QueryResolvers['outputTemplates'] = () => {
+  return db.outputTemplate.findMany()
+}
+
+export const outputTemplate: QueryResolvers['outputTemplate'] = ({ id }) => {
+  return db.outputTemplate.findUnique({
+    where: { id },
+  })
+}
+
+export const createOutputTemplate: MutationResolvers['createOutputTemplate'] =
+  ({ input }) => {
+    return db.outputTemplate.create({
+      data: input,
+    })
+  }
+
+export const updateOutputTemplate: MutationResolvers['updateOutputTemplate'] =
+  ({ id, input }) => {
+    return db.outputTemplate.update({
+      data: input,
+      where: { id },
+    })
+  }
+
+export const deleteOutputTemplate: MutationResolvers['deleteOutputTemplate'] =
+  ({ id }) => {
+    return db.outputTemplate.delete({
+      where: { id },
+    })
+  }
+
+export const OutputTemplate: OutputTemplateRelationResolvers = {
+  reportingPeriods: (_obj, { root }) => {
+    return db.outputTemplate
+      .findUnique({ where: { id: root?.id } })
+      .reportingPeriods()
+  },
+}

--- a/api/src/services/reportingPeriods/reportingPeriods.scenarios.ts
+++ b/api/src/services/reportingPeriods/reportingPeriods.scenarios.ts
@@ -1,0 +1,57 @@
+import type { Prisma, ReportingPeriod } from '@prisma/client'
+import type { ScenarioData } from '@redwoodjs/testing/api'
+
+export const standard = defineScenario<Prisma.ReportingPeriodCreateArgs>({
+  reportingPeriod: {
+    one: {
+      data: {
+        name: 'String',
+        startDate: '2023-12-07T18:38:12.356Z',
+        endDate: '2023-12-07T18:38:12.356Z',
+        updatedAt: '2023-12-07T18:38:12.356Z',
+        inputTemplate: {
+          create: {
+            name: 'String',
+            version: 'String',
+            effectiveDate: '2023-12-07T18:38:12.356Z',
+            updatedAt: '2023-12-07T18:38:12.356Z',
+          },
+        },
+        outputTemplate: {
+          create: {
+            name: 'String',
+            version: 'String',
+            effectiveDate: '2023-12-07T18:38:12.356Z',
+            updatedAt: '2023-12-07T18:38:12.356Z',
+          },
+        },
+      },
+    },
+    two: {
+      data: {
+        name: 'String',
+        startDate: '2023-12-07T18:38:12.356Z',
+        endDate: '2023-12-07T18:38:12.356Z',
+        updatedAt: '2023-12-07T18:38:12.356Z',
+        inputTemplate: {
+          create: {
+            name: 'String',
+            version: 'String',
+            effectiveDate: '2023-12-07T18:38:12.356Z',
+            updatedAt: '2023-12-07T18:38:12.356Z',
+          },
+        },
+        outputTemplate: {
+          create: {
+            name: 'String',
+            version: 'String',
+            effectiveDate: '2023-12-07T18:38:12.356Z',
+            updatedAt: '2023-12-07T18:38:12.356Z',
+          },
+        },
+      },
+    },
+  },
+})
+
+export type StandardScenario = ScenarioData<ReportingPeriod, 'reportingPeriod'>

--- a/api/src/services/reportingPeriods/reportingPeriods.test.ts
+++ b/api/src/services/reportingPeriods/reportingPeriods.test.ts
@@ -1,0 +1,85 @@
+import type { ReportingPeriod } from '@prisma/client'
+
+import {
+  reportingPeriods,
+  reportingPeriod,
+  createReportingPeriod,
+  updateReportingPeriod,
+  deleteReportingPeriod,
+} from './reportingPeriods'
+import type { StandardScenario } from './reportingPeriods.scenarios'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float.
+//           Please refer to the RedwoodJS Testing Docs:
+//       https://redwoodjs.com/docs/testing#testing-services
+// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+
+describe('reportingPeriods', () => {
+  scenario(
+    'returns all reportingPeriods',
+    async (scenario: StandardScenario) => {
+      const result = await reportingPeriods()
+
+      expect(result.length).toEqual(
+        Object.keys(scenario.reportingPeriod).length
+      )
+    }
+  )
+
+  scenario(
+    'returns a single reportingPeriod',
+    async (scenario: StandardScenario) => {
+      const result = await reportingPeriod({
+        id: scenario.reportingPeriod.one.id,
+      })
+
+      expect(result).toEqual(scenario.reportingPeriod.one)
+    }
+  )
+
+  scenario('creates a reportingPeriod', async (scenario: StandardScenario) => {
+    const result = await createReportingPeriod({
+      input: {
+        name: 'String',
+        startDate: '2023-12-07T18:38:12.341Z',
+        endDate: '2023-12-07T18:38:12.341Z',
+        inputTemplateId: scenario.reportingPeriod.two.inputTemplateId,
+        outputTemplateId: scenario.reportingPeriod.two.outputTemplateId,
+        updatedAt: '2023-12-07T18:38:12.341Z',
+      },
+    })
+
+    expect(result.name).toEqual('String')
+    expect(result.startDate).toEqual(new Date('2023-12-07T18:38:12.341Z'))
+    expect(result.endDate).toEqual(new Date('2023-12-07T18:38:12.341Z'))
+    expect(result.inputTemplateId).toEqual(
+      scenario.reportingPeriod.two.inputTemplateId
+    )
+    expect(result.outputTemplateId).toEqual(
+      scenario.reportingPeriod.two.outputTemplateId
+    )
+    expect(result.updatedAt).toEqual(new Date('2023-12-07T18:38:12.341Z'))
+  })
+
+  scenario('updates a reportingPeriod', async (scenario: StandardScenario) => {
+    const original = (await reportingPeriod({
+      id: scenario.reportingPeriod.one.id,
+    })) as ReportingPeriod
+    const result = await updateReportingPeriod({
+      id: original.id,
+      input: { name: 'String2' },
+    })
+
+    expect(result.name).toEqual('String2')
+  })
+
+  scenario('deletes a reportingPeriod', async (scenario: StandardScenario) => {
+    const original = (await deleteReportingPeriod({
+      id: scenario.reportingPeriod.one.id,
+    })) as ReportingPeriod
+    const result = await reportingPeriod({ id: original.id })
+
+    expect(result).toEqual(null)
+  })
+})

--- a/api/src/services/reportingPeriods/reportingPeriods.ts
+++ b/api/src/services/reportingPeriods/reportingPeriods.ts
@@ -1,0 +1,57 @@
+import type {
+  QueryResolvers,
+  MutationResolvers,
+  ReportingPeriodRelationResolvers,
+} from 'types/graphql'
+
+import { db } from 'src/lib/db'
+
+export const reportingPeriods: QueryResolvers['reportingPeriods'] = () => {
+  return db.reportingPeriod.findMany()
+}
+
+export const reportingPeriod: QueryResolvers['reportingPeriod'] = ({ id }) => {
+  return db.reportingPeriod.findUnique({
+    where: { id },
+  })
+}
+
+export const createReportingPeriod: MutationResolvers['createReportingPeriod'] =
+  ({ input }) => {
+    return db.reportingPeriod.create({
+      data: input,
+    })
+  }
+
+export const updateReportingPeriod: MutationResolvers['updateReportingPeriod'] =
+  ({ id, input }) => {
+    return db.reportingPeriod.update({
+      data: input,
+      where: { id },
+    })
+  }
+
+export const deleteReportingPeriod: MutationResolvers['deleteReportingPeriod'] =
+  ({ id }) => {
+    return db.reportingPeriod.delete({
+      where: { id },
+    })
+  }
+
+export const ReportingPeriod: ReportingPeriodRelationResolvers = {
+  certifiedBy: (_obj, { root }) => {
+    return db.reportingPeriod
+      .findUnique({ where: { id: root?.id } })
+      .certifiedBy()
+  },
+  inputTemplate: (_obj, { root }) => {
+    return db.reportingPeriod
+      .findUnique({ where: { id: root?.id } })
+      .inputTemplate()
+  },
+  outputTemplate: (_obj, { root }) => {
+    return db.reportingPeriod
+      .findUnique({ where: { id: root?.id } })
+      .outputTemplate()
+  },
+}

--- a/api/src/services/roles/roles.scenarios.ts
+++ b/api/src/services/roles/roles.scenarios.ts
@@ -1,0 +1,11 @@
+import type { Prisma, Role } from '@prisma/client'
+import type { ScenarioData } from '@redwoodjs/testing/api'
+
+export const standard = defineScenario<Prisma.RoleCreateArgs>({
+  role: {
+    one: { data: { name: 'String', updatedAt: '2023-12-07T18:20:00.186Z' } },
+    two: { data: { name: 'String', updatedAt: '2023-12-07T18:20:00.186Z' } },
+  },
+})
+
+export type StandardScenario = ScenarioData<Role, 'role'>

--- a/api/src/services/roles/roles.test.ts
+++ b/api/src/services/roles/roles.test.ts
@@ -1,0 +1,50 @@
+import type { Role } from '@prisma/client'
+
+import { roles, role, createRole, updateRole, deleteRole } from './roles'
+import type { StandardScenario } from './roles.scenarios'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float.
+//           Please refer to the RedwoodJS Testing Docs:
+//       https://redwoodjs.com/docs/testing#testing-services
+// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+
+describe('roles', () => {
+  scenario('returns all roles', async (scenario: StandardScenario) => {
+    const result = await roles()
+
+    expect(result.length).toEqual(Object.keys(scenario.role).length)
+  })
+
+  scenario('returns a single role', async (scenario: StandardScenario) => {
+    const result = await role({ id: scenario.role.one.id })
+
+    expect(result).toEqual(scenario.role.one)
+  })
+
+  scenario('creates a role', async () => {
+    const result = await createRole({
+      input: { name: 'String', updatedAt: '2023-12-07T18:20:00.167Z' },
+    })
+
+    expect(result.name).toEqual('String')
+    expect(result.updatedAt).toEqual(new Date('2023-12-07T18:20:00.167Z'))
+  })
+
+  scenario('updates a role', async (scenario: StandardScenario) => {
+    const original = (await role({ id: scenario.role.one.id })) as Role
+    const result = await updateRole({
+      id: original.id,
+      input: { name: 'String2' },
+    })
+
+    expect(result.name).toEqual('String2')
+  })
+
+  scenario('deletes a role', async (scenario: StandardScenario) => {
+    const original = (await deleteRole({ id: scenario.role.one.id })) as Role
+    const result = await role({ id: original.id })
+
+    expect(result).toEqual(null)
+  })
+})

--- a/api/src/services/roles/roles.ts
+++ b/api/src/services/roles/roles.ts
@@ -1,0 +1,42 @@
+import type {
+  QueryResolvers,
+  MutationResolvers,
+  RoleRelationResolvers,
+} from 'types/graphql'
+
+import { db } from 'src/lib/db'
+
+export const roles: QueryResolvers['roles'] = () => {
+  return db.role.findMany()
+}
+
+export const role: QueryResolvers['role'] = ({ id }) => {
+  return db.role.findUnique({
+    where: { id },
+  })
+}
+
+export const createRole: MutationResolvers['createRole'] = ({ input }) => {
+  return db.role.create({
+    data: input,
+  })
+}
+
+export const updateRole: MutationResolvers['updateRole'] = ({ id, input }) => {
+  return db.role.update({
+    data: input,
+    where: { id },
+  })
+}
+
+export const deleteRole: MutationResolvers['deleteRole'] = ({ id }) => {
+  return db.role.delete({
+    where: { id },
+  })
+}
+
+export const Role: RoleRelationResolvers = {
+  users: (_obj, { root }) => {
+    return db.role.findUnique({ where: { id: root?.id } }).users()
+  },
+}

--- a/api/src/services/users/users.scenarios.ts
+++ b/api/src/services/users/users.scenarios.ts
@@ -1,0 +1,23 @@
+import type { Prisma, User } from '@prisma/client'
+import type { ScenarioData } from '@redwoodjs/testing/api'
+
+export const standard = defineScenario<Prisma.UserCreateArgs>({
+  user: {
+    one: {
+      data: {
+        email: 'String',
+        updatedAt: '2023-12-07T18:20:20.679Z',
+        organization: { create: { name: 'String' } },
+      },
+    },
+    two: {
+      data: {
+        email: 'String',
+        updatedAt: '2023-12-07T18:20:20.679Z',
+        organization: { create: { name: 'String' } },
+      },
+    },
+  },
+})
+
+export type StandardScenario = ScenarioData<User, 'user'>

--- a/api/src/services/users/users.test.ts
+++ b/api/src/services/users/users.test.ts
@@ -1,0 +1,55 @@
+import type { User } from '@prisma/client'
+
+import { users, user, createUser, updateUser, deleteUser } from './users'
+import type { StandardScenario } from './users.scenarios'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float.
+//           Please refer to the RedwoodJS Testing Docs:
+//       https://redwoodjs.com/docs/testing#testing-services
+// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+
+describe('users', () => {
+  scenario('returns all users', async (scenario: StandardScenario) => {
+    const result = await users()
+
+    expect(result.length).toEqual(Object.keys(scenario.user).length)
+  })
+
+  scenario('returns a single user', async (scenario: StandardScenario) => {
+    const result = await user({ id: scenario.user.one.id })
+
+    expect(result).toEqual(scenario.user.one)
+  })
+
+  scenario('creates a user', async (scenario: StandardScenario) => {
+    const result = await createUser({
+      input: {
+        email: 'String',
+        organizationId: scenario.user.two.organizationId,
+        updatedAt: '2023-12-07T18:20:20.664Z',
+      },
+    })
+
+    expect(result.email).toEqual('String')
+    expect(result.organizationId).toEqual(scenario.user.two.organizationId)
+    expect(result.updatedAt).toEqual(new Date('2023-12-07T18:20:20.664Z'))
+  })
+
+  scenario('updates a user', async (scenario: StandardScenario) => {
+    const original = (await user({ id: scenario.user.one.id })) as User
+    const result = await updateUser({
+      id: original.id,
+      input: { email: 'String2' },
+    })
+
+    expect(result.email).toEqual('String2')
+  })
+
+  scenario('deletes a user', async (scenario: StandardScenario) => {
+    const original = (await deleteUser({ id: scenario.user.one.id })) as User
+    const result = await user({ id: original.id })
+
+    expect(result).toEqual(null)
+  })
+})

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -1,0 +1,51 @@
+import type {
+  QueryResolvers,
+  MutationResolvers,
+  UserRelationResolvers,
+} from 'types/graphql'
+
+import { db } from 'src/lib/db'
+
+export const users: QueryResolvers['users'] = () => {
+  return db.user.findMany()
+}
+
+export const user: QueryResolvers['user'] = ({ id }) => {
+  return db.user.findUnique({
+    where: { id },
+  })
+}
+
+export const createUser: MutationResolvers['createUser'] = ({ input }) => {
+  return db.user.create({
+    data: input,
+  })
+}
+
+export const updateUser: MutationResolvers['updateUser'] = ({ id, input }) => {
+  return db.user.update({
+    data: input,
+    where: { id },
+  })
+}
+
+export const deleteUser: MutationResolvers['deleteUser'] = ({ id }) => {
+  return db.user.delete({
+    where: { id },
+  })
+}
+
+export const User: UserRelationResolvers = {
+  agency: (_obj, { root }) => {
+    return db.user.findUnique({ where: { id: root?.id } }).agency()
+  },
+  organization: (_obj, { root }) => {
+    return db.user.findUnique({ where: { id: root?.id } }).organization()
+  },
+  role: (_obj, { root }) => {
+    return db.user.findUnique({ where: { id: root?.id } }).role()
+  },
+  certified: (_obj, { root }) => {
+    return db.user.findUnique({ where: { id: root?.id } }).certified()
+  },
+}

--- a/api/types/graphql.d.ts
+++ b/api/types/graphql.d.ts
@@ -1,6 +1,6 @@
 import { Prisma } from "@prisma/client"
 import { MergePrismaWithSdlTypes, MakeRelationsOptional } from '@redwoodjs/api'
-import { Agency as PrismaAgency, Organization as PrismaOrganization, User as PrismaUser, Role as PrismaRole } from '@prisma/client'
+import { Agency as PrismaAgency, Organization as PrismaOrganization, User as PrismaUser, Role as PrismaRole, InputTemplate as PrismaInputTemplate, OutputTemplate as PrismaOutputTemplate, ReportingPeriod as PrismaReportingPeriod } from '@prisma/client'
 import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 import { RedwoodGraphQLContext } from '@redwoodjs/graphql-server/dist/types';
 export type Maybe<T> = T | null;
@@ -52,18 +52,82 @@ export type CreateAgencyInput = {
   name: Scalars['String'];
 };
 
+export type CreateInputTemplateInput = {
+  effectiveDate: Scalars['DateTime'];
+  name: Scalars['String'];
+  rulesGeneratedAt: Scalars['DateTime'];
+  version: Scalars['String'];
+};
+
 export type CreateOrganizationInput = {
   name: Scalars['String'];
+};
+
+export type CreateOutputTemplateInput = {
+  effectiveDate: Scalars['DateTime'];
+  name: Scalars['String'];
+  rulesGeneratedAt: Scalars['DateTime'];
+  version: Scalars['String'];
+};
+
+export type CreateReportingPeriodInput = {
+  certifiedAt?: InputMaybe<Scalars['DateTime']>;
+  certifiedById?: InputMaybe<Scalars['Int']>;
+  endDate: Scalars['DateTime'];
+  inputTemplateId: Scalars['Int'];
+  isCurrentPeriod: Scalars['Boolean'];
+  name: Scalars['String'];
+  outputTemplateId: Scalars['Int'];
+  startDate: Scalars['DateTime'];
+};
+
+export type CreateRoleInput = {
+  name: Scalars['String'];
+};
+
+export type CreateUserInput = {
+  agencyId?: InputMaybe<Scalars['Int']>;
+  email: Scalars['String'];
+  name?: InputMaybe<Scalars['String']>;
+  organizationId: Scalars['Int'];
+  roleId?: InputMaybe<Scalars['Int']>;
+};
+
+export type InputTemplate = {
+  __typename?: 'InputTemplate';
+  createdAt: Scalars['DateTime'];
+  effectiveDate: Scalars['DateTime'];
+  id: Scalars['Int'];
+  name: Scalars['String'];
+  reportingPeriods: Array<Maybe<ReportingPeriod>>;
+  rulesGeneratedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime'];
+  version: Scalars['String'];
 };
 
 export type Mutation = {
   __typename?: 'Mutation';
   createAgency: Agency;
+  createInputTemplate: InputTemplate;
   createOrganization: Organization;
+  createOutputTemplate: OutputTemplate;
+  createReportingPeriod: ReportingPeriod;
+  createRole: Role;
+  createUser: User;
   deleteAgency: Agency;
+  deleteInputTemplate: InputTemplate;
   deleteOrganization: Organization;
+  deleteOutputTemplate: OutputTemplate;
+  deleteReportingPeriod: ReportingPeriod;
+  deleteRole: Role;
+  deleteUser: User;
   updateAgency: Agency;
+  updateInputTemplate: InputTemplate;
   updateOrganization: Organization;
+  updateOutputTemplate: OutputTemplate;
+  updateReportingPeriod: ReportingPeriod;
+  updateRole: Role;
+  updateUser: User;
 };
 
 
@@ -72,8 +136,33 @@ export type MutationcreateAgencyArgs = {
 };
 
 
+export type MutationcreateInputTemplateArgs = {
+  input: CreateInputTemplateInput;
+};
+
+
 export type MutationcreateOrganizationArgs = {
   input: CreateOrganizationInput;
+};
+
+
+export type MutationcreateOutputTemplateArgs = {
+  input: CreateOutputTemplateInput;
+};
+
+
+export type MutationcreateReportingPeriodArgs = {
+  input: CreateReportingPeriodInput;
+};
+
+
+export type MutationcreateRoleArgs = {
+  input: CreateRoleInput;
+};
+
+
+export type MutationcreateUserArgs = {
+  input: CreateUserInput;
 };
 
 
@@ -82,7 +171,32 @@ export type MutationdeleteAgencyArgs = {
 };
 
 
+export type MutationdeleteInputTemplateArgs = {
+  id: Scalars['Int'];
+};
+
+
 export type MutationdeleteOrganizationArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type MutationdeleteOutputTemplateArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type MutationdeleteReportingPeriodArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type MutationdeleteRoleArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type MutationdeleteUserArgs = {
   id: Scalars['Int'];
 };
 
@@ -93,9 +207,39 @@ export type MutationupdateAgencyArgs = {
 };
 
 
+export type MutationupdateInputTemplateArgs = {
+  id: Scalars['Int'];
+  input: UpdateInputTemplateInput;
+};
+
+
 export type MutationupdateOrganizationArgs = {
   id: Scalars['Int'];
   input: UpdateOrganizationInput;
+};
+
+
+export type MutationupdateOutputTemplateArgs = {
+  id: Scalars['Int'];
+  input: UpdateOutputTemplateInput;
+};
+
+
+export type MutationupdateReportingPeriodArgs = {
+  id: Scalars['Int'];
+  input: UpdateReportingPeriodInput;
+};
+
+
+export type MutationupdateRoleArgs = {
+  id: Scalars['Int'];
+  input: UpdateRoleInput;
+};
+
+
+export type MutationupdateUserArgs = {
+  id: Scalars['Int'];
+  input: UpdateUserInput;
 };
 
 export type Organization = {
@@ -105,16 +249,38 @@ export type Organization = {
   name: Scalars['String'];
 };
 
+export type OutputTemplate = {
+  __typename?: 'OutputTemplate';
+  createdAt: Scalars['DateTime'];
+  effectiveDate: Scalars['DateTime'];
+  id: Scalars['Int'];
+  name: Scalars['String'];
+  reportingPeriods: Array<Maybe<ReportingPeriod>>;
+  rulesGeneratedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime'];
+  version: Scalars['String'];
+};
+
 /** About the Redwood queries. */
 export type Query = {
   __typename?: 'Query';
   agencies: Array<Agency>;
   agenciesByOrganization: Array<Agency>;
   agency?: Maybe<Agency>;
+  inputTemplate?: Maybe<InputTemplate>;
+  inputTemplates: Array<InputTemplate>;
   organization?: Maybe<Organization>;
   organizations: Array<Organization>;
+  outputTemplate?: Maybe<OutputTemplate>;
+  outputTemplates: Array<OutputTemplate>;
   /** Fetches the Redwood root schema. */
   redwood?: Maybe<Redwood>;
+  reportingPeriod?: Maybe<ReportingPeriod>;
+  reportingPeriods: Array<ReportingPeriod>;
+  role?: Maybe<Role>;
+  roles: Array<Role>;
+  user?: Maybe<User>;
+  users: Array<User>;
 };
 
 
@@ -131,7 +297,37 @@ export type QueryagencyArgs = {
 
 
 /** About the Redwood queries. */
+export type QueryinputTemplateArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** About the Redwood queries. */
 export type QueryorganizationArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** About the Redwood queries. */
+export type QueryoutputTemplateArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** About the Redwood queries. */
+export type QueryreportingPeriodArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** About the Redwood queries. */
+export type QueryroleArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** About the Redwood queries. */
+export type QueryuserArgs = {
   id: Scalars['Int'];
 };
 
@@ -150,18 +346,98 @@ export type Redwood = {
   version?: Maybe<Scalars['String']>;
 };
 
+export type ReportingPeriod = {
+  __typename?: 'ReportingPeriod';
+  certifiedAt?: Maybe<Scalars['DateTime']>;
+  certifiedBy?: Maybe<User>;
+  certifiedById?: Maybe<Scalars['Int']>;
+  createdAt: Scalars['DateTime'];
+  endDate: Scalars['DateTime'];
+  id: Scalars['Int'];
+  inputTemplate: InputTemplate;
+  inputTemplateId: Scalars['Int'];
+  isCurrentPeriod: Scalars['Boolean'];
+  name: Scalars['String'];
+  outputTemplate: OutputTemplate;
+  outputTemplateId: Scalars['Int'];
+  startDate: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime'];
+};
+
+export type Role = {
+  __typename?: 'Role';
+  createdAt: Scalars['DateTime'];
+  id: Scalars['Int'];
+  name: Scalars['String'];
+  updatedAt: Scalars['DateTime'];
+  users: Array<Maybe<User>>;
+};
+
 export type UpdateAgencyInput = {
   abbreviation?: InputMaybe<Scalars['String']>;
   code?: InputMaybe<Scalars['String']>;
   name?: InputMaybe<Scalars['String']>;
 };
 
+export type UpdateInputTemplateInput = {
+  effectiveDate?: InputMaybe<Scalars['DateTime']>;
+  name?: InputMaybe<Scalars['String']>;
+  rulesGeneratedAt?: InputMaybe<Scalars['DateTime']>;
+  version?: InputMaybe<Scalars['String']>;
+};
+
 export type UpdateOrganizationInput = {
   name?: InputMaybe<Scalars['String']>;
 };
 
+export type UpdateOutputTemplateInput = {
+  effectiveDate?: InputMaybe<Scalars['DateTime']>;
+  name?: InputMaybe<Scalars['String']>;
+  rulesGeneratedAt?: InputMaybe<Scalars['DateTime']>;
+  version?: InputMaybe<Scalars['String']>;
+};
+
+export type UpdateReportingPeriodInput = {
+  certifiedAt?: InputMaybe<Scalars['DateTime']>;
+  certifiedById?: InputMaybe<Scalars['Int']>;
+  endDate?: InputMaybe<Scalars['DateTime']>;
+  inputTemplateId?: InputMaybe<Scalars['Int']>;
+  isCurrentPeriod?: InputMaybe<Scalars['Boolean']>;
+  name?: InputMaybe<Scalars['String']>;
+  outputTemplateId?: InputMaybe<Scalars['Int']>;
+  startDate?: InputMaybe<Scalars['DateTime']>;
+};
+
+export type UpdateRoleInput = {
+  name?: InputMaybe<Scalars['String']>;
+};
+
+export type UpdateUserInput = {
+  agencyId?: InputMaybe<Scalars['Int']>;
+  email?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']>;
+  organizationId?: InputMaybe<Scalars['Int']>;
+  roleId?: InputMaybe<Scalars['Int']>;
+};
+
+export type User = {
+  __typename?: 'User';
+  agency?: Maybe<Agency>;
+  agencyId?: Maybe<Scalars['Int']>;
+  certified: Array<Maybe<ReportingPeriod>>;
+  createdAt: Scalars['DateTime'];
+  email: Scalars['String'];
+  id: Scalars['Int'];
+  name?: Maybe<Scalars['String']>;
+  organization: Organization;
+  organizationId: Scalars['Int'];
+  role?: Maybe<Role>;
+  roleId?: Maybe<Scalars['Int']>;
+  updatedAt: Scalars['DateTime'];
+};
+
 type MaybeOrArrayOfMaybe<T> = T | Maybe<T> | Maybe<T>[];
-type AllMappedModels = MaybeOrArrayOfMaybe<Agency | Organization>
+type AllMappedModels = MaybeOrArrayOfMaybe<Agency | InputTemplate | Organization | OutputTemplate | ReportingPeriod | Role | User>
 
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
@@ -226,20 +502,35 @@ export type ResolversTypes = {
   BigInt: ResolverTypeWrapper<Scalars['BigInt']>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
   CreateAgencyInput: CreateAgencyInput;
+  CreateInputTemplateInput: CreateInputTemplateInput;
   CreateOrganizationInput: CreateOrganizationInput;
+  CreateOutputTemplateInput: CreateOutputTemplateInput;
+  CreateReportingPeriodInput: CreateReportingPeriodInput;
+  CreateRoleInput: CreateRoleInput;
+  CreateUserInput: CreateUserInput;
   Date: ResolverTypeWrapper<Scalars['Date']>;
   DateTime: ResolverTypeWrapper<Scalars['DateTime']>;
+  InputTemplate: ResolverTypeWrapper<MergePrismaWithSdlTypes<PrismaInputTemplate, MakeRelationsOptional<InputTemplate, AllMappedModels>, AllMappedModels>>;
   Int: ResolverTypeWrapper<Scalars['Int']>;
   JSON: ResolverTypeWrapper<Scalars['JSON']>;
   JSONObject: ResolverTypeWrapper<Scalars['JSONObject']>;
   Mutation: ResolverTypeWrapper<{}>;
   Organization: ResolverTypeWrapper<MergePrismaWithSdlTypes<PrismaOrganization, MakeRelationsOptional<Organization, AllMappedModels>, AllMappedModels>>;
+  OutputTemplate: ResolverTypeWrapper<MergePrismaWithSdlTypes<PrismaOutputTemplate, MakeRelationsOptional<OutputTemplate, AllMappedModels>, AllMappedModels>>;
   Query: ResolverTypeWrapper<{}>;
   Redwood: ResolverTypeWrapper<Redwood>;
+  ReportingPeriod: ResolverTypeWrapper<MergePrismaWithSdlTypes<PrismaReportingPeriod, MakeRelationsOptional<ReportingPeriod, AllMappedModels>, AllMappedModels>>;
+  Role: ResolverTypeWrapper<MergePrismaWithSdlTypes<PrismaRole, MakeRelationsOptional<Role, AllMappedModels>, AllMappedModels>>;
   String: ResolverTypeWrapper<Scalars['String']>;
   Time: ResolverTypeWrapper<Scalars['Time']>;
   UpdateAgencyInput: UpdateAgencyInput;
+  UpdateInputTemplateInput: UpdateInputTemplateInput;
   UpdateOrganizationInput: UpdateOrganizationInput;
+  UpdateOutputTemplateInput: UpdateOutputTemplateInput;
+  UpdateReportingPeriodInput: UpdateReportingPeriodInput;
+  UpdateRoleInput: UpdateRoleInput;
+  UpdateUserInput: UpdateUserInput;
+  User: ResolverTypeWrapper<MergePrismaWithSdlTypes<PrismaUser, MakeRelationsOptional<User, AllMappedModels>, AllMappedModels>>;
 };
 
 /** Mapping between all available schema types and the resolvers parents */
@@ -248,20 +539,35 @@ export type ResolversParentTypes = {
   BigInt: Scalars['BigInt'];
   Boolean: Scalars['Boolean'];
   CreateAgencyInput: CreateAgencyInput;
+  CreateInputTemplateInput: CreateInputTemplateInput;
   CreateOrganizationInput: CreateOrganizationInput;
+  CreateOutputTemplateInput: CreateOutputTemplateInput;
+  CreateReportingPeriodInput: CreateReportingPeriodInput;
+  CreateRoleInput: CreateRoleInput;
+  CreateUserInput: CreateUserInput;
   Date: Scalars['Date'];
   DateTime: Scalars['DateTime'];
+  InputTemplate: MergePrismaWithSdlTypes<PrismaInputTemplate, MakeRelationsOptional<InputTemplate, AllMappedModels>, AllMappedModels>;
   Int: Scalars['Int'];
   JSON: Scalars['JSON'];
   JSONObject: Scalars['JSONObject'];
   Mutation: {};
   Organization: MergePrismaWithSdlTypes<PrismaOrganization, MakeRelationsOptional<Organization, AllMappedModels>, AllMappedModels>;
+  OutputTemplate: MergePrismaWithSdlTypes<PrismaOutputTemplate, MakeRelationsOptional<OutputTemplate, AllMappedModels>, AllMappedModels>;
   Query: {};
   Redwood: Redwood;
+  ReportingPeriod: MergePrismaWithSdlTypes<PrismaReportingPeriod, MakeRelationsOptional<ReportingPeriod, AllMappedModels>, AllMappedModels>;
+  Role: MergePrismaWithSdlTypes<PrismaRole, MakeRelationsOptional<Role, AllMappedModels>, AllMappedModels>;
   String: Scalars['String'];
   Time: Scalars['Time'];
   UpdateAgencyInput: UpdateAgencyInput;
+  UpdateInputTemplateInput: UpdateInputTemplateInput;
   UpdateOrganizationInput: UpdateOrganizationInput;
+  UpdateOutputTemplateInput: UpdateOutputTemplateInput;
+  UpdateReportingPeriodInput: UpdateReportingPeriodInput;
+  UpdateRoleInput: UpdateRoleInput;
+  UpdateUserInput: UpdateUserInput;
+  User: MergePrismaWithSdlTypes<PrismaUser, MakeRelationsOptional<User, AllMappedModels>, AllMappedModels>;
 };
 
 export type requireAuthDirectiveArgs = {
@@ -304,6 +610,30 @@ export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversT
   name: 'DateTime';
 }
 
+export type InputTemplateResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['InputTemplate'] = ResolversParentTypes['InputTemplate']> = {
+  createdAt: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  effectiveDate: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  id: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  name: OptArgsResolverFn<ResolversTypes['String'], ParentType, ContextType>;
+  reportingPeriods: OptArgsResolverFn<Array<Maybe<ResolversTypes['ReportingPeriod']>>, ParentType, ContextType>;
+  rulesGeneratedAt: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  updatedAt: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  version: OptArgsResolverFn<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type InputTemplateRelationResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['InputTemplate'] = ResolversParentTypes['InputTemplate']> = {
+  createdAt?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  effectiveDate?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  id?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  name?: RequiredResolverFn<ResolversTypes['String'], ParentType, ContextType>;
+  reportingPeriods?: RequiredResolverFn<Array<Maybe<ResolversTypes['ReportingPeriod']>>, ParentType, ContextType>;
+  rulesGeneratedAt?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  updatedAt?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  version?: RequiredResolverFn<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export interface JSONScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['JSON'], any> {
   name: 'JSON';
 }
@@ -314,20 +644,50 @@ export interface JSONObjectScalarConfig extends GraphQLScalarTypeConfig<Resolver
 
 export type MutationResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   createAgency: Resolver<ResolversTypes['Agency'], ParentType, ContextType, RequireFields<MutationcreateAgencyArgs, 'input'>>;
+  createInputTemplate: Resolver<ResolversTypes['InputTemplate'], ParentType, ContextType, RequireFields<MutationcreateInputTemplateArgs, 'input'>>;
   createOrganization: Resolver<ResolversTypes['Organization'], ParentType, ContextType, RequireFields<MutationcreateOrganizationArgs, 'input'>>;
+  createOutputTemplate: Resolver<ResolversTypes['OutputTemplate'], ParentType, ContextType, RequireFields<MutationcreateOutputTemplateArgs, 'input'>>;
+  createReportingPeriod: Resolver<ResolversTypes['ReportingPeriod'], ParentType, ContextType, RequireFields<MutationcreateReportingPeriodArgs, 'input'>>;
+  createRole: Resolver<ResolversTypes['Role'], ParentType, ContextType, RequireFields<MutationcreateRoleArgs, 'input'>>;
+  createUser: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationcreateUserArgs, 'input'>>;
   deleteAgency: Resolver<ResolversTypes['Agency'], ParentType, ContextType, RequireFields<MutationdeleteAgencyArgs, 'id'>>;
+  deleteInputTemplate: Resolver<ResolversTypes['InputTemplate'], ParentType, ContextType, RequireFields<MutationdeleteInputTemplateArgs, 'id'>>;
   deleteOrganization: Resolver<ResolversTypes['Organization'], ParentType, ContextType, RequireFields<MutationdeleteOrganizationArgs, 'id'>>;
+  deleteOutputTemplate: Resolver<ResolversTypes['OutputTemplate'], ParentType, ContextType, RequireFields<MutationdeleteOutputTemplateArgs, 'id'>>;
+  deleteReportingPeriod: Resolver<ResolversTypes['ReportingPeriod'], ParentType, ContextType, RequireFields<MutationdeleteReportingPeriodArgs, 'id'>>;
+  deleteRole: Resolver<ResolversTypes['Role'], ParentType, ContextType, RequireFields<MutationdeleteRoleArgs, 'id'>>;
+  deleteUser: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationdeleteUserArgs, 'id'>>;
   updateAgency: Resolver<ResolversTypes['Agency'], ParentType, ContextType, RequireFields<MutationupdateAgencyArgs, 'id' | 'input'>>;
+  updateInputTemplate: Resolver<ResolversTypes['InputTemplate'], ParentType, ContextType, RequireFields<MutationupdateInputTemplateArgs, 'id' | 'input'>>;
   updateOrganization: Resolver<ResolversTypes['Organization'], ParentType, ContextType, RequireFields<MutationupdateOrganizationArgs, 'id' | 'input'>>;
+  updateOutputTemplate: Resolver<ResolversTypes['OutputTemplate'], ParentType, ContextType, RequireFields<MutationupdateOutputTemplateArgs, 'id' | 'input'>>;
+  updateReportingPeriod: Resolver<ResolversTypes['ReportingPeriod'], ParentType, ContextType, RequireFields<MutationupdateReportingPeriodArgs, 'id' | 'input'>>;
+  updateRole: Resolver<ResolversTypes['Role'], ParentType, ContextType, RequireFields<MutationupdateRoleArgs, 'id' | 'input'>>;
+  updateUser: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationupdateUserArgs, 'id' | 'input'>>;
 };
 
 export type MutationRelationResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   createAgency?: RequiredResolverFn<ResolversTypes['Agency'], ParentType, ContextType, RequireFields<MutationcreateAgencyArgs, 'input'>>;
+  createInputTemplate?: RequiredResolverFn<ResolversTypes['InputTemplate'], ParentType, ContextType, RequireFields<MutationcreateInputTemplateArgs, 'input'>>;
   createOrganization?: RequiredResolverFn<ResolversTypes['Organization'], ParentType, ContextType, RequireFields<MutationcreateOrganizationArgs, 'input'>>;
+  createOutputTemplate?: RequiredResolverFn<ResolversTypes['OutputTemplate'], ParentType, ContextType, RequireFields<MutationcreateOutputTemplateArgs, 'input'>>;
+  createReportingPeriod?: RequiredResolverFn<ResolversTypes['ReportingPeriod'], ParentType, ContextType, RequireFields<MutationcreateReportingPeriodArgs, 'input'>>;
+  createRole?: RequiredResolverFn<ResolversTypes['Role'], ParentType, ContextType, RequireFields<MutationcreateRoleArgs, 'input'>>;
+  createUser?: RequiredResolverFn<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationcreateUserArgs, 'input'>>;
   deleteAgency?: RequiredResolverFn<ResolversTypes['Agency'], ParentType, ContextType, RequireFields<MutationdeleteAgencyArgs, 'id'>>;
+  deleteInputTemplate?: RequiredResolverFn<ResolversTypes['InputTemplate'], ParentType, ContextType, RequireFields<MutationdeleteInputTemplateArgs, 'id'>>;
   deleteOrganization?: RequiredResolverFn<ResolversTypes['Organization'], ParentType, ContextType, RequireFields<MutationdeleteOrganizationArgs, 'id'>>;
+  deleteOutputTemplate?: RequiredResolverFn<ResolversTypes['OutputTemplate'], ParentType, ContextType, RequireFields<MutationdeleteOutputTemplateArgs, 'id'>>;
+  deleteReportingPeriod?: RequiredResolverFn<ResolversTypes['ReportingPeriod'], ParentType, ContextType, RequireFields<MutationdeleteReportingPeriodArgs, 'id'>>;
+  deleteRole?: RequiredResolverFn<ResolversTypes['Role'], ParentType, ContextType, RequireFields<MutationdeleteRoleArgs, 'id'>>;
+  deleteUser?: RequiredResolverFn<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationdeleteUserArgs, 'id'>>;
   updateAgency?: RequiredResolverFn<ResolversTypes['Agency'], ParentType, ContextType, RequireFields<MutationupdateAgencyArgs, 'id' | 'input'>>;
+  updateInputTemplate?: RequiredResolverFn<ResolversTypes['InputTemplate'], ParentType, ContextType, RequireFields<MutationupdateInputTemplateArgs, 'id' | 'input'>>;
   updateOrganization?: RequiredResolverFn<ResolversTypes['Organization'], ParentType, ContextType, RequireFields<MutationupdateOrganizationArgs, 'id' | 'input'>>;
+  updateOutputTemplate?: RequiredResolverFn<ResolversTypes['OutputTemplate'], ParentType, ContextType, RequireFields<MutationupdateOutputTemplateArgs, 'id' | 'input'>>;
+  updateReportingPeriod?: RequiredResolverFn<ResolversTypes['ReportingPeriod'], ParentType, ContextType, RequireFields<MutationupdateReportingPeriodArgs, 'id' | 'input'>>;
+  updateRole?: RequiredResolverFn<ResolversTypes['Role'], ParentType, ContextType, RequireFields<MutationupdateRoleArgs, 'id' | 'input'>>;
+  updateUser?: RequiredResolverFn<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationupdateUserArgs, 'id' | 'input'>>;
 };
 
 export type OrganizationResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['Organization'] = ResolversParentTypes['Organization']> = {
@@ -344,22 +704,66 @@ export type OrganizationRelationResolvers<ContextType = RedwoodGraphQLContext, P
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type OutputTemplateResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['OutputTemplate'] = ResolversParentTypes['OutputTemplate']> = {
+  createdAt: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  effectiveDate: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  id: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  name: OptArgsResolverFn<ResolversTypes['String'], ParentType, ContextType>;
+  reportingPeriods: OptArgsResolverFn<Array<Maybe<ResolversTypes['ReportingPeriod']>>, ParentType, ContextType>;
+  rulesGeneratedAt: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  updatedAt: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  version: OptArgsResolverFn<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type OutputTemplateRelationResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['OutputTemplate'] = ResolversParentTypes['OutputTemplate']> = {
+  createdAt?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  effectiveDate?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  id?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  name?: RequiredResolverFn<ResolversTypes['String'], ParentType, ContextType>;
+  reportingPeriods?: RequiredResolverFn<Array<Maybe<ResolversTypes['ReportingPeriod']>>, ParentType, ContextType>;
+  rulesGeneratedAt?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  updatedAt?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  version?: RequiredResolverFn<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type QueryResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   agencies: OptArgsResolverFn<Array<ResolversTypes['Agency']>, ParentType, ContextType>;
   agenciesByOrganization: Resolver<Array<ResolversTypes['Agency']>, ParentType, ContextType, RequireFields<QueryagenciesByOrganizationArgs, 'organizationId'>>;
   agency: Resolver<Maybe<ResolversTypes['Agency']>, ParentType, ContextType, RequireFields<QueryagencyArgs, 'id'>>;
+  inputTemplate: Resolver<Maybe<ResolversTypes['InputTemplate']>, ParentType, ContextType, RequireFields<QueryinputTemplateArgs, 'id'>>;
+  inputTemplates: OptArgsResolverFn<Array<ResolversTypes['InputTemplate']>, ParentType, ContextType>;
   organization: Resolver<Maybe<ResolversTypes['Organization']>, ParentType, ContextType, RequireFields<QueryorganizationArgs, 'id'>>;
   organizations: OptArgsResolverFn<Array<ResolversTypes['Organization']>, ParentType, ContextType>;
+  outputTemplate: Resolver<Maybe<ResolversTypes['OutputTemplate']>, ParentType, ContextType, RequireFields<QueryoutputTemplateArgs, 'id'>>;
+  outputTemplates: OptArgsResolverFn<Array<ResolversTypes['OutputTemplate']>, ParentType, ContextType>;
   redwood: OptArgsResolverFn<Maybe<ResolversTypes['Redwood']>, ParentType, ContextType>;
+  reportingPeriod: Resolver<Maybe<ResolversTypes['ReportingPeriod']>, ParentType, ContextType, RequireFields<QueryreportingPeriodArgs, 'id'>>;
+  reportingPeriods: OptArgsResolverFn<Array<ResolversTypes['ReportingPeriod']>, ParentType, ContextType>;
+  role: Resolver<Maybe<ResolversTypes['Role']>, ParentType, ContextType, RequireFields<QueryroleArgs, 'id'>>;
+  roles: OptArgsResolverFn<Array<ResolversTypes['Role']>, ParentType, ContextType>;
+  user: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryuserArgs, 'id'>>;
+  users: OptArgsResolverFn<Array<ResolversTypes['User']>, ParentType, ContextType>;
 };
 
 export type QueryRelationResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   agencies?: RequiredResolverFn<Array<ResolversTypes['Agency']>, ParentType, ContextType>;
   agenciesByOrganization?: RequiredResolverFn<Array<ResolversTypes['Agency']>, ParentType, ContextType, RequireFields<QueryagenciesByOrganizationArgs, 'organizationId'>>;
   agency?: RequiredResolverFn<Maybe<ResolversTypes['Agency']>, ParentType, ContextType, RequireFields<QueryagencyArgs, 'id'>>;
+  inputTemplate?: RequiredResolverFn<Maybe<ResolversTypes['InputTemplate']>, ParentType, ContextType, RequireFields<QueryinputTemplateArgs, 'id'>>;
+  inputTemplates?: RequiredResolverFn<Array<ResolversTypes['InputTemplate']>, ParentType, ContextType>;
   organization?: RequiredResolverFn<Maybe<ResolversTypes['Organization']>, ParentType, ContextType, RequireFields<QueryorganizationArgs, 'id'>>;
   organizations?: RequiredResolverFn<Array<ResolversTypes['Organization']>, ParentType, ContextType>;
+  outputTemplate?: RequiredResolverFn<Maybe<ResolversTypes['OutputTemplate']>, ParentType, ContextType, RequireFields<QueryoutputTemplateArgs, 'id'>>;
+  outputTemplates?: RequiredResolverFn<Array<ResolversTypes['OutputTemplate']>, ParentType, ContextType>;
   redwood?: RequiredResolverFn<Maybe<ResolversTypes['Redwood']>, ParentType, ContextType>;
+  reportingPeriod?: RequiredResolverFn<Maybe<ResolversTypes['ReportingPeriod']>, ParentType, ContextType, RequireFields<QueryreportingPeriodArgs, 'id'>>;
+  reportingPeriods?: RequiredResolverFn<Array<ResolversTypes['ReportingPeriod']>, ParentType, ContextType>;
+  role?: RequiredResolverFn<Maybe<ResolversTypes['Role']>, ParentType, ContextType, RequireFields<QueryroleArgs, 'id'>>;
+  roles?: RequiredResolverFn<Array<ResolversTypes['Role']>, ParentType, ContextType>;
+  user?: RequiredResolverFn<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryuserArgs, 'id'>>;
+  users?: RequiredResolverFn<Array<ResolversTypes['User']>, ParentType, ContextType>;
 };
 
 export type RedwoodResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['Redwood'] = ResolversParentTypes['Redwood']> = {
@@ -376,22 +780,113 @@ export type RedwoodRelationResolvers<ContextType = RedwoodGraphQLContext, Parent
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type ReportingPeriodResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['ReportingPeriod'] = ResolversParentTypes['ReportingPeriod']> = {
+  certifiedAt: OptArgsResolverFn<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  certifiedBy: OptArgsResolverFn<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  certifiedById: OptArgsResolverFn<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  createdAt: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  endDate: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  id: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  inputTemplate: OptArgsResolverFn<ResolversTypes['InputTemplate'], ParentType, ContextType>;
+  inputTemplateId: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  isCurrentPeriod: OptArgsResolverFn<ResolversTypes['Boolean'], ParentType, ContextType>;
+  name: OptArgsResolverFn<ResolversTypes['String'], ParentType, ContextType>;
+  outputTemplate: OptArgsResolverFn<ResolversTypes['OutputTemplate'], ParentType, ContextType>;
+  outputTemplateId: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  startDate: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  updatedAt: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ReportingPeriodRelationResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['ReportingPeriod'] = ResolversParentTypes['ReportingPeriod']> = {
+  certifiedAt?: RequiredResolverFn<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  certifiedBy?: RequiredResolverFn<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  certifiedById?: RequiredResolverFn<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  createdAt?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  endDate?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  id?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  inputTemplate?: RequiredResolverFn<ResolversTypes['InputTemplate'], ParentType, ContextType>;
+  inputTemplateId?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  isCurrentPeriod?: RequiredResolverFn<ResolversTypes['Boolean'], ParentType, ContextType>;
+  name?: RequiredResolverFn<ResolversTypes['String'], ParentType, ContextType>;
+  outputTemplate?: RequiredResolverFn<ResolversTypes['OutputTemplate'], ParentType, ContextType>;
+  outputTemplateId?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  startDate?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  updatedAt?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type RoleResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['Role'] = ResolversParentTypes['Role']> = {
+  createdAt: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  id: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  name: OptArgsResolverFn<ResolversTypes['String'], ParentType, ContextType>;
+  updatedAt: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  users: OptArgsResolverFn<Array<Maybe<ResolversTypes['User']>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type RoleRelationResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['Role'] = ResolversParentTypes['Role']> = {
+  createdAt?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  id?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  name?: RequiredResolverFn<ResolversTypes['String'], ParentType, ContextType>;
+  updatedAt?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  users?: RequiredResolverFn<Array<Maybe<ResolversTypes['User']>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export interface TimeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Time'], any> {
   name: 'Time';
 }
+
+export type UserResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
+  agency: OptArgsResolverFn<Maybe<ResolversTypes['Agency']>, ParentType, ContextType>;
+  agencyId: OptArgsResolverFn<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  certified: OptArgsResolverFn<Array<Maybe<ResolversTypes['ReportingPeriod']>>, ParentType, ContextType>;
+  createdAt: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  email: OptArgsResolverFn<ResolversTypes['String'], ParentType, ContextType>;
+  id: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  name: OptArgsResolverFn<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  organization: OptArgsResolverFn<ResolversTypes['Organization'], ParentType, ContextType>;
+  organizationId: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  role: OptArgsResolverFn<Maybe<ResolversTypes['Role']>, ParentType, ContextType>;
+  roleId: OptArgsResolverFn<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  updatedAt: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type UserRelationResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
+  agency?: RequiredResolverFn<Maybe<ResolversTypes['Agency']>, ParentType, ContextType>;
+  agencyId?: RequiredResolverFn<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  certified?: RequiredResolverFn<Array<Maybe<ResolversTypes['ReportingPeriod']>>, ParentType, ContextType>;
+  createdAt?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  email?: RequiredResolverFn<ResolversTypes['String'], ParentType, ContextType>;
+  id?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  name?: RequiredResolverFn<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  organization?: RequiredResolverFn<ResolversTypes['Organization'], ParentType, ContextType>;
+  organizationId?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  role?: RequiredResolverFn<Maybe<ResolversTypes['Role']>, ParentType, ContextType>;
+  roleId?: RequiredResolverFn<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  updatedAt?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
 
 export type Resolvers<ContextType = RedwoodGraphQLContext> = {
   Agency: AgencyResolvers<ContextType>;
   BigInt: GraphQLScalarType;
   Date: GraphQLScalarType;
   DateTime: GraphQLScalarType;
+  InputTemplate: InputTemplateResolvers<ContextType>;
   JSON: GraphQLScalarType;
   JSONObject: GraphQLScalarType;
   Mutation: MutationResolvers<ContextType>;
   Organization: OrganizationResolvers<ContextType>;
+  OutputTemplate: OutputTemplateResolvers<ContextType>;
   Query: QueryResolvers<ContextType>;
   Redwood: RedwoodResolvers<ContextType>;
+  ReportingPeriod: ReportingPeriodResolvers<ContextType>;
+  Role: RoleResolvers<ContextType>;
   Time: GraphQLScalarType;
+  User: UserResolvers<ContextType>;
 };
 
 export type DirectiveResolvers<ContextType = RedwoodGraphQLContext> = {

--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -29,6 +29,8 @@ const Routes = () => {
         <Route path="/agencies/{id:Int}" page={AgencyAgencyPage} name="agency" />
         <Route path="/agencies/new" page={AgencyNewAgencyPage} name="newAgency" />
         <Route path="/agencies" page={AgencyAgenciesPage} name="agencies" />
+        <Route path="/upload-template/{id:Int}" page={UploadTemplatePage} name="uploadTemplate" />
+        <Route path="/reporting-periods" page={ReportingPeriodsPage} name="reportingPeriods" />
       </Set>
       <Route notfound page={NotFoundPage} />
     </Router>

--- a/web/src/components/ReportingPeriodCell/ReportingPeriodCell.mock.ts
+++ b/web/src/components/ReportingPeriodCell/ReportingPeriodCell.mock.ts
@@ -1,0 +1,6 @@
+// Define your own mock data here:
+export const standard = (/* vars, { ctx, req } */) => ({
+  reportingPeriod: {
+    id: 42,
+  },
+})

--- a/web/src/components/ReportingPeriodCell/ReportingPeriodCell.stories.tsx
+++ b/web/src/components/ReportingPeriodCell/ReportingPeriodCell.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Loading, Empty, Failure, Success } from './ReportingPeriodCell'
+import { standard } from './ReportingPeriodCell.mock'
+
+const meta: Meta = {
+  title: 'Cells/ReportingPeriodCell',
+}
+
+export default meta
+
+export const loading: StoryObj<typeof Loading> = {
+  render: () => {
+    return Loading ? <Loading /> : <></>
+  },
+}
+
+export const empty: StoryObj<typeof Empty> = {
+  render: () => {
+    return Empty ? <Empty /> : <></>
+  },
+}
+
+export const failure: StoryObj<typeof Failure> = {
+  render: (args) => {
+    return Failure ? <Failure error={new Error('Oh no')} {...args} /> : <></>
+  },
+}
+
+export const success: StoryObj<typeof Success> = {
+  render: (args) => {
+    return Success ? <Success {...standard()} {...args} /> : <></>
+  },
+}

--- a/web/src/components/ReportingPeriodCell/ReportingPeriodCell.test.tsx
+++ b/web/src/components/ReportingPeriodCell/ReportingPeriodCell.test.tsx
@@ -1,0 +1,41 @@
+import { render } from '@redwoodjs/testing/web'
+import { Loading, Empty, Failure, Success } from './ReportingPeriodCell'
+import { standard } from './ReportingPeriodCell.mock'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float and DateTime types.
+//           Please refer to the RedwoodJS Testing Docs:
+//        https://redwoodjs.com/docs/testing#testing-cells
+// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+
+describe('ReportingPeriodCell', () => {
+  it('renders Loading successfully', () => {
+    expect(() => {
+      render(<Loading />)
+    }).not.toThrow()
+  })
+
+  it('renders Empty successfully', async () => {
+    expect(() => {
+      render(<Empty />)
+    }).not.toThrow()
+  })
+
+  it('renders Failure successfully', async () => {
+    expect(() => {
+      render(<Failure error={new Error('Oh no')} />)
+    }).not.toThrow()
+  })
+
+  // When you're ready to test the actual output of your component render
+  // you could test that, for example, certain text is present:
+  //
+  // 1. import { screen } from '@redwoodjs/testing/web'
+  // 2. Add test: expect(screen.getByText('Hello, world')).toBeInTheDocument()
+
+  it('renders Success successfully', async () => {
+    expect(() => {
+      render(<Success reportingPeriod={standard().reportingPeriod} />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/ReportingPeriodCell/ReportingPeriodCell.tsx
+++ b/web/src/components/ReportingPeriodCell/ReportingPeriodCell.tsx
@@ -1,0 +1,34 @@
+import type {
+  FindReportingPeriodQuery,
+  FindReportingPeriodQueryVariables,
+} from 'types/graphql'
+
+import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
+
+export const QUERY = gql`
+  query FindReportingPeriodQuery($id: Int!) {
+    reportingPeriod: reportingPeriod(id: $id) {
+      id
+      name
+    }
+  }
+`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Empty</div>
+
+export const Failure = ({
+  error,
+}: CellFailureProps<FindReportingPeriodQueryVariables>) => (
+  <div style={{ color: 'red' }}>Error: {error?.message}</div>
+)
+
+export const Success = ({
+  reportingPeriod,
+}: CellSuccessProps<
+  FindReportingPeriodQuery,
+  FindReportingPeriodQueryVariables
+>) => {
+  return <span>{reportingPeriod.name}</span>
+}

--- a/web/src/components/ReportingPeriodsCell/ReportingPeriodsCell.mock.ts
+++ b/web/src/components/ReportingPeriodsCell/ReportingPeriodsCell.mock.ts
@@ -1,0 +1,4 @@
+// Define your own mock data here:
+export const standard = (/* vars, { ctx, req } */) => ({
+  reportingPeriods: [{ id: 42 }, { id: 43 }, { id: 44 }],
+})

--- a/web/src/components/ReportingPeriodsCell/ReportingPeriodsCell.stories.tsx
+++ b/web/src/components/ReportingPeriodsCell/ReportingPeriodsCell.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Loading, Empty, Failure, Success } from './ReportingPeriodsCell'
+import { standard } from './ReportingPeriodsCell.mock'
+
+const meta: Meta = {
+  title: 'Cells/ReportingPeriodsCell',
+}
+
+export default meta
+
+export const loading: StoryObj<typeof Loading> = {
+  render: () => {
+    return Loading ? <Loading /> : <></>
+  },
+}
+
+export const empty: StoryObj<typeof Empty> = {
+  render: () => {
+    return Empty ? <Empty /> : <></>
+  },
+}
+
+export const failure: StoryObj<typeof Failure> = {
+  render: (args) => {
+    return Failure ? <Failure error={new Error('Oh no')} {...args} /> : <></>
+  },
+}
+
+export const success: StoryObj<typeof Success> = {
+  render: (args) => {
+    return Success ? <Success {...standard()} {...args} /> : <></>
+  },
+}

--- a/web/src/components/ReportingPeriodsCell/ReportingPeriodsCell.test.tsx
+++ b/web/src/components/ReportingPeriodsCell/ReportingPeriodsCell.test.tsx
@@ -1,0 +1,41 @@
+import { render } from '@redwoodjs/testing/web'
+import { Loading, Empty, Failure, Success } from './ReportingPeriodsCell'
+import { standard } from './ReportingPeriodsCell.mock'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float and DateTime types.
+//           Please refer to the RedwoodJS Testing Docs:
+//        https://redwoodjs.com/docs/testing#testing-cells
+// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+
+describe('ReportingPeriodsCell', () => {
+  it('renders Loading successfully', () => {
+    expect(() => {
+      render(<Loading />)
+    }).not.toThrow()
+  })
+
+  it('renders Empty successfully', async () => {
+    expect(() => {
+      render(<Empty />)
+    }).not.toThrow()
+  })
+
+  it('renders Failure successfully', async () => {
+    expect(() => {
+      render(<Failure error={new Error('Oh no')} />)
+    }).not.toThrow()
+  })
+
+  // When you're ready to test the actual output of your component render
+  // you could test that, for example, certain text is present:
+  //
+  // 1. import { screen } from '@redwoodjs/testing/web'
+  // 2. Add test: expect(screen.getByText('Hello, world')).toBeInTheDocument()
+
+  it('renders Success successfully', async () => {
+    expect(() => {
+      render(<Success reportingPeriods={standard().reportingPeriods} />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/ReportingPeriodsCell/ReportingPeriodsCell.tsx
+++ b/web/src/components/ReportingPeriodsCell/ReportingPeriodsCell.tsx
@@ -1,0 +1,78 @@
+import type { ReportingPeriodsQuery } from 'types/graphql'
+
+import { Link, routes } from '@redwoodjs/router'
+import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
+
+export const QUERY = gql`
+  query ReportingPeriodsQuery {
+    reportingPeriods {
+      id
+      startDate
+      endDate
+      isCurrentPeriod
+      certifiedAt
+      certifiedBy {
+        email
+      }
+      inputTemplate {
+        name
+      }
+    }
+  }
+`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Empty</div>
+
+export const Failure = ({ error }: CellFailureProps) => (
+  <div style={{ color: 'red' }}>Error: {error?.message}</div>
+)
+
+export const Success = ({
+  reportingPeriods,
+}: CellSuccessProps<ReportingPeriodsQuery>) => {
+  return (
+    <table border="1">
+      <thead>
+        <tr>
+          <th>Start Date</th>
+          <th>End Date</th>
+          <th>Template</th>
+          <th>Certified At</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+      {reportingPeriods.map((item) => {
+        return (
+          <tr>
+            <td>{item.startDate}</td>
+            <td>{item.endDate}</td>
+            <td>
+              {item.inputTemplate.name}
+              {!item.certifiedAt && (
+                <span>
+                  {' '}
+                  <Link to={routes.uploadTemplate({ id: item.id })}>
+                    Upload Template
+                  </Link>
+                </span>
+              )}
+            </td>
+            <td>
+              {item.isCurrentPeriod ? (
+                <button>Certify Reporting Period</button>
+              ) : (
+                item.certifiedAt && (
+                  <span>
+                    {item.certifiedAt} by {item.certifiedBy}
+                  </span>
+                )
+              )}
+            </td>
+          </tr>
+        )
+      })}
+    </table>
+  )
+}

--- a/web/src/pages/ReportingPeriodsPage/ReportingPeriodsPage.stories.tsx
+++ b/web/src/pages/ReportingPeriodsPage/ReportingPeriodsPage.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import ReportingPeriodsPage from './ReportingPeriodsPage'
+
+const meta: Meta<typeof ReportingPeriodsPage> = {
+  component: ReportingPeriodsPage,
+}
+
+export default meta
+
+type Story = StoryObj<typeof ReportingPeriodsPage>
+
+export const Primary: Story = {}

--- a/web/src/pages/ReportingPeriodsPage/ReportingPeriodsPage.test.tsx
+++ b/web/src/pages/ReportingPeriodsPage/ReportingPeriodsPage.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@redwoodjs/testing/web'
+
+import ReportingPeriodsPage from './ReportingPeriodsPage'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+
+describe('ReportingPeriodsPage', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<ReportingPeriodsPage />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/pages/ReportingPeriodsPage/ReportingPeriodsPage.tsx
+++ b/web/src/pages/ReportingPeriodsPage/ReportingPeriodsPage.tsx
@@ -1,0 +1,16 @@
+import { MetaTags } from '@redwoodjs/web'
+
+import ReportingPeriodsCell from 'src/components/ReportingPeriodsCell'
+
+const ReportingPeriodsPage = () => {
+  return (
+    <>
+      <MetaTags title="ReportingPeriods" description="ReportingPeriods page" />
+
+      <h1>Reporting Periods</h1>
+      <ReportingPeriodsCell />
+    </>
+  )
+}
+
+export default ReportingPeriodsPage

--- a/web/src/pages/UploadTemplatePage/UploadTemplatePage.stories.tsx
+++ b/web/src/pages/UploadTemplatePage/UploadTemplatePage.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import UploadTemplatePage from './UploadTemplatePage'
+
+const meta: Meta<typeof UploadTemplatePage> = {
+  component: UploadTemplatePage,
+}
+
+export default meta
+
+type Story = StoryObj<typeof UploadTemplatePage>
+
+export const Primary: Story = {}

--- a/web/src/pages/UploadTemplatePage/UploadTemplatePage.test.tsx
+++ b/web/src/pages/UploadTemplatePage/UploadTemplatePage.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@redwoodjs/testing/web'
+
+import UploadTemplatePage from './UploadTemplatePage'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+
+describe('UploadTemplatePage', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<UploadTemplatePage />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/pages/UploadTemplatePage/UploadTemplatePage.tsx
+++ b/web/src/pages/UploadTemplatePage/UploadTemplatePage.tsx
@@ -1,0 +1,38 @@
+import { Form, FileField, HiddenField, Submit } from '@redwoodjs/forms'
+import { Link, routes } from '@redwoodjs/router'
+import { MetaTags } from '@redwoodjs/web'
+
+import ReportingPeriodCell from 'src/components/ReportingPeriodCell'
+
+const UploadTemplatePage = ({ id }) => {
+  const onSubmit = (data) => {
+    console.log(data)
+  }
+
+  return (
+    <>
+      <MetaTags title="UploadTemplate" description="UploadTemplate page" />
+
+      <h1>Upload Period Template</h1>
+      <p>
+        This upload will be used as the template for period{' '}
+        <ReportingPeriodCell id={id} />
+      </p>
+      <Form onSubmit={onSubmit}>
+        <FileField name="file" />
+        <HiddenField name="reportingPeriodId" value={id} />
+        <Submit>Upload</Submit>
+      </Form>
+      <p>
+        Find me in{' '}
+        <code>./web/src/pages/UploadTemplatePage/UploadTemplatePage.tsx</code>
+      </p>
+      <p>
+        My default route is named <code>uploadTemplate</code>, link to me with `
+        <Link to={routes.uploadTemplate({ id: id })}>UploadTemplate</Link>`
+      </p>
+    </>
+  )
+}
+
+export default UploadTemplatePage

--- a/web/types/graphql.d.ts
+++ b/web/types/graphql.d.ts
@@ -34,18 +34,82 @@ export type CreateAgencyInput = {
   name: Scalars['String'];
 };
 
+export type CreateInputTemplateInput = {
+  effectiveDate: Scalars['DateTime'];
+  name: Scalars['String'];
+  rulesGeneratedAt: Scalars['DateTime'];
+  version: Scalars['String'];
+};
+
 export type CreateOrganizationInput = {
   name: Scalars['String'];
+};
+
+export type CreateOutputTemplateInput = {
+  effectiveDate: Scalars['DateTime'];
+  name: Scalars['String'];
+  rulesGeneratedAt: Scalars['DateTime'];
+  version: Scalars['String'];
+};
+
+export type CreateReportingPeriodInput = {
+  certifiedAt?: InputMaybe<Scalars['DateTime']>;
+  certifiedById?: InputMaybe<Scalars['Int']>;
+  endDate: Scalars['DateTime'];
+  inputTemplateId: Scalars['Int'];
+  isCurrentPeriod: Scalars['Boolean'];
+  name: Scalars['String'];
+  outputTemplateId: Scalars['Int'];
+  startDate: Scalars['DateTime'];
+};
+
+export type CreateRoleInput = {
+  name: Scalars['String'];
+};
+
+export type CreateUserInput = {
+  agencyId?: InputMaybe<Scalars['Int']>;
+  email: Scalars['String'];
+  name?: InputMaybe<Scalars['String']>;
+  organizationId: Scalars['Int'];
+  roleId?: InputMaybe<Scalars['Int']>;
+};
+
+export type InputTemplate = {
+  __typename?: 'InputTemplate';
+  createdAt: Scalars['DateTime'];
+  effectiveDate: Scalars['DateTime'];
+  id: Scalars['Int'];
+  name: Scalars['String'];
+  reportingPeriods: Array<Maybe<ReportingPeriod>>;
+  rulesGeneratedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime'];
+  version: Scalars['String'];
 };
 
 export type Mutation = {
   __typename?: 'Mutation';
   createAgency: Agency;
+  createInputTemplate: InputTemplate;
   createOrganization: Organization;
+  createOutputTemplate: OutputTemplate;
+  createReportingPeriod: ReportingPeriod;
+  createRole: Role;
+  createUser: User;
   deleteAgency: Agency;
+  deleteInputTemplate: InputTemplate;
   deleteOrganization: Organization;
+  deleteOutputTemplate: OutputTemplate;
+  deleteReportingPeriod: ReportingPeriod;
+  deleteRole: Role;
+  deleteUser: User;
   updateAgency: Agency;
+  updateInputTemplate: InputTemplate;
   updateOrganization: Organization;
+  updateOutputTemplate: OutputTemplate;
+  updateReportingPeriod: ReportingPeriod;
+  updateRole: Role;
+  updateUser: User;
 };
 
 
@@ -54,8 +118,33 @@ export type MutationcreateAgencyArgs = {
 };
 
 
+export type MutationcreateInputTemplateArgs = {
+  input: CreateInputTemplateInput;
+};
+
+
 export type MutationcreateOrganizationArgs = {
   input: CreateOrganizationInput;
+};
+
+
+export type MutationcreateOutputTemplateArgs = {
+  input: CreateOutputTemplateInput;
+};
+
+
+export type MutationcreateReportingPeriodArgs = {
+  input: CreateReportingPeriodInput;
+};
+
+
+export type MutationcreateRoleArgs = {
+  input: CreateRoleInput;
+};
+
+
+export type MutationcreateUserArgs = {
+  input: CreateUserInput;
 };
 
 
@@ -64,7 +153,32 @@ export type MutationdeleteAgencyArgs = {
 };
 
 
+export type MutationdeleteInputTemplateArgs = {
+  id: Scalars['Int'];
+};
+
+
 export type MutationdeleteOrganizationArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type MutationdeleteOutputTemplateArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type MutationdeleteReportingPeriodArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type MutationdeleteRoleArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type MutationdeleteUserArgs = {
   id: Scalars['Int'];
 };
 
@@ -75,9 +189,39 @@ export type MutationupdateAgencyArgs = {
 };
 
 
+export type MutationupdateInputTemplateArgs = {
+  id: Scalars['Int'];
+  input: UpdateInputTemplateInput;
+};
+
+
 export type MutationupdateOrganizationArgs = {
   id: Scalars['Int'];
   input: UpdateOrganizationInput;
+};
+
+
+export type MutationupdateOutputTemplateArgs = {
+  id: Scalars['Int'];
+  input: UpdateOutputTemplateInput;
+};
+
+
+export type MutationupdateReportingPeriodArgs = {
+  id: Scalars['Int'];
+  input: UpdateReportingPeriodInput;
+};
+
+
+export type MutationupdateRoleArgs = {
+  id: Scalars['Int'];
+  input: UpdateRoleInput;
+};
+
+
+export type MutationupdateUserArgs = {
+  id: Scalars['Int'];
+  input: UpdateUserInput;
 };
 
 export type Organization = {
@@ -87,16 +231,38 @@ export type Organization = {
   name: Scalars['String'];
 };
 
+export type OutputTemplate = {
+  __typename?: 'OutputTemplate';
+  createdAt: Scalars['DateTime'];
+  effectiveDate: Scalars['DateTime'];
+  id: Scalars['Int'];
+  name: Scalars['String'];
+  reportingPeriods: Array<Maybe<ReportingPeriod>>;
+  rulesGeneratedAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime'];
+  version: Scalars['String'];
+};
+
 /** About the Redwood queries. */
 export type Query = {
   __typename?: 'Query';
   agencies: Array<Agency>;
   agenciesByOrganization: Array<Agency>;
   agency?: Maybe<Agency>;
+  inputTemplate?: Maybe<InputTemplate>;
+  inputTemplates: Array<InputTemplate>;
   organization?: Maybe<Organization>;
   organizations: Array<Organization>;
+  outputTemplate?: Maybe<OutputTemplate>;
+  outputTemplates: Array<OutputTemplate>;
   /** Fetches the Redwood root schema. */
   redwood?: Maybe<Redwood>;
+  reportingPeriod?: Maybe<ReportingPeriod>;
+  reportingPeriods: Array<ReportingPeriod>;
+  role?: Maybe<Role>;
+  roles: Array<Role>;
+  user?: Maybe<User>;
+  users: Array<User>;
 };
 
 
@@ -113,7 +279,37 @@ export type QueryagencyArgs = {
 
 
 /** About the Redwood queries. */
+export type QueryinputTemplateArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** About the Redwood queries. */
 export type QueryorganizationArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** About the Redwood queries. */
+export type QueryoutputTemplateArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** About the Redwood queries. */
+export type QueryreportingPeriodArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** About the Redwood queries. */
+export type QueryroleArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** About the Redwood queries. */
+export type QueryuserArgs = {
   id: Scalars['Int'];
 };
 
@@ -132,14 +328,94 @@ export type Redwood = {
   version?: Maybe<Scalars['String']>;
 };
 
+export type ReportingPeriod = {
+  __typename?: 'ReportingPeriod';
+  certifiedAt?: Maybe<Scalars['DateTime']>;
+  certifiedBy?: Maybe<User>;
+  certifiedById?: Maybe<Scalars['Int']>;
+  createdAt: Scalars['DateTime'];
+  endDate: Scalars['DateTime'];
+  id: Scalars['Int'];
+  inputTemplate: InputTemplate;
+  inputTemplateId: Scalars['Int'];
+  isCurrentPeriod: Scalars['Boolean'];
+  name: Scalars['String'];
+  outputTemplate: OutputTemplate;
+  outputTemplateId: Scalars['Int'];
+  startDate: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime'];
+};
+
+export type Role = {
+  __typename?: 'Role';
+  createdAt: Scalars['DateTime'];
+  id: Scalars['Int'];
+  name: Scalars['String'];
+  updatedAt: Scalars['DateTime'];
+  users: Array<Maybe<User>>;
+};
+
 export type UpdateAgencyInput = {
   abbreviation?: InputMaybe<Scalars['String']>;
   code?: InputMaybe<Scalars['String']>;
   name?: InputMaybe<Scalars['String']>;
 };
 
+export type UpdateInputTemplateInput = {
+  effectiveDate?: InputMaybe<Scalars['DateTime']>;
+  name?: InputMaybe<Scalars['String']>;
+  rulesGeneratedAt?: InputMaybe<Scalars['DateTime']>;
+  version?: InputMaybe<Scalars['String']>;
+};
+
 export type UpdateOrganizationInput = {
   name?: InputMaybe<Scalars['String']>;
+};
+
+export type UpdateOutputTemplateInput = {
+  effectiveDate?: InputMaybe<Scalars['DateTime']>;
+  name?: InputMaybe<Scalars['String']>;
+  rulesGeneratedAt?: InputMaybe<Scalars['DateTime']>;
+  version?: InputMaybe<Scalars['String']>;
+};
+
+export type UpdateReportingPeriodInput = {
+  certifiedAt?: InputMaybe<Scalars['DateTime']>;
+  certifiedById?: InputMaybe<Scalars['Int']>;
+  endDate?: InputMaybe<Scalars['DateTime']>;
+  inputTemplateId?: InputMaybe<Scalars['Int']>;
+  isCurrentPeriod?: InputMaybe<Scalars['Boolean']>;
+  name?: InputMaybe<Scalars['String']>;
+  outputTemplateId?: InputMaybe<Scalars['Int']>;
+  startDate?: InputMaybe<Scalars['DateTime']>;
+};
+
+export type UpdateRoleInput = {
+  name?: InputMaybe<Scalars['String']>;
+};
+
+export type UpdateUserInput = {
+  agencyId?: InputMaybe<Scalars['Int']>;
+  email?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']>;
+  organizationId?: InputMaybe<Scalars['Int']>;
+  roleId?: InputMaybe<Scalars['Int']>;
+};
+
+export type User = {
+  __typename?: 'User';
+  agency?: Maybe<Agency>;
+  agencyId?: Maybe<Scalars['Int']>;
+  certified: Array<Maybe<ReportingPeriod>>;
+  createdAt: Scalars['DateTime'];
+  email: Scalars['String'];
+  id: Scalars['Int'];
+  name?: Maybe<Scalars['String']>;
+  organization: Organization;
+  organizationId: Scalars['Int'];
+  role?: Maybe<Role>;
+  roleId?: Maybe<Scalars['Int']>;
+  updatedAt: Scalars['DateTime'];
 };
 
 export type FindAgenciesByOrganizationIdVariables = Exact<{
@@ -225,3 +501,15 @@ export type FindOrganizationsVariables = Exact<{ [key: string]: never; }>;
 
 
 export type FindOrganizations = { __typename?: 'Query', organizations: Array<{ __typename?: 'Organization', id: number, name: string }> };
+
+export type FindReportingPeriodQueryVariables = Exact<{
+  id: Scalars['Int'];
+}>;
+
+
+export type FindReportingPeriodQuery = { __typename?: 'Query', reportingPeriod?: { __typename?: 'ReportingPeriod', id: number } | null };
+
+export type ReportingPeriodsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type ReportingPeriodsQuery = { __typename?: 'Query', reportingPeriods: Array<{ __typename?: 'ReportingPeriod', id: number, startDate: string, endDate: string, isCurrentPeriod: boolean, certifiedAt?: string | null, certifiedBy?: { __typename?: 'User', email: string } | null, inputTemplate: { __typename?: 'InputTemplate', name: string } }> };


### PR DESCRIPTION
This adds the Reporting Periods page, which includes three new models for the schema: InputTemplate, OutputTemplate, and ReportingPeriod.

I generated the SDL I needed for this to work, which included some models that didn't have SDL yet (roles and users).