### PR TITLE
fix: remove duplicate routes

### DIFF
--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -40,29 +40,6 @@ const Routes = () => {
         <Route path="/organizations/{id:Int}" page={OrganizationOrganizationPage} name="organization" />
         <Route path="/organizations" page={OrganizationOrganizationsPage} name="organizations" />
       </PrivateSet>
-      {/* Uploads */}
-      <Route path="/" page={UploadUploadsPage} name="uploads" />
-      <Route path="/uploads/new" page={UploadNewUploadPage} name="newUpload" />
-      <Route path="/uploads/{id:Int}/edit" page={UploadEditUploadPage} name="editUpload" />
-      <Route path="/uploads/{id:Int}" page={UploadUploadPage} name="upload" />
-      <Route path="/upload-template/{id:Int}" page={UploadTemplatePage} name="uploadTemplate" />
-      {/* Agencies */}
-      <Route path="/agencies/{id:Int}/edit" page={AgencyEditAgencyPage} name="editAgency" />
-      <Route path="/agencies/{id:Int}" page={AgencyAgencyPage} name="agency" />
-      <Route path="/agencies/new" page={AgencyNewAgencyPage} name="newAgency" />
-      <Route path="/agencies" page={AgencyAgenciesPage} name="agencies" />
-      {/* Users */}
-      <Route path="/users/new" page={UserNewUserPage} name="newUser" />
-      <Route path="/users/{id:Int}/edit" page={UserEditUserPage} name="editUser" />
-      <Route path="/users/{id:Int}" page={UserUserPage} name="user" />
-      <Route path="/users" page={UserUsersPage} name="users" />
-      {/* Reporting Periods */}
-      <Route path="/reporting-periods" page={ReportingPeriodsPage} name="reportingPeriods" />
-      {/* Organizations */}
-      <Route path="/organizations/new" page={OrganizationNewOrganizationPage} name="newOrganization" />
-      <Route path="/organizations/{id:Int}/edit" page={OrganizationEditOrganizationPage} name="editOrganization" />
-      <Route path="/organizations/{id:Int}" page={OrganizationOrganizationPage} name="organization" />
-      <Route path="/organizations" page={OrganizationOrganizationsPage} name="organizations" />
       <Route path="/login" page={LoginPage} name="login" />
       <Route notfound page={NotFoundPage} />
     </Router>

--- a/web/src/auth.ts
+++ b/web/src/auth.ts
@@ -33,11 +33,13 @@ const client = {
   login: () => ({
     id: 1,
     email: 'email@example.com',
+    organizationId: 1,
     roles: [],
   }),
   signup: () => ({
     id: 1,
     email: 'email@example.com',
+    organizationId: 1,
     roles: [],
   }),
   logout: () => {},
@@ -45,6 +47,7 @@ const client = {
   getUserMetadata: () => ({
     id: 1,
     email: 'email@example.com',
+    organizationId: 1,
     roles: [],
   }),
 }


### PR DESCRIPTION
Previously we copied a few routes from private-set into unauthenticated. However, this does not provide the appropriate data needed to support the upload page load. Hence this PR does:
1. Remove the duplicate routes
2. Ensure all routes (except login and not found) are within the private-set