### PR TITLE
Configure Access-Control-Allow-Headers for RUM

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -64,10 +64,15 @@ module "api_gateway" {
     allow_headers = [
       "authorization",
       "content-type",
+      "traceparent",
       "x-amz-date",
       "x-amz-security-token",
       "x-amz-user-agent",
       "x-api-key",
+      "x-datadog-trace-id",
+      "x-datadog-parent-id",
+      "x-datadog-origin",
+      "x-datadog-sampling-priority",
     ]
     max_age = 86400 // 24 hours, in seconds
   }


### PR DESCRIPTION
This PR is a follow up to #45, which updates API Gateway CORS configuration to allow tracing headers in API requests.