### PR TITLE
fix: remove tf-plan conditional in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
       - aws-auth
       - build
     uses: ./.github/workflows/terraform-plan.yml
-    if: needs.build.outputs.build-api-image-result == 'success' && needs.build.outputs.build-web-result == 'success' && needs.aws-auth.result == 'success'
     with:
       ref: ${{ github.event.pull_request.head.sha }}
       concurrency-group: run_terraform-staging


### PR DESCRIPTION
This PR fixes an issue that is currently blocking certain PRs from running the entire Continuous Integration workflow to completion. The root problem was the presence of an `if:` job conditional that was evaluating to `false`, causing the "Plan Terraform" phase to be skipped. Since generating a successful Terraform plan is a requirement for PRs, they're effectively blocked from merging.

The problematic conditional doesn't seem to be doing anything useful, so it's been removed entirely.