### PR TITLE
Support SPA requests by routing 404 to /index.html

### DIFF
--- a/terraform/web.tf
+++ b/terraform/web.tf
@@ -227,13 +227,8 @@ module "cdn" {
   custom_error_response = [
     {
       error_code         = 404
-      response_code      = 404
-      response_page_path = "/errors/404.html"
-    },
-    {
-      error_code         = 403
-      response_code      = 403
-      response_page_path = "/errors/403.html"
+      response_code      = 200
+      response_page_path = "/index.html"
     },
   ]
 
@@ -264,6 +259,9 @@ module "cdn" {
     compress             = true
     cache_policy_id      = data.aws_cloudfront_cache_policy.Managed-CachingOptimized.id
     use_forwarded_values = false
+
+    // See https://github.com/aws-samples/amazon-cloudfront-functions/tree/main/url-rewrite-single-page-apps
+    function_association = {}
   }
 
   ordered_cache_behavior = [


### PR DESCRIPTION
This PR addresses an issue where requests to top-level routes like `/agencies`, `/organizations`, `/agencies/new`, etc. resolve a 404 response. Since React routing determines which view to serve based on the URI, this PR configures the CDN to serve `/index.html` (which loads the React app) whenever a request doesn't match an origin key (i.e. an S3 object). 

Caveat for this behavior: since the CDN can only differentiate between requests that match S3 object keys and those that don't, it is unable to determine whether an arbitrary path like `/maybe-this-exists` is valid as far as React is concerned. Although React's ability to serve the correct view (including potentially falling back to the "Not Found" view) is not impacted, it does mean that all requests to the CDN will respond with a 200 status code, even when the requested route is truly invalid.