### PR TITLE
make expenditure_category nullable on an Upload

### DIFF
--- a/api/db/migrations/20240126151638_expenditure_category_nullable/migration.sql
+++ b/api/db/migrations/20240126151638_expenditure_category_nullable/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "Upload" DROP CONSTRAINT "Upload_expenditureCategoryId_fkey";
+
+-- AlterTable
+ALTER TABLE "Upload" ALTER COLUMN "expenditureCategoryId" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Upload" ADD CONSTRAINT "Upload_expenditureCategoryId_fkey" FOREIGN KEY ("expenditureCategoryId") REFERENCES "ExpenditureCategory"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -112,21 +112,21 @@ model ExpenditureCategory {
 }
 
 model Upload {
-  id                    Int                 @id @default(autoincrement())
+  id                    Int                  @id @default(autoincrement())
   filename              String
   notes                 String?
   uploadedById          Int
-  uploadedBy            User                @relation(fields: [uploadedById], references: [id])
+  uploadedBy            User                 @relation(fields: [uploadedById], references: [id])
   agencyId              Int
-  agency                Agency              @relation(fields: [agencyId], references: [id])
+  agency                Agency               @relation(fields: [agencyId], references: [id])
   organizationId        Int
-  organization          Organization        @relation(fields: [organizationId], references: [id])
+  organization          Organization         @relation(fields: [organizationId], references: [id])
   reportingPeriodId     Int
-  reportingPeriod       ReportingPeriod     @relation(fields: [reportingPeriodId], references: [id])
-  expenditureCategoryId Int
-  expenditureCategory   ExpenditureCategory @relation(fields: [expenditureCategoryId], references: [id])
-  createdAt             DateTime            @default(now()) @db.Timestamptz(6)
-  updatedAt             DateTime            @default(now()) @db.Timestamptz(6)
+  reportingPeriod       ReportingPeriod      @relation(fields: [reportingPeriodId], references: [id])
+  expenditureCategoryId Int?
+  expenditureCategory   ExpenditureCategory? @relation(fields: [expenditureCategoryId], references: [id])
+  createdAt             DateTime             @default(now()) @db.Timestamptz(6)
+  updatedAt             DateTime             @default(now()) @db.Timestamptz(6)
   validations           UploadValidation[]
   subrecipients         Subrecipient[]
 }

--- a/api/src/graphql/uploads.sdl.ts
+++ b/api/src/graphql/uploads.sdl.ts
@@ -11,12 +11,13 @@ export const schema = gql`
     organization: Organization!
     reportingPeriodId: Int!
     reportingPeriod: ReportingPeriod!
-    expenditureCategoryId: Int!
-    expenditureCategory: ExpenditureCategory!
+    expenditureCategoryId: Int
+    expenditureCategory: ExpenditureCategory
     createdAt: DateTime!
     updatedAt: DateTime!
     validations: [UploadValidation]!
     signedUrl: String
+    subrecipients: [Subrecipient]!
   }
 
   type Query {
@@ -31,7 +32,7 @@ export const schema = gql`
     agencyId: Int!
     organizationId: Int!
     reportingPeriodId: Int!
-    expenditureCategoryId: Int!
+    expenditureCategoryId: Int
   }
 
   input UpdateUploadInput {

--- a/api/src/services/uploads/uploads.scenarios.ts
+++ b/api/src/services/uploads/uploads.scenarios.ts
@@ -7,48 +7,29 @@ export const standard = defineScenario<Prisma.UploadCreateArgs>({
     one: {
       data: {
         filename: 'String',
-        updatedAt: '2023-12-10T04:48:04.896Z',
-        uploadedBy: {
-          create: {
-            email: 'String',
-            updatedAt: '2023-12-10T04:48:04.896Z',
-            organization: { create: { name: 'String' } },
-          },
-        },
+        uploadedBy: { create: { email: 'String' } },
         agency: { create: { name: 'String', code: 'String' } },
         organization: { create: { name: 'String' } },
         reportingPeriod: {
           create: {
             name: 'String',
-            startDate: '2023-12-10T04:48:04.896Z',
-            endDate: '2023-12-10T04:48:04.896Z',
-            updatedAt: '2023-12-10T04:48:04.896Z',
+            startDate: '2024-01-26T15:11:27.688Z',
+            endDate: '2024-01-26T15:11:27.688Z',
+            organization: { create: { name: 'String' } },
             inputTemplate: {
               create: {
                 name: 'String',
                 version: 'String',
-                effectiveDate: '2023-12-10T04:48:04.896Z',
-                updatedAt: '2023-12-10T04:48:04.896Z',
+                effectiveDate: '2024-01-26T15:11:27.688Z',
               },
             },
             outputTemplate: {
               create: {
                 name: 'String',
                 version: 'String',
-                effectiveDate: '2023-12-10T04:48:04.896Z',
-                updatedAt: '2023-12-10T04:48:04.896Z',
+                effectiveDate: '2024-01-26T15:11:27.688Z',
               },
             },
-            organization: {
-              create: { name: 'String' },
-            },
-          },
-        },
-        expenditureCategory: {
-          create: {
-            name: 'String',
-            code: 'String',
-            updatedAt: '2023-12-10T04:48:04.896Z',
           },
         },
       },
@@ -56,48 +37,29 @@ export const standard = defineScenario<Prisma.UploadCreateArgs>({
     two: {
       data: {
         filename: 'String',
-        updatedAt: '2023-12-10T04:48:04.896Z',
-        uploadedBy: {
-          create: {
-            email: 'String',
-            updatedAt: '2023-12-10T04:48:04.896Z',
-            organization: { create: { name: 'String' } },
-          },
-        },
+        uploadedBy: { create: { email: 'String' } },
         agency: { create: { name: 'String', code: 'String' } },
         organization: { create: { name: 'String' } },
         reportingPeriod: {
           create: {
             name: 'String',
-            startDate: '2023-12-10T04:48:04.896Z',
-            endDate: '2023-12-10T04:48:04.896Z',
-            updatedAt: '2023-12-10T04:48:04.896Z',
+            startDate: '2024-01-26T15:11:27.688Z',
+            endDate: '2024-01-26T15:11:27.688Z',
+            organization: { create: { name: 'String' } },
             inputTemplate: {
               create: {
                 name: 'String',
                 version: 'String',
-                effectiveDate: '2023-12-10T04:48:04.896Z',
-                updatedAt: '2023-12-10T04:48:04.896Z',
+                effectiveDate: '2024-01-26T15:11:27.688Z',
               },
             },
             outputTemplate: {
               create: {
                 name: 'String',
                 version: 'String',
-                effectiveDate: '2023-12-10T04:48:04.896Z',
-                updatedAt: '2023-12-10T04:48:04.896Z',
+                effectiveDate: '2024-01-26T15:11:27.688Z',
               },
             },
-            organization: {
-              create: { name: 'String' },
-            },
-          },
-        },
-        expenditureCategory: {
-          create: {
-            name: 'String',
-            code: 'String',
-            updatedAt: '2023-12-10T04:48:04.896Z',
           },
         },
       },

--- a/api/src/services/uploads/uploads.test.ts
+++ b/api/src/services/uploads/uploads.test.ts
@@ -36,7 +36,6 @@ describe('uploads', () => {
         agencyId: scenario.upload.two.agencyId,
         organizationId: scenario.upload.two.organizationId,
         reportingPeriodId: scenario.upload.two.reportingPeriodId,
-        expenditureCategoryId: scenario.upload.two.expenditureCategoryId,
       },
     })
 
@@ -47,10 +46,6 @@ describe('uploads', () => {
     expect(result.reportingPeriodId).toEqual(
       scenario.upload.two.reportingPeriodId
     )
-    expect(result.expenditureCategoryId).toEqual(
-      scenario.upload.two.expenditureCategoryId
-    )
-    expect(result.updatedAt).toBeDefined()
   })
 
   scenario('updates a upload', async (scenario: StandardScenario) => {

--- a/api/src/services/uploads/uploads.ts
+++ b/api/src/services/uploads/uploads.ts
@@ -4,8 +4,8 @@ import type {
   UploadRelationResolvers,
 } from 'types/graphql'
 
-import { s3PutSignedUrl } from 'src/lib/aws'
 import { db } from 'src/lib/db'
+
 export const uploads: QueryResolvers['uploads'] = () => {
   return db.upload.findMany()
 }
@@ -16,16 +16,10 @@ export const upload: QueryResolvers['upload'] = ({ id }) => {
   })
 }
 
-export const createUpload: MutationResolvers['createUpload'] = async ({
-  input,
-}) => {
-  // validateUpload(input, context.currentUser)
-  const upload = await db.upload.create({
+export const createUpload: MutationResolvers['createUpload'] = ({ input }) => {
+  return db.upload.create({
     data: input,
   })
-
-  upload.signedUrl = await s3PutSignedUrl(upload, upload.id)
-  return upload
 }
 
 export const updateUpload: MutationResolvers['updateUpload'] = ({
@@ -64,5 +58,8 @@ export const Upload: UploadRelationResolvers = {
   },
   validations: (_obj, { root }) => {
     return db.upload.findUnique({ where: { id: root?.id } }).validations()
+  },
+  subrecipients: (_obj, { root }) => {
+    return db.upload.findUnique({ where: { id: root?.id } }).subrecipients()
   },
 }

--- a/api/types/graphql.d.ts
+++ b/api/types/graphql.d.ts
@@ -131,7 +131,7 @@ export type CreateSubrecipientInput = {
 
 export type CreateUploadInput = {
   agencyId: Scalars['Int'];
-  expenditureCategoryId: Scalars['Int'];
+  expenditureCategoryId?: InputMaybe<Scalars['Int']>;
   filename: Scalars['String'];
   notes?: InputMaybe<Scalars['String']>;
   organizationId: Scalars['Int'];
@@ -747,8 +747,8 @@ export type Upload = {
   agency: Agency;
   agencyId: Scalars['Int'];
   createdAt: Scalars['DateTime'];
-  expenditureCategory: ExpenditureCategory;
-  expenditureCategoryId: Scalars['Int'];
+  expenditureCategory?: Maybe<ExpenditureCategory>;
+  expenditureCategoryId?: Maybe<Scalars['Int']>;
   filename: Scalars['String'];
   id: Scalars['Int'];
   notes?: Maybe<Scalars['String']>;
@@ -757,6 +757,7 @@ export type Upload = {
   reportingPeriod: ReportingPeriod;
   reportingPeriodId: Scalars['Int'];
   signedUrl?: Maybe<Scalars['String']>;
+  subrecipients: Array<Maybe<Subrecipient>>;
   updatedAt: Scalars['DateTime'];
   uploadedBy: User;
   uploadedById: Scalars['Int'];
@@ -1421,8 +1422,8 @@ export type UploadResolvers<ContextType = RedwoodGraphQLContext, ParentType exte
   agency: OptArgsResolverFn<ResolversTypes['Agency'], ParentType, ContextType>;
   agencyId: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
   createdAt: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
-  expenditureCategory: OptArgsResolverFn<ResolversTypes['ExpenditureCategory'], ParentType, ContextType>;
-  expenditureCategoryId: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  expenditureCategory: OptArgsResolverFn<Maybe<ResolversTypes['ExpenditureCategory']>, ParentType, ContextType>;
+  expenditureCategoryId: OptArgsResolverFn<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   filename: OptArgsResolverFn<ResolversTypes['String'], ParentType, ContextType>;
   id: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
   notes: OptArgsResolverFn<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -1431,6 +1432,7 @@ export type UploadResolvers<ContextType = RedwoodGraphQLContext, ParentType exte
   reportingPeriod: OptArgsResolverFn<ResolversTypes['ReportingPeriod'], ParentType, ContextType>;
   reportingPeriodId: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
   signedUrl: OptArgsResolverFn<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  subrecipients: OptArgsResolverFn<Array<Maybe<ResolversTypes['Subrecipient']>>, ParentType, ContextType>;
   updatedAt: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
   uploadedBy: OptArgsResolverFn<ResolversTypes['User'], ParentType, ContextType>;
   uploadedById: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
@@ -1442,8 +1444,8 @@ export type UploadRelationResolvers<ContextType = RedwoodGraphQLContext, ParentT
   agency?: RequiredResolverFn<ResolversTypes['Agency'], ParentType, ContextType>;
   agencyId?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
   createdAt?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
-  expenditureCategory?: RequiredResolverFn<ResolversTypes['ExpenditureCategory'], ParentType, ContextType>;
-  expenditureCategoryId?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  expenditureCategory?: RequiredResolverFn<Maybe<ResolversTypes['ExpenditureCategory']>, ParentType, ContextType>;
+  expenditureCategoryId?: RequiredResolverFn<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   filename?: RequiredResolverFn<ResolversTypes['String'], ParentType, ContextType>;
   id?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
   notes?: RequiredResolverFn<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -1452,6 +1454,7 @@ export type UploadRelationResolvers<ContextType = RedwoodGraphQLContext, ParentT
   reportingPeriod?: RequiredResolverFn<ResolversTypes['ReportingPeriod'], ParentType, ContextType>;
   reportingPeriodId?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
   signedUrl?: RequiredResolverFn<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  subrecipients?: RequiredResolverFn<Array<Maybe<ResolversTypes['Subrecipient']>>, ParentType, ContextType>;
   updatedAt?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
   uploadedBy?: RequiredResolverFn<ResolversTypes['User'], ParentType, ContextType>;
   uploadedById?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -47,6 +47,29 @@ export default async () => {
       )
     )
 
+    const expendtitureCategoriesData = [
+      {
+        name: '1A - Broadband Infrastructure',
+        code: '1A',
+      },
+      {
+        name: '1B - Digital Connectivity Technology',
+        code: '1B',
+      },
+      {
+        name: '1C - Multi-Purpose Community Facility',
+        code: '1C',
+      },
+    ]
+    await Promise.all(
+      expendtitureCategoriesData.map(
+        async (data: Prisma.ExpenditureCategoryCreateArgs['data']) => {
+          const record = await db.expenditureCategory.create({ data })
+          console.log(record)
+        }
+      )
+    )
+
     // If using dbAuth and seeding users, you'll need to add a `hashedPassword`
     // and associated `salt` to their record. Here's how to create them using
     // the same algorithm that dbAuth uses internally:

--- a/web/src/components/Upload/NewUpload/NewUpload.tsx
+++ b/web/src/components/Upload/NewUpload/NewUpload.tsx
@@ -36,6 +36,7 @@ const NewUpload = () => {
       </header>
       <div className="rw-segment-main">
         <UploadForm
+          userId={currentUser.id}
           organizationId={currentUser.organizationId}
           loading={loading}
           error={error}

--- a/web/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/web/src/components/Upload/UploadForm/UploadForm.tsx
@@ -5,7 +5,6 @@ import type { EditUploadById } from 'types/graphql'
 import {
   Form,
   FileField,
-  // HiddenField,
   FormError,
   FieldError,
   Label,
@@ -30,6 +29,7 @@ const CREATE_UPLOAD = gql`
 // type FormUpload = NonNullable<EditUploadById['upload']>
 
 interface UploadFormProps {
+  userId: number
   organizationId: number
   upload?: EditUploadById['upload']
   error: RWGqlError
@@ -58,13 +58,12 @@ const UploadForm = (props: UploadFormProps) => {
     data.reportingPeriodId = parseInt(data.reportingPeriodId)
 
     const uploadInput = {
-      uploadedById: 1,
-      agencyId: 1,
+      uploadedById: props.userId,
+      agencyId: data.agencyId,
       notes: data.notes,
       filename: data.file[0].name,
-      organizationId: 1,
+      organizationId: props.organizationId,
       reportingPeriodId: data.reportingPeriodId,
-      expenditureCategoryId: 1,
     }
     const res = await create({ variables: { input: uploadInput } })
     const formData = new FormData()
@@ -103,7 +102,6 @@ const UploadForm = (props: UploadFormProps) => {
         titleClassName="rw-form-error-title"
         listClassName="rw-form-error-list"
       />
-      {/* <HiddenField name="uploadedBy">1</HiddenField> */}
       <OrganizationPickListsCell id={props.organizationId} />
       <FileField name="file" validation={{ required: true }} />
       <FieldError name="file" className="rw-field-error" />

--- a/web/types/graphql.d.ts
+++ b/web/types/graphql.d.ts
@@ -917,17 +917,17 @@ export type FindReportingPeriodsVariables = Exact<{ [key: string]: never; }>;
 
 export type FindReportingPeriods = { __typename?: 'Query', reportingPeriods: Array<{ __typename?: 'ReportingPeriod', id: number, name: string, startDate: string, endDate: string, organizationId: number, certifiedAt?: string | null, certifiedById?: number | null, inputTemplateId: number, outputTemplateId: number, isCurrentPeriod: boolean, createdAt: string, updatedAt: string }> };
 
+export type ReportingPeriodsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type ReportingPeriodsQuery = { __typename?: 'Query', reportingPeriods: Array<{ __typename?: 'ReportingPeriod', id: number, startDate: string, endDate: string, isCurrentPeriod: boolean, certifiedAt?: string | null, certifiedBy?: { __typename?: 'User', email: string } | null, inputTemplate: { __typename?: 'InputTemplate', name: string } }> };
+
 export type FindReportingPeriodQueryVariables = Exact<{
   id: Scalars['Int'];
 }>;
 
 
 export type FindReportingPeriodQuery = { __typename?: 'Query', reportingPeriod?: { __typename?: 'ReportingPeriod', name: string } | null };
-
-export type ReportingPeriodsQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type ReportingPeriodsQuery = { __typename?: 'Query', reportingPeriods: Array<{ __typename?: 'ReportingPeriod', id: number, startDate: string, endDate: string, isCurrentPeriod: boolean, certifiedAt?: string | null, certifiedBy?: { __typename?: 'User', email: string } | null, inputTemplate: { __typename?: 'InputTemplate', name: string } }> };
 
 export type EditUploadByIdVariables = Exact<{
   id: Scalars['Int'];


### PR DESCRIPTION
Adds seed data for Expenditure Categories and makes expenditure_category nullable on Upload records.

This is because expenditure category will be derived from the uploaded workbook data, and this occurs _after_ the record has been created in the database.