### PR TITLE
Fix: Add CORS config to reporting data bucket

### DIFF
--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -131,6 +131,30 @@ module "reporting_data_bucket" {
   allow_encrypted_uploads_only = true
   source_policy_documents      = []
 
+  cors_configuration = [
+    {
+      allowed_methods = ["GET", "HEAD", "POST", "PUT"]
+      allowed_origins = [var.website_domain_name]
+      allowed_headers = ["*"]
+      expose_headers = [
+        "Content-Disposition",
+        "Content-Encoding",
+        "Content-Length",
+        "Content-Location",
+        "Content-Range",
+        "Date",
+        "ETag",
+        "Server",
+        "x-amz-delete-marker",
+        "x-amz-id-2",
+        "x-amz-request-id",
+        "x-amz-version-id",
+        "x-amz-server-side-encryption",
+      ]
+      max_age_seconds = 300 // 5 minutes, in seconds
+    },
+  ]
+
   lifecycle_configuration_rules = [
     {
       enabled                                = true


### PR DESCRIPTION
## Issue
#73

This PR adds CORS configuration to the "reporting data" S3 bucket to which the web application uploads files using a PUT request to a pre-signed S3 object URL. Since the object URL belongs to an S3 domain the remote resource (in this case, the S3 bucket), CORS configuration is required in order to allow browser scripts running on the website origin to make requests and read certain response data.

The CORS configuration is fairly permissive in this case, allowing GET, HEAD, PUT, and POST requests (DELETE is omitted on the assumption that object deletions would be handled by Lambda functions rather than through a presigned URL request made by the web-side). Additionally, all request headers are allowed, as are all [common S3 response headers](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html). Given that the bucket and its objects are private and that request origin is restricted to the website URL for a particular deployment stage, these choices seem reasonably low-risk.

Once pre-signed URL request cases are more well-known, it would be ideal to follow policy-of-least-privilege here, and restrict `allowed_methods`, `allowed_headers`, and `expose_headers` settings to only include values known to be used by the CPF Reporter web application for a specific purpose.