### PR TITLE
Fix skipped CI reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    if: needs.qa.result != 'skipped' || needs.qa.result != 'cancelled'
+    if: always() && (needs.qa.result != 'skipped' && needs.qa.result != 'cancelled')
     needs:
       - qa
     uses: "./.github/workflows/publish-qa-results.yml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    if: needs.tf-plan.result != 'skipped' || needs.tf-plan.result != 'cancelled'
+    if: always() && (needs.tf-plan.result != 'skipped' && needs.tf-plan.result != 'cancelled')
     needs:
       - tf-plan
     uses: ./.github/workflows/publish-terraform-plan.yml


### PR DESCRIPTION
This PR implements a fix for an issue that prevents reporting on QA and Terraform Plan outcomes when either/both of those CI jobs fail due to error. The problem is due to a misconfiguration in the conditionals for the reporting jobs in the CI workflow.

This is identical to the solution implemented recently for another repo that was having the same issue: https://github.com/usdigitalresponse/usdr-gost/pull/2378