### PR TITLE
fix: generate aws-auth after build step

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -59,6 +59,7 @@ jobs:
       id-token: write
     needs:
       - validate
+      - build
     uses: ./.github/workflows/aws-auth.yml
     with:
       aws-region: us-west-2


### PR DESCRIPTION
## Context
AWS tokens are valid for a specific amount of time. If these tokens are generated during the build-step there is a risk that they will expire by the time they are being used for the terraform steps. The reason why they expire is because the build step currently takes longer than the AWS tokens validity duration.


## Solution
This PR ensures that we make the `build` step a pre-requisite for AWS token generation so there is ample time for terraform steps to complete during the token validity duration.