### PR TITLE
Fix prisma CLI in Redwood ECS console

### DIFF
--- a/api/src/lib/db.ts
+++ b/api/src/lib/db.ts
@@ -35,12 +35,6 @@ async function ssmAuthForURL(databaseURL: string): Promise<string> {
   return url.toString()
 }
 
-function pgpasswordAuthForURL(databaseURL: string): string {
-  const url = new URL(databaseURL)
-  url.password = process.env.PGPASSWORD
-  return url.toString()
-}
-
 /*
  * Instance of the Prisma Client
  */
@@ -51,8 +45,6 @@ async function createPrismaClient() {
     datasourceUrl = await rdsIAMAuthForURL(process.env.DATABASE_URL)
   } else if (process.env.DATABASE_SECRET_SOURCE === 'ssm') {
     datasourceUrl = await ssmAuthForURL(process.env.DATABASE_URL)
-  } else if (process.env.DATABASE_SECRET_SOURCE === 'env_PGPASSWORD') {
-    datasourceUrl = pgpasswordAuthForURL(process.env.DATABASE_URL)
   }
 
   db = new PrismaClient({

--- a/terraform/ecs_redwood_console.tf
+++ b/terraform/ecs_redwood_console.tf
@@ -21,26 +21,14 @@ module "ecs_console_container_definition" {
   }
 
   map_environment = {
-    AWS_REGION             = data.aws_region.current.name
-    AWS_DEFAULT_REGION     = data.aws_region.current.name
-    DATABASE_SECRET_SOURCE = "env_PGPASSWORD"
-    DATABASE_URL = format(
-      "postgres://%s@%s:%s/%s?%s",
-      module.postgres.cluster_master_username,
-      module.postgres.cluster_endpoint,
-      module.postgres.cluster_port,
-      module.postgres.cluster_database_name,
-      join("&", [
-        "sslmode=verify",
-        "sslcert=/home/node/app/api/db/rds-combined-ca-bundle.pem"
-      ])
-    )
-    CI       = ""
-    NODE_ENV = "development"
+    AWS_REGION         = data.aws_region.current.name
+    AWS_DEFAULT_REGION = data.aws_region.current.name
+    CI                 = ""
+    NODE_ENV           = "development"
   }
 
   map_secrets = {
-    PGPASSWORD = aws_ssm_parameter.postgres_master_password.arn
+    DATABASE_URL = aws_ssm_parameter.ecs_console_secret_database_url.arn
   }
 
   log_configuration = {
@@ -51,6 +39,25 @@ module "ecs_console_container_definition" {
       awslogs-stream-prefix = "console"
     }
   }
+}
+
+resource "aws_ssm_parameter" "ecs_console_secret_database_url" {
+  name        = "${var.ssm_service_parameters_path_prefix}/postgres/database_url"
+  description = "Prisma database URL for connecting the Postgres cluster"
+  type        = "SecureString"
+  key_id      = data.aws_kms_key.ssm.arn
+  value = format(
+    "postgres://%s:%s@%s:%s/%s?%s",
+    module.postgres.cluster_master_username,
+    module.postgres.cluster_master_password,
+    module.postgres.cluster_endpoint,
+    module.postgres.cluster_port,
+    module.postgres.cluster_database_name,
+    join("&", [
+      "sslmode=verify-full",
+      "sslrootcert=${urlencode("/home/node/app/api/db/rds-combined-ca-bundle.pem")}",
+    ])
+  )
 }
 
 resource "aws_iam_role" "ecs_console_execution" {
@@ -80,7 +87,7 @@ data "aws_iam_policy_document" "ecs_console_execution" {
     ]
     resources = [
       data.aws_kms_key.ssm.arn,
-      aws_ssm_parameter.postgres_master_password.arn,
+      aws_ssm_parameter.ecs_console_secret_database_url,
     ]
   }
   statement {

--- a/terraform/ecs_redwood_console.tf
+++ b/terraform/ecs_redwood_console.tf
@@ -87,7 +87,7 @@ data "aws_iam_policy_document" "ecs_console_execution" {
     ]
     resources = [
       data.aws_kms_key.ssm.arn,
-      aws_ssm_parameter.ecs_console_secret_database_url,
+      aws_ssm_parameter.ecs_console_secret_database_url.arn,
     ]
   }
   statement {


### PR DESCRIPTION
This PR fixes problems using Prisma CLI commands in the Redwood ECS console, which were only partially resolved by #87 (which this PR largely reverts).

**Problem statement:** The Prisma CLI has no support for custom `PrismaClient` objects, meaning that the programmatic customizations/overrides present in `api/src/lib/db.ts` file's instantiation of `PrismaClient` have no effect when running `yarn rw prisma ...` commands. This is an unfortunate [limitation of Prisma](https://github.com/prisma/prisma/discussions/12336#discussioncomment-2361283) that is not particularly well-documented, despite [support for at-runtime customization](https://www.prisma.io/docs/orm/reference/prisma-client-reference#programmatically-override-a-datasource-url).
**Solution:** This PR updates the Terraform IAC for the Redwood console environment to mount the entire `DATABASE_URL` environment variable as a secret on the container (previously we were only doing this for the Postgres-standard `PGPASSWORD` env var). It also removes the runtime override behavior introduced by #87, as it is no longer needed.

---

**Other considerations:** This limitation of Prisma will cause further difficulty in adopting IAM authentication for RDS Postgres (which is our preference over using static credentials), given that there's no mechanism to interpolate non-environment (e.g. secret) values into a connection string at the time that a Prisma CLI command is run, which is necessary given that IAM auth credentials are time-limited. 

A potential (but not particularly ideal) solution could be to introduce a wrapper (bash) script that exports IAM auth credentials to subcommands, e.g.
`rdsiamauth.bash`:
```bash
#!/usr/bin/env bash
PGPASSWORD="$(aws rds generate-db-auth-token --hostname $RDSHOST --port $PGPORT --region us-west-2 --username $PGUSER)"
export DATABASE_URL="postgres://$PGUSER:$PGPASSWORD@$RDSHOST:$PGPORT?sslmode=$PGSSLMODE&sslrootcert=$PGSSLROOTCERT"

# Run the wrapped command
bash -c "$@"
```
which could be used like this:
```cli
./rdsiamauth.bash yarn rw prisma migrate deploy
```

Given that we are not yet implementing IAM Auth for RDS, this (or an alternate) solution is out-of-scope for this PR.