### PR TITLE
Fix/66 new lambdas iac

### DIFF
--- a/api/src/functions/cpfValidation/cpfValidation.ts
+++ b/api/src/functions/cpfValidation/cpfValidation.ts
@@ -6,6 +6,7 @@ import { logger } from 'src/lib/logger'
 
 const apiEndpoint = 'https://example.com'
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
 export const handler: S3Handler = async (event: S3Event): Promise<void> => {
   try {
     const bucket = event.Records[0].s3.bucket.name

--- a/api/src/lib/aws.ts
+++ b/api/src/lib/aws.ts
@@ -15,7 +15,7 @@ import { getSignedUrl as awsGetSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { StreamingBlobPayloadInputTypes } from '@smithy/types'
 import { QueryResolvers, CreateUploadInput } from 'types/graphql'
 
-const CPF_REPORTER_BUCKET_NAME = `cpf-reporter-${process.env.environment}`
+const REPORTING_DATA_BUCKET_NAME = `${process.env.REPORTING_DATA_BUCKET_NAME}`
 
 function getS3Client() {
   let s3: S3Client
@@ -64,8 +64,8 @@ export function uploadWorkbook(
   uploadId: number,
   body: StreamingBlobPayloadInputTypes
 ) {
-  const folderName = `${upload.organizationId}/${upload.agencyId}/${upload.reportingPeriodId}/uploads/${upload.expenditureCategoryId}/${uploadId}/${upload.filename}`
-  return sendPutObjectToS3Bucket(CPF_REPORTER_BUCKET_NAME, folderName, body)
+  const folderName = `uploads/${upload.organizationId}/${upload.agencyId}/${upload.reportingPeriodId}/${upload.expenditureCategoryId}/${uploadId}/${upload.filename}`
+  return sendPutObjectToS3Bucket(REPORTING_DATA_BUCKET_NAME, folderName, body)
 }
 
 async function sendPutObjectToS3Bucket(
@@ -85,7 +85,7 @@ async function sendPutObjectToS3Bucket(
 
 export function getTemplateRules(inputTemplateId: number) {
   return sendHeadObjectToS3Bucket(
-    CPF_REPORTER_BUCKET_NAME,
+    REPORTING_DATA_BUCKET_NAME,
     `templates/input_templates/${inputTemplateId}/rules/`
   )
 }
@@ -104,9 +104,9 @@ export async function s3PutSignedUrl(
   uploadId: number
 ): Promise<string> {
   const s3 = getS3Client()
-  const key = `${upload.organizationId}/${upload.agencyId}/${upload.reportingPeriodId}/uploads/${upload.expenditureCategoryId}/${uploadId}/${upload.filename}`
+  const key = `uploads/${upload.organizationId}/${upload.agencyId}/${upload.reportingPeriodId}/${upload.expenditureCategoryId}/${uploadId}/${upload.filename}`
   const baseParams: PutObjectCommandInput = {
-    Bucket: CPF_REPORTER_BUCKET_NAME,
+    Bucket: REPORTING_DATA_BUCKET_NAME,
     Key: key,
     ContentType:
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -314,16 +314,16 @@ module "lambda_function-excelToJson" {
         "s3:HeadObject",
       ]
       resources = [
-        # Path: uploads/{organization_id}/{agency_id}/{reporting_period_id}/{expenditure_category_code}/{upload_id}/{filename}.xlsx
-        "${module.reporting_data_bucket.bucket_arn}/uploads/*/*/*/*/*/*.xlsx",
+        # Path: uploads/{organization_id}/{agency_id}/{reporting_period_id}/{expenditure_category_code}/{upload_id}/{filename}.xlsm
+        "${module.reporting_data_bucket.bucket_arn}/uploads/*/*/*/*/*/*.xlsm",
       ]
     }
     AllowUploadJsonObjects = {
       effect  = "Allow"
       actions = ["s3:PutObject"]
       resources = [
-        # Path: uploads/{organization_id}/{agency_id}/{reporting_period_id}/{expenditure_category_code}/{upload_id}/{filename}.xlsx.json
-        "${module.reporting_data_bucket.bucket_arn}/uploads/*/*/*/*/*/*.xlsx.json",
+        # Path: uploads/{organization_id}/{agency_id}/{reporting_period_id}/{expenditure_category_code}/{upload_id}/{filename}.xlsm.json
+        "${module.reporting_data_bucket.bucket_arn}/uploads/*/*/*/*/*/*.xlsm.json",
       ]
     }
   }
@@ -384,8 +384,8 @@ module "lambda_function-cpfValidation" {
         "s3:HeadObject",
       ]
       resources = [
-        # Path: uploads/{organization_id}/{agency_id}/{reporting_period_id}/{expenditure_category_code}/{upload_id}/{filename}.xlsx.json
-        "${module.reporting_data_bucket.bucket_arn}/uploads/*/*/*/*/*/*.xlsx.json",
+        # Path: uploads/{organization_id}/{agency_id}/{reporting_period_id}/{expenditure_category_code}/{upload_id}/{filename}.xlsm.json
+        "${module.reporting_data_bucket.bucket_arn}/uploads/*/*/*/*/*/*.xlsm.json",
       ]
     }
   }

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -306,6 +306,7 @@ module "lambda_function-excelToJson" {
   cloudwatch_logs_retention_in_days = var.log_retention_in_days
   attach_policy_jsons               = length(local.lambda_default_execution_policies) > 0
   number_of_policy_jsons            = length(local.lambda_default_execution_policies)
+  policy_jsons                      = local.lambda_default_execution_policies
   attach_policy_statements          = true
   policy_statements = {
     AllowDownloadExcelObjects = {
@@ -376,6 +377,7 @@ module "lambda_function-cpfValidation" {
   cloudwatch_logs_retention_in_days = var.log_retention_in_days
   attach_policy_jsons               = length(local.lambda_default_execution_policies) > 0
   number_of_policy_jsons            = length(local.lambda_default_execution_policies)
+  policy_jsons                      = local.lambda_default_execution_policies
   attach_policy_statements          = true
   policy_statements = {
     AllowDownloadJSONObjects = {

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -217,7 +217,7 @@ module "lambda_function-graphql" {
   role_permissions_boundary         = local.permissions_boundary_arn
   attach_cloudwatch_logs_policy     = true
   cloudwatch_logs_retention_in_days = var.log_retention_in_days
-  attach_policy_jsons               = true
+  attach_policy_jsons               = length(local.lambda_default_execution_policies) > 0
   number_of_policy_jsons            = length(local.lambda_default_execution_policies)
   policy_jsons                      = local.lambda_default_execution_policies
   attach_policy_statements          = true
@@ -304,7 +304,7 @@ module "lambda_function-excelToJson" {
   role_permissions_boundary         = local.permissions_boundary_arn
   attach_cloudwatch_logs_policy     = true
   cloudwatch_logs_retention_in_days = var.log_retention_in_days
-  attach_policy_jsons               = true
+  attach_policy_jsons               = length(local.lambda_default_execution_policies) > 0
   number_of_policy_jsons            = length(local.lambda_default_execution_policies)
   attach_policy_statements          = true
   policy_statements = {
@@ -374,7 +374,7 @@ module "lambda_function-cpfValidation" {
   role_permissions_boundary         = local.permissions_boundary_arn
   attach_cloudwatch_logs_policy     = true
   cloudwatch_logs_retention_in_days = var.log_retention_in_days
-  attach_policy_jsons               = true
+  attach_policy_jsons               = length(local.lambda_default_execution_policies) > 0
   number_of_policy_jsons            = length(local.lambda_default_execution_policies)
   attach_policy_statements          = true
   policy_statements = {

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -117,11 +117,11 @@ module "lambda_artifacts_bucket" {
   ]
 }
 
-module "cpf_uploads_bucket" {
+module "reporting_data_bucket" {
   source  = "cloudposse/s3-bucket/aws"
   version = "4.0.1"
   context = module.s3_label.context
-  name    = "cpf-reporter-${var.environment}"
+  name    = "reporting_data"
 
   acl                          = "private"
   versioning_enabled           = true
@@ -178,8 +178,8 @@ resource "aws_s3_object" "lambda_artifact-cpfValidation" {
   server_side_encryption = "AES256"
 }
 
-resource "aws_s3_bucket_notification" "cpf_uploads_bucket" {
-  bucket = module.cpf_uploads_bucket.bucket_id
+resource "aws_s3_bucket_notification" "reporting_data" {
+  bucket = module.reporting_data_bucket.bucket_id
 
   lambda_function {
     lambda_function_arn = module.lambda_function-excelToJson.lambda_function_arn
@@ -315,7 +315,7 @@ module "lambda_function-excelToJson" {
       ]
       resources = [
         # Path: uploads/{organization_id}/{agency_id}/{reporting_period_id}/{expenditure_category_code}/{upload_id}/{filename}.xlsx
-        "${module.cpf_uploads_bucket.bucket_arn}/uploads/*/*/*/*/*/*.xlsx",
+        "${module.reporting_data_bucket.bucket_arn}/uploads/*/*/*/*/*/*.xlsx",
       ]
     }
     AllowUploadJsonObjects = {
@@ -323,7 +323,7 @@ module "lambda_function-excelToJson" {
       actions = ["s3:PutObject"]
       resources = [
         # Path: uploads/{organization_id}/{agency_id}/{reporting_period_id}/{expenditure_category_code}/{upload_id}/{filename}.xlsx.json
-        "${module.cpf_uploads_bucket.bucket_arn}/uploads/*/*/*/*/*/*.xlsx.json",
+        "${module.reporting_data_bucket.bucket_arn}/uploads/*/*/*/*/*/*.xlsx.json",
       ]
     }
   }
@@ -351,7 +351,7 @@ module "lambda_function-excelToJson" {
   allowed_triggers = {
     S3BucketNotification = {
       principal  = "s3.amazonaws.com"
-      source_arn = module.cpf_uploads_bucket.bucket_arn
+      source_arn = module.reporting_data_bucket.bucket_arn
     }
   }
 }
@@ -385,7 +385,7 @@ module "lambda_function-cpfValidation" {
       ]
       resources = [
         # Path: uploads/{organization_id}/{agency_id}/{reporting_period_id}/{expenditure_category_code}/{upload_id}/{filename}.xlsx.json
-        "${module.cpf_uploads_bucket.bucket_arn}/uploads/*/*/*/*/*/*.xlsx.json",
+        "${module.reporting_data_bucket.bucket_arn}/uploads/*/*/*/*/*/*.xlsx.json",
       ]
     }
   }
@@ -413,7 +413,7 @@ module "lambda_function-cpfValidation" {
   allowed_triggers = {
     S3BucketNotification = {
       principal  = "s3.amazonaws.com"
-      source_arn = module.cpf_uploads_bucket.bucket_arn
+      source_arn = module.reporting_data_bucket.bucket_arn
     }
   }
 }

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -47,8 +47,9 @@ locals {
       var.datadog_default_environment_variables,
     ),
     {
-      LOG_LEVEL = var.lambda_log_level
-      TZ        = "UTC"
+      LOG_LEVEL                  = var.lambda_log_level
+      REPORTING_DATA_BUCKET_NAME = module.reporting_data_bucket.bucket_id
+      TZ                         = "UTC"
     },
   )
   lambda_default_execution_policies = compact([

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -178,23 +178,21 @@ resource "aws_s3_object" "lambda_artifact-cpfValidation" {
   server_side_encryption = "AES256"
 }
 
-resource "aws_s3_bucket_notification" "json_notification" {
-  bucket = module.cpf_uploads_bucket.bucket_id
-
-  lambda_function {
-    lambda_function_arn = module.lambda_function-cpfValidation.lambda_function_arn
-    events              = ["s3:ObjectCreated:*"]
-    filter_suffix       = ".json"
-  }
-}
-
-resource "aws_s3_bucket_notification" "excel_notification" {
+resource "aws_s3_bucket_notification" "cpf_uploads_bucket" {
   bucket = module.cpf_uploads_bucket.bucket_id
 
   lambda_function {
     lambda_function_arn = module.lambda_function-excelToJson.lambda_function_arn
     events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "uploads/"
     filter_suffix       = ".xlsm"
+  }
+
+  lambda_function {
+    lambda_function_arn = module.lambda_function-cpfValidation.lambda_function_arn
+    events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "uploads/"
+    filter_suffix       = ".xlsm.json"
   }
 }
 

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -295,8 +295,8 @@ module "lambda_function-excelToJson" {
   description   = "Reacts to S3 events and converts Excel files to JSON."
 
   // Networking
-  attach_network_policy = false
-  vpc_subnet_ids = null
+  attach_network_policy  = false
+  vpc_subnet_ids         = null
   vpc_security_group_ids = null
 
   // Permissions
@@ -341,8 +341,8 @@ module "lambda_function-excelToJson" {
   architectures = [var.lambda_arch]
   publish       = true
   layers        = local.lambda_layer_arns
-  timeout     = 300 # 5 minutes, in seconds
-  memory_size = 512 # MB
+  timeout       = 300 # 5 minutes, in seconds
+  memory_size   = 512 # MB
   environment_variables = merge(local.lambda_default_environment_variables, {
     DD_LAMBDA_HANDLER = "excelToJson.handler"
   })


### PR DESCRIPTION
This PR provides fixes and related changes that address issues preventing successful deployment following #66.

Summary of changes:
- Consolidate multiple `aws_s3_bucket_notification` resources for the same bucket in Terraform, per [this note from the Terraform documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification)
  > S3 Buckets only support a single notification configuration. Declaring multiple aws_s3_bucket_notification resources to the same S3 Bucket will cause a perpetual difference in configuration. See the example "Trigger multiple Lambda functions" for an option.

  To be clear "perpetual difference" means that the resources will be in conflict, and will create a race condition during `terraform apply` wherein one of the resources will always overwrite the other(s).
- Update the naming convention used to refer to the bucket where CPF Reporter data (uploads and their derived JSON files, as well as reporting templates, and other S3 data managed at runtime) is stored. Since this bucket is used to store more than just uploads, I updated names like `cpf_uploads_bucket` to `reporting_data_bucket`. 
- Reorder and add `// Label` comments to the various inputs on the `lambda_function-graphql` Terraform module, and update the other `lambda_function-` modules (added in #66) to match.
  - Hopefully, this change will contribute to more of a "living example" out of these implementations and make it easier to add new Lambda functions in the future.
  - As discussed with @as1729, more formal documentation around how to add a Lambda function may ultimately be warranted, but this seems like a good starting point. Curious to get @dysmento's thoughts on whether this makes our Lambda conventions more obvious.
  - Would be good to discuss if anything still seems unclear / if there are questions about why a convention exists.
  - NB: In addition to more documentation, I'm also interested in leveraging something like TFLint or another static analysis tool to make it easier to validate conventions in CI workflows at PR time, which would help avoid post-merge failures when deploying to Staging.
- Expose the name of the reporting data bucket as a `$REPORTING_DATA_BUCKET_NAME` environment variable to all Lambda functions.