### PR TITLE
Correlate RUM with API requests

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,7 @@ if (process.env.DD_RUM_ENABLED === 'true') {
     service: process.env.DD_SERVICE || 'cpf-reporter',
     env: process.env.DD_ENV,
     version: process.env.DD_VERSION,
+    allowedTracingUrls: [global.RWJS_API_URL],
   })
 }
 


### PR DESCRIPTION
Just like it says on the tin, this PR enables correlating Datadog RUM traces with upstream API traces, per [these instructions](https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces/?tab=browserrum).

I believe that the headers that the Datadog RUM integration will automatically add to requests will be passed through as-is to the Lambda function event payload when invoked by API Gateway. If that doesn't appear to be the case, another (likely similarly small) PR may be necessary.