### PR TITLE
fix: add auth-provider to allow header

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -62,6 +62,7 @@ module "api_gateway" {
     ])
     allow_credentials = true
     allow_headers = [
+      "auth-provider",
       "authorization",
       "content-type",
       "traceparent",


### PR DESCRIPTION
Based on the discussion in Slack it appears that the issues we're seeing in staging is due to the lack of `auth-provider` being marked as an allowed header.

<img width="1907" alt="image" src="https://github.com/usdigitalresponse/cpf-reporter/assets/6497366/d2f3182e-f2a2-4adf-b072-5d8169ba1ab8">
