### PR TITLE
Fix: S3 pre-signed uploads (PR #98 follow up)

### DIFF
--- a/api/src/lib/aws.ts
+++ b/api/src/lib/aws.ts
@@ -110,6 +110,7 @@ export async function s3PutSignedUrl(
     Key: key,
     ContentType:
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ServerSideEncryption: 'AES256',
   }
   const url = await awsGetSignedUrl(s3, new PutObjectCommand(baseParams), {
     expiresIn: 60,

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -134,7 +134,7 @@ module "reporting_data_bucket" {
   cors_configuration = [
     {
       allowed_methods = ["GET", "HEAD", "POST", "PUT"]
-      allowed_origins = [var.website_domain_name]
+      allowed_origins = ["https://${var.website_domain_name}"]
       allowed_headers = ["*"]
       expose_headers = [
         "Content-Disposition",


### PR DESCRIPTION
This PR fixes two issues with pre-signed S3 URLs:
1. A CORS misconfiguration, which currently omits `https://` from the allowed origin (website) domain name. This should have been included in #98.
2. An issue with the `PutObject` command used to configure pre-signed URLs for web-side upload. Currently, the command is configured without AES256 server-side encryption, which is a [requirement](https://github.com/usdigitalresponse/cpf-reporter/blob/4cf3d15cbdd6422d676ebbaac1b10fe49daf4803/terraform/functions.tf#L129-L131) of this S3 bucket. Without this fix, object uploads to S3 (regardless of CORS configuration) will continue to fail.