### PR TITLE
Fix: Postgres auth in Staging console

### DIFF
--- a/api/src/lib/db.ts
+++ b/api/src/lib/db.ts
@@ -35,6 +35,12 @@ async function ssmAuthForURL(databaseURL: string): Promise<string> {
   return url.toString()
 }
 
+function pgpasswordAuthForURL(databaseURL: string): string {
+  const url = new URL(databaseURL)
+  url.password = process.env.PGPASSWORD
+  return url.toString()
+}
+
 /*
  * Instance of the Prisma Client
  */
@@ -45,6 +51,8 @@ async function createPrismaClient() {
     datasourceUrl = await rdsIAMAuthForURL(process.env.DATABASE_URL)
   } else if (process.env.DATABASE_SECRET_SOURCE === 'ssm') {
     datasourceUrl = await ssmAuthForURL(process.env.DATABASE_URL)
+  } else if (process.env.DATABASE_SECRET_SOURCE === 'env_PGPASSWORD') {
+    datasourceUrl = pgpasswordAuthForURL(process.env.DATABASE_URL)
   }
 
   db = new PrismaClient({

--- a/terraform/ecs_redwood_console.tf
+++ b/terraform/ecs_redwood_console.tf
@@ -23,6 +23,7 @@ module "ecs_console_container_definition" {
   map_environment = {
     AWS_REGION         = data.aws_region.current.name
     AWS_DEFAULT_REGION = data.aws_region.current.name
+    DATABASE_SECRET_SOURCE = "env_PGPASSWORD"
     DATABASE_URL = format(
       "postgres://%s@%s:%s/%s?%s",
       module.postgres.cluster_master_username,

--- a/terraform/ecs_redwood_console.tf
+++ b/terraform/ecs_redwood_console.tf
@@ -21,8 +21,8 @@ module "ecs_console_container_definition" {
   }
 
   map_environment = {
-    AWS_REGION         = data.aws_region.current.name
-    AWS_DEFAULT_REGION = data.aws_region.current.name
+    AWS_REGION             = data.aws_region.current.name
+    AWS_DEFAULT_REGION     = data.aws_region.current.name
     DATABASE_SECRET_SOURCE = "env_PGPASSWORD"
     DATABASE_URL = format(
       "postgres://%s@%s:%s/%s?%s",


### PR DESCRIPTION
This PR provides a solution for errors experienced getting the Prisma client to successfully connect to RDS Postgres in our Redwood console containers (running in ECS).

The current issue is that Prisma does not consider driver-specific environment variables (e.g. `PGHOST`, `PGPASSWORD`) when connecting to a database – Prisma will only use the default URL defined in `schema.prisma` or a `datasourceUrl` parameter passed during `PrismaClient` instantiation. At the moment, we only pass an explicit `datasourceUrl` parameter in Lambda environments (since Lambda doesn't support mounting secrets as environment variables) or when using RDS IAM authentication (which we haven't yet enabled in Staging, but would ultimately be the best option here); the ECS container environment running Redwood console instead mounts an SSM-derived secret to a `$PGPASSWORD` environment variable, while the `DATABASE_URL` environment variable is plaintext (and does not contain any secrets). This effectively leaves Prisma without a defined Postgres password at connection-time. 

This PR fixes the problem by implementing a mechanism that interpolates a `$PGPASSWORD`-supplied secret into the initialy-password-less connection string provided by `$DATABASE_URL`, and then passes the resulting value as the `datasourceUrl` parameter during `PrismaClient` instantiation. It effectively works the same way as the existing SSM- and RDS Signer-based methods, but instead pulls the secret value from the runtime environment when a `$DATABASE_SECRET_SOURCE` environment variable is set to `env_PGPASSWORD` (which Terraform has been updated to configure for the ECS console environments).

See also: https://github.com/prisma/prisma/issues/2559