### PR TITLE
Bugfix/CPF-74 - Creating a new agency not visible to the user

### DIFF
--- a/api/src/graphql/agencies.sdl.ts
+++ b/api/src/graphql/agencies.sdl.ts
@@ -17,12 +17,14 @@ export const schema = gql`
     name: String!
     abbreviation: String
     code: String!
+    organizationId: Int!
   }
 
   input UpdateAgencyInput {
     name: String
     abbreviation: String
     code: String
+    organizationId: Int!
   }
 
   type Mutation {

--- a/api/types/graphql.d.ts
+++ b/api/types/graphql.d.ts
@@ -51,6 +51,7 @@ export type CreateAgencyInput = {
   abbreviation?: InputMaybe<Scalars['String']>;
   code: Scalars['String'];
   name: Scalars['String'];
+  organizationId: Scalars['Int'];
 };
 
 export type CreateExpenditureCategoryInput = {
@@ -659,6 +660,7 @@ export type UpdateAgencyInput = {
   abbreviation?: InputMaybe<Scalars['String']>;
   code?: InputMaybe<Scalars['String']>;
   name?: InputMaybe<Scalars['String']>;
+  organizationId: Scalars['Int'];
 };
 
 export type UpdateExpenditureCategoryInput = {

--- a/web/src/components/Agency/AgencyForm/AgencyForm.tsx
+++ b/web/src/components/Agency/AgencyForm/AgencyForm.tsx
@@ -1,6 +1,7 @@
 import { Button } from 'react-bootstrap'
 import { useForm, UseFormReturn } from 'react-hook-form'
 import type { EditAgencyById, UpdateAgencyInput } from 'types/graphql'
+import { useAuth } from 'web/src/auth'
 
 import {
   Form,
@@ -25,6 +26,7 @@ const AgencyForm = (props: AgencyFormProps) => {
   const { agency, onSave, error, loading } = props
   const formMethods: UseFormReturn<FormAgency> = useForm<FormAgency>()
   const hasErrors = Object.keys(formMethods.formState.errors).length > 0
+  const { currentUser } = useAuth()
 
   // Resets the form to the previous values when editing the existing agency
   // Clears out the form when creating a new agency
@@ -33,7 +35,8 @@ const AgencyForm = (props: AgencyFormProps) => {
   }
 
   const onSubmit = (data: FormAgency) => {
-    onSave(data, props?.agency?.id)
+    const modifiedData = { ...data, organizationId: currentUser.organizationId }
+    onSave(modifiedData, props?.agency?.id)
   }
 
   return (

--- a/web/src/components/Agency/EditAgencyCell/EditAgencyCell.tsx
+++ b/web/src/components/Agency/EditAgencyCell/EditAgencyCell.tsx
@@ -24,6 +24,7 @@ const UPDATE_AGENCY_MUTATION = gql`
       name
       abbreviation
       code
+      organizationId
     }
   }
 `

--- a/web/src/pages/Agency/AgenciesPage/AgenciesPage.tsx
+++ b/web/src/pages/Agency/AgenciesPage/AgenciesPage.tsx
@@ -1,12 +1,13 @@
 import Button from 'react-bootstrap/Button'
+import { useAuth } from 'web/src/auth'
 
 import { Link, routes } from '@redwoodjs/router'
 
 import AgenciesCell from 'src/components/Agency/AgenciesCell'
 
 const AgenciesPage = () => {
-  // temporarily hardcode organizationId to 2
-  const organizationIdOfUser = 2
+  const { currentUser } = useAuth()
+  const organizationIdOfUser = currentUser.organizationId
 
   return (
     <div>

--- a/web/types/graphql.d.ts
+++ b/web/types/graphql.d.ts
@@ -32,6 +32,7 @@ export type CreateAgencyInput = {
   abbreviation?: InputMaybe<Scalars['String']>;
   code: Scalars['String'];
   name: Scalars['String'];
+  organizationId: Scalars['Int'];
 };
 
 export type CreateExpenditureCategoryInput = {
@@ -640,6 +641,7 @@ export type UpdateAgencyInput = {
   abbreviation?: InputMaybe<Scalars['String']>;
   code?: InputMaybe<Scalars['String']>;
   name?: InputMaybe<Scalars['String']>;
+  organizationId: Scalars['Int'];
 };
 
 export type UpdateExpenditureCategoryInput = {
@@ -826,7 +828,7 @@ export type UpdateAgencyMutationVariables = Exact<{
 }>;
 
 
-export type UpdateAgencyMutation = { __typename?: 'Mutation', updateAgency: { __typename?: 'Agency', id: number, name: string, abbreviation?: string | null, code: string } };
+export type UpdateAgencyMutation = { __typename?: 'Mutation', updateAgency: { __typename?: 'Agency', id: number, name: string, abbreviation?: string | null, code: string, organizationId: number } };
 
 export type CreateAgencyMutationVariables = Exact<{
   input: CreateAgencyInput;


### PR DESCRIPTION
# Ticket #74 

## About the issue
This PR fixes the issue where creating a new agency using the "Create New Agency" button doesn't display that agency, and the Agencies page remains empty.

## Fixes:
1. `organizationId` is now being passed in correctly when creating/editing an agency
2. `organizationId` is initiated to the organization ID of the current user (currently `1`). This will be dynamic once authentication is implemented.
3. The agencies table now uses the current user's organization id (currently `1`) to display agencies only under that organization.