### PR TITLE
Implement access controls for user queries

### DIFF
--- a/api/src/services/users/users.scenarios.ts
+++ b/api/src/services/users/users.scenarios.ts
@@ -28,10 +28,32 @@ export const standard = defineScenario<
       data: {
         email: 'uniqueemail1@test.com',
         name: 'String',
-        agency: { create: { name: 'String', code: 'String' } },
         role: 'ORGANIZATION_ADMIN',
+        agency: { create: { name: 'String', code: 'String' } },
       },
     },
+    two: (scenario) => ({
+      data: {
+        email: 'uniqueemail25@test.com',
+        name: 'String',
+        role: 'ORGANIZATION_STAFF',
+        agency: { connect: { id: scenario.agency.one.id } },
+      },
+      include: {
+        agency: true,
+      },
+    }),
+    three: (scenario) => ({
+      data: {
+        email: 'uniqueemail350@test.com',
+        name: 'String',
+        role: 'ORGANIZATION_STAFF',
+        agency: { connect: { id: scenario.agency.one.id } },
+      },
+      include: {
+        agency: true,
+      },
+    }),
   },
 })
 

--- a/api/src/services/users/users.test.ts
+++ b/api/src/services/users/users.test.ts
@@ -1,6 +1,14 @@
 import type { User } from '@prisma/client'
 
-import { users, user, createUser, updateUser, deleteUser } from './users'
+import {
+  users,
+  user,
+  createUser,
+  updateUser,
+  deleteUser,
+  currentUserIsUSDRAdmin,
+  usersByOrganization,
+} from './users'
 import type { StandardScenario } from './users.scenarios'
 
 // Generated boilerplate tests do not account for all circumstances
@@ -10,17 +18,79 @@ import type { StandardScenario } from './users.scenarios'
 // https://redwoodjs.com/docs/testing#jest-expect-type-considerations
 
 describe('users', () => {
-  scenario('returns all users', async (scenario: StandardScenario) => {
-    const result = await users()
+  scenario(
+    'users query returns all users for USDR admin',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.user.one.id,
+        email: scenario.user.one.email,
+        roles: ['USDR_ADMIN'],
+      })
+      const result = await users()
 
-    expect(result.length).toEqual(Object.keys(scenario.user).length)
-  })
+      expect(result.length).toEqual(Object.keys(scenario.user).length)
+    }
+  )
 
-  scenario('returns a single user', async (scenario: StandardScenario) => {
-    const result = await user({ id: scenario.user.one.id })
+  scenario(
+    'users query returns only users in organization for non-USDR admin',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.user.two.id,
+        email: scenario.user.two.email,
+        roles: ['ORGANIZATION_STAFF'],
+        agency: scenario.agency.one,
+      })
+      const result = await users()
 
-    expect(result).toEqual(scenario.user.one)
-  })
+      expect(result.length).toEqual(2)
+    }
+  )
+
+  scenario(
+    'returns a single user, USDR admin',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.user.one.id,
+        email: scenario.user.one.email,
+        roles: ['USDR_ADMIN'],
+      })
+      const result = await user({ id: scenario.user.one.id })
+
+      expect(result).toEqual(scenario.user.one)
+    }
+  )
+
+  scenario(
+    'returns a single user, staff member in same organization',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.user.two.id,
+        email: scenario.user.two.email,
+        roles: ['ORGANIZATION_STAFF'],
+        agency: scenario.agency.one,
+      })
+
+      const result = await user({ id: scenario.user.three.id })
+      //Not doing toEqual here because user doesn't eagerly fetch agency, so the objects differ slightly
+      expect(result?.id).toBeTruthy()
+    }
+  )
+
+  scenario(
+    'does not find user, staff member in different organization',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.user.two.id,
+        email: scenario.user.two.email,
+        roles: ['ORGANIZATION_STAFF'],
+        agency: scenario.agency.one,
+      })
+
+      const result = await user({ id: scenario.user.one.id })
+      expect(result).toBeNull()
+    }
+  )
 
   scenario('creates a user', async (scenario: StandardScenario) => {
     mockCurrentUser({
@@ -42,6 +112,11 @@ describe('users', () => {
   })
 
   scenario('updates a user', async (scenario: StandardScenario) => {
+    mockCurrentUser({
+      id: scenario.user.one.id,
+      email: scenario.user.one.email,
+      roles: ['USDR_ADMIN'],
+    })
     const original = (await user({ id: scenario.user.one.id })) as User
     const result = await updateUser({
       id: original.id,
@@ -52,9 +127,92 @@ describe('users', () => {
   })
 
   scenario('deletes a user', async (scenario: StandardScenario) => {
+    mockCurrentUser({
+      id: scenario.user.one.id,
+      email: scenario.user.one.email,
+      roles: ['USDR_ADMIN'],
+    })
     const original = (await deleteUser({ id: scenario.user.one.id })) as User
     const result = await user({ id: original.id })
 
     expect(result).toEqual(null)
   })
+
+  scenario(
+    'users by organization, usdr admin',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.user.one.id,
+        email: scenario.user.one.email,
+        roles: ['USDR_ADMIN'],
+      })
+      const result = await usersByOrganization({
+        organizationId: scenario.organization.one.id,
+      })
+
+      expect(result.length).toBe(2)
+    }
+  )
+
+  scenario(
+    'users by organization, staff in same organization',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.user.two.id,
+        email: scenario.user.two.email,
+        roles: ['ORGANIZATION_STAFF'],
+        agency: scenario.agency.one,
+      })
+      const result = await usersByOrganization({
+        organizationId: scenario.organization.one.id,
+      })
+
+      expect(result.length).toBe(2)
+    }
+  )
+
+  scenario(
+    'users by organization, staff in different organization',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.user.one.id,
+        email: scenario.user.one.email,
+        roles: ['USDR_ORGANIZATION_STAFF'],
+        agency: {},
+      })
+      const result = await usersByOrganization({
+        organizationId: scenario.organization.one.id,
+      })
+
+      expect(result.length).toBe(0)
+    }
+  )
+
+  scenario(
+    'identifies current user as USDR admin',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.user.one.id,
+        email: scenario.user.one.email,
+        roles: ['USDR_ADMIN'],
+      })
+      const result = currentUserIsUSDRAdmin()
+
+      expect(result).toBeTruthy()
+    }
+  )
+
+  scenario(
+    'identifies current user as not USDR admin',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.user.one.id,
+        email: scenario.user.one.email,
+        roles: ['ORGANIZATION_STAFF'],
+      })
+      const result = currentUserIsUSDRAdmin()
+
+      expect(result).toBeFalsy()
+    }
+  )
 })


### PR DESCRIPTION
- Create a common `currentUserIsUSDRAdmin` function to use across queries
- Modify `users`, `user` and `usersByOrganization` queries to use above function and, if user is not USDR admin, limit access only to other users in the querying user's organization
- Unit tests for the above changes