### PR TITLE
fix: Propagate ECS task tags from service

### DIFF
--- a/terraform/ecs_redwood_console.tf
+++ b/terraform/ecs_redwood_console.tf
@@ -189,7 +189,7 @@ resource "aws_ecs_task_definition" "console" {
   }
 
   // Empty map prevents `{} -> null` perma-diff in plans
-  tags = {}
+  tags = null
 }
 
 module "ecs_console_security_group" {

--- a/terraform/ecs_redwood_console.tf
+++ b/terraform/ecs_redwood_console.tf
@@ -175,6 +175,7 @@ resource "aws_ecs_task_definition" "console" {
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   container_definitions    = jsonencode([module.ecs_console_container_definition.json_map_object])
+  tags                     = {}
 
   cpu    = 512
   memory = 1024

--- a/terraform/ecs_redwood_console.tf
+++ b/terraform/ecs_redwood_console.tf
@@ -187,6 +187,9 @@ resource "aws_ecs_task_definition" "console" {
   lifecycle {
     create_before_destroy = true
   }
+
+  // Empty map prevents `{} -> null` perma-diff in plans
+  tags = {}
 }
 
 module "ecs_console_security_group" {

--- a/terraform/ecs_redwood_console.tf
+++ b/terraform/ecs_redwood_console.tf
@@ -187,9 +187,6 @@ resource "aws_ecs_task_definition" "console" {
   lifecycle {
     create_before_destroy = true
   }
-
-  // Empty map prevents `{} -> null` perma-diff in plans
-  tags = null
 }
 
 module "ecs_console_security_group" {
@@ -211,6 +208,7 @@ resource "aws_ecs_service" "console" {
   desired_count          = 1
   launch_type            = "FARGATE"
   enable_execute_command = true
+  propagate_tags         = "SERVICE"
 
   network_configuration {
     assign_public_ip = false


### PR DESCRIPTION
This PR explicitly sets `tags = {}` on the `aws_ecs_task.console` resource definition in Terraform in order to allow default provider tags to populate the resource, as well as to avoid a permanent `{} -> null` change in plans.