### PR TITLE
Update user changes

### DIFF
--- a/api/src/graphql/users.sdl.ts
+++ b/api/src/graphql/users.sdl.ts
@@ -37,6 +37,7 @@ export const schema = gql`
     name: String
     agencyId: Int
     role: RoleEnum
+    isActive: Boolean
   }
 
   type Mutation {

--- a/api/src/services/users/users.scenarios.ts
+++ b/api/src/services/users/users.scenarios.ts
@@ -13,13 +13,70 @@ export const standard = defineScenario<
         name: 'String',
       },
     },
+    two: {
+      data: {
+        name: 'String',
+      },
+    },
+    three: {
+      data: {
+        name: 'String',
+      },
+    },
   },
   agency: {
     one: (scenario) => ({
       data: {
         name: 'String',
-        organizationId: scenario.organization.one.id,
+        organization: {
+          connect: {
+            id: scenario.organization.one.id,
+          },
+        },
         code: 'String',
+      },
+      include: {
+        organization: true,
+      },
+    }),
+    two: (scenario) => ({
+      data: {
+        name: 'String',
+        organization: {
+          connect: { id: scenario.organization.one.id },
+        },
+        code: 'String',
+      },
+      include: {
+        organization: true,
+      },
+    }),
+    three: (scenario) => ({
+      data: {
+        name: 'String',
+        code: 'String',
+        organization: {
+          connect: {
+            id: scenario.organization.two.id,
+          },
+        },
+      },
+      include: {
+        organization: true,
+      },
+    }),
+    four: (scenario) => ({
+      data: {
+        name: 'String',
+        code: 'String',
+        organization: {
+          connect: {
+            id: scenario.organization.three.id,
+          },
+        },
+      },
+      include: {
+        organization: true,
       },
     }),
   },
@@ -49,6 +106,17 @@ export const standard = defineScenario<
         name: 'String',
         role: 'ORGANIZATION_STAFF',
         agency: { connect: { id: scenario.agency.one.id } },
+      },
+      include: {
+        agency: true,
+      },
+    }),
+    four: (scenario) => ({
+      data: {
+        email: 'uniqueemail450@test.com',
+        name: 'String',
+        role: 'ORGANIZATION_STAFF',
+        agency: { connect: { id: scenario.agency.three.id } },
       },
       include: {
         agency: true,

--- a/api/src/services/users/users.test.ts
+++ b/api/src/services/users/users.test.ts
@@ -318,7 +318,7 @@ describe('permissions write validations', () => {
         async () =>
           await runPermissionsCreateOrUpdateValidations({
             role: ROLES.ORGANIZATION_STAFF,
-            agencyId: scenario.agency.one.id,
+            agencyId: scenario.agency.three.id,
           })
       ).rejects.toThrow("You don't have permission to do that")
     }

--- a/api/src/services/users/users.test.ts
+++ b/api/src/services/users/users.test.ts
@@ -1,6 +1,6 @@
 import type { User } from '@prisma/client'
 
-import { EmailValidationError, ServiceValidationError } from '@redwoodjs/api'
+import { EmailValidationError } from '@redwoodjs/api'
 
 import { ROLES } from 'src/lib/constants'
 

--- a/api/src/services/users/users.test.ts
+++ b/api/src/services/users/users.test.ts
@@ -1,5 +1,9 @@
 import type { User } from '@prisma/client'
 
+import { EmailValidationError, ServiceValidationError } from '@redwoodjs/api'
+
+import { ROLES } from 'src/lib/constants'
+
 import {
   users,
   user,
@@ -8,6 +12,9 @@ import {
   deleteUser,
   currentUserIsUSDRAdmin,
   usersByOrganization,
+  runGeneralCreateOrUpdateValidations,
+  runPermissionsCreateOrUpdateValidations,
+  runUpdateSpecificValidations,
 } from './users'
 import type { StandardScenario } from './users.scenarios'
 
@@ -17,7 +24,7 @@ import type { StandardScenario } from './users.scenarios'
 //       https://redwoodjs.com/docs/testing#testing-services
 // https://redwoodjs.com/docs/testing#jest-expect-type-considerations
 
-describe('users', () => {
+describe('user queries', () => {
   scenario(
     'users query returns all users for USDR admin',
     async (scenario: StandardScenario) => {
@@ -92,52 +99,6 @@ describe('users', () => {
     }
   )
 
-  scenario('creates a user', async (scenario: StandardScenario) => {
-    mockCurrentUser({
-      id: scenario.user.one.id,
-      email: scenario.user.one.email,
-      roles: ['USDR_ADMIN'],
-    })
-
-    const result = await createUser({
-      input: {
-        email: 'uniqueemail2@test.com',
-        name: 'String',
-        agencyId: scenario.agency.one.id,
-        role: 'USDR_ADMIN',
-      },
-    })
-
-    expect(result.email).toEqual('uniqueemail2@test.com')
-  })
-
-  scenario('updates a user', async (scenario: StandardScenario) => {
-    mockCurrentUser({
-      id: scenario.user.one.id,
-      email: scenario.user.one.email,
-      roles: ['USDR_ADMIN'],
-    })
-    const original = (await user({ id: scenario.user.one.id })) as User
-    const result = await updateUser({
-      id: original.id,
-      input: { email: 'String2' },
-    })
-
-    expect(result.email).toEqual('String2')
-  })
-
-  scenario('deletes a user', async (scenario: StandardScenario) => {
-    mockCurrentUser({
-      id: scenario.user.one.id,
-      email: scenario.user.one.email,
-      roles: ['USDR_ADMIN'],
-    })
-    const original = (await deleteUser({ id: scenario.user.one.id })) as User
-    const result = await user({ id: original.id })
-
-    expect(result).toEqual(null)
-  })
-
   scenario(
     'users by organization, usdr admin',
     async (scenario: StandardScenario) => {
@@ -187,7 +148,267 @@ describe('users', () => {
       expect(result.length).toBe(0)
     }
   )
+})
 
+describe('user writes', () => {
+  scenario('creates a user', async (scenario: StandardScenario) => {
+    mockCurrentUser({
+      id: scenario.user.one.id,
+      email: scenario.user.one.email,
+      roles: ['USDR_ADMIN'],
+    })
+
+    const result = await createUser({
+      input: {
+        email: 'uniqueemail2@test.com',
+        name: 'String',
+        agencyId: scenario.agency.one.id,
+        role: 'USDR_ADMIN',
+      },
+    })
+
+    expect(result.email).toEqual('uniqueemail2@test.com')
+  })
+
+  scenario('updates a user', async (scenario: StandardScenario) => {
+    mockCurrentUser({
+      id: scenario.user.one.id,
+      email: scenario.user.one.email,
+      roles: ['USDR_ADMIN'],
+    })
+    const email = 'String2@gmail.com'
+    const name = 'FDR'
+    const role = 'ORGANIZATION_STAFF'
+    const original = (await user({ id: scenario.user.one.id })) as User
+    const result = await updateUser({
+      id: original.id,
+      input: { email, name, role, agencyId: scenario.agency.one.id },
+    })
+
+    expect(result.email).toEqual(email)
+    expect(result.name).toEqual(name)
+    expect(result.role).toEqual(ROLES.ORGANIZATION_STAFF)
+    expect(result.agencyId).toEqual(scenario.agency.one.id)
+  })
+
+  scenario('deletes a user', async (scenario: StandardScenario) => {
+    mockCurrentUser({
+      id: scenario.user.one.id,
+      email: scenario.user.one.email,
+      roles: ['USDR_ADMIN'],
+    })
+    const original = (await deleteUser({
+      id: scenario.user.one.id,
+    })) as User
+    const result = await user({ id: original.id })
+
+    expect(result).toEqual(null)
+  })
+})
+
+describe('general write validations', () => {
+  scenario('general validations, fails on invalid email', async () => {
+    expect(
+      async () =>
+        await runGeneralCreateOrUpdateValidations({
+          email: 'iamnotarealemail',
+        })
+    ).rejects.toThrow(EmailValidationError)
+  })
+
+  scenario('general validations, fails on missing name', async () => {
+    expect(
+      async () =>
+        await runGeneralCreateOrUpdateValidations({
+          email: 'iamreal@gmail.com',
+        })
+    ).rejects.toThrow('Please provide a name')
+  })
+
+  scenario('general validations, fails on missing role', async () => {
+    expect(
+      async () =>
+        await runGeneralCreateOrUpdateValidations({
+          email: 'iamreal@gmail.com',
+          name: 'FDR',
+        })
+    ).rejects.toThrow('Please provide a role')
+  })
+
+  scenario(
+    'permissions validations, USDR admin should throw no exceptions',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.user.one.id,
+        email: scenario.user.one.email,
+        roles: ['USDR_ADMIN'],
+      })
+      expect(
+        async () => await runPermissionsCreateOrUpdateValidations({})
+      ).not.toThrowError()
+    }
+  )
+
+  scenario(
+    'permissions validations, user w/o admin privileges should throw auth error',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.user.one.id,
+        email: scenario.user.one.email,
+        roles: ['ORGANIZATION_STAFF'],
+      })
+      expect(
+        async () => await runPermissionsCreateOrUpdateValidations({})
+      ).rejects.toThrow("You don't have permission to do that")
+    }
+  )
+
+  scenario('general validations, fails on bad role', async () => {
+    expect(
+      async () =>
+        await runGeneralCreateOrUpdateValidations({
+          email: 'iamreal@gmail.com',
+          name: 'FDR',
+          role: 'FAKE_ROLE',
+        })
+    ).rejects.toThrow('Please select a recognized role')
+  })
+
+  scenario('general validations, fails on bad agency id', async () => {
+    expect(
+      async () =>
+        await runGeneralCreateOrUpdateValidations({
+          email: 'iamreal@gmail.com',
+          name: 'FDR',
+          role: 'ORGANIZATION_STAFF',
+          agencyId: 4598,
+        })
+    ).rejects.toThrowError('No Agency found')
+  })
+})
+
+describe('permissions write validations', () => {
+  scenario(
+    'permissions validations, organization admin cannot update a USDR admin',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.user.one.id,
+        email: scenario.user.one.email,
+        roles: ['ORGANIZATION_ADMIN'],
+      })
+      expect(
+        async () =>
+          await runPermissionsCreateOrUpdateValidations({
+            role: ROLES.USDR_ADMIN,
+          })
+      ).rejects.toThrow("You don't have permission to update that role")
+    }
+  )
+
+  scenario(
+    'permissions validations, organization admin cannot update a user in a different organization',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.user.one.id,
+        email: scenario.user.one.email,
+        roles: ['ORGANIZATION_ADMIN'],
+        agency: scenario.agency.one,
+      })
+      expect(
+        async () =>
+          await runPermissionsCreateOrUpdateValidations({
+            role: ROLES.ORGANIZATION_STAFF,
+            agencyId: scenario.agency.one.id,
+          })
+      ).rejects.toThrow("You don't have permission to do that")
+    }
+  )
+
+  scenario(
+    'permissions validations, passes when expected',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.user.two.id,
+        email: scenario.user.two.email,
+        roles: ['ORGANIZATION_ADMIN'],
+      })
+      expect(
+        async () =>
+          await runPermissionsCreateOrUpdateValidations({
+            role: ROLES.ORGANIZATION_STAFF,
+            agencyId: scenario.agency.one.id,
+          })
+      ).rejects.toThrow("You don't have permission to do that")
+    }
+  )
+})
+
+describe('update specific validations', () => {
+  scenario(
+    'update specific validations, passes when USDR admin',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.user.two.id,
+        email: scenario.user.two.email,
+        roles: ['USDR_ADMIN'],
+      })
+      await expect(
+        async () =>
+          await runUpdateSpecificValidations(
+            {
+              role: ROLES.ORGANIZATION_STAFF,
+              agencyId: scenario.agency.one.id,
+            },
+            scenario.user.one.id
+          )
+      ).not.toThrowError()
+    }
+  )
+
+  scenario(
+    'update specific validations, passes when agency is the same',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.user.two.id,
+        email: scenario.user.two.email,
+        roles: ['ORGANIZATION_ADMIN'],
+      })
+      await expect(
+        async () =>
+          await runUpdateSpecificValidations(
+            {
+              role: ROLES.ORGANIZATION_STAFF,
+              agencyId: scenario.agency.one.id,
+            },
+            scenario.user.three.id
+          )
+      ).not.toThrowError()
+    }
+  )
+
+  scenario(
+    'update specific validations, fails when agency is the different',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.user.two.id,
+        email: scenario.user.two.email,
+        roles: ['ORGANIZATION_ADMIN'],
+      })
+      await expect(
+        async () =>
+          await runUpdateSpecificValidations(
+            {
+              role: ROLES.ORGANIZATION_STAFF,
+              agencyId: scenario.agency.one.id,
+            },
+            scenario.user.four.id
+          )
+      ).rejects.toThrow('agencyId is invalid or unavailable to this user')
+    }
+  )
+})
+
+describe('identifies user role', () => {
   scenario(
     'identifies current user as USDR admin',
     async (scenario: StandardScenario) => {

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -108,12 +108,6 @@ export const runUpdateSpecificValidations = async (input, id) => {
           },
         })
       ).agency
-      console.log('current agency ' + currentAgency.id)
-      console.log(currentAgency)
-      console.log(
-        'current agency organization id ' + currentAgency.organizationId
-      )
-      console.log('input agency ' + input.agencyId)
 
       if (input.agencyId === currentAgency.id) {
         return

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -5,14 +5,133 @@ import type {
   Agency,
 } from 'types/graphql'
 
-import { validate, validateWith, validateUniqueness } from '@redwoodjs/api'
+import {
+  validate,
+  validateWith,
+  validateUniqueness,
+  validateWithSync,
+} from '@redwoodjs/api'
 import { AuthenticationError } from '@redwoodjs/graphql-server'
 
 import { ROLES } from 'src/lib/constants'
 import { db } from 'src/lib/db'
+import { logger } from 'src/lib/logger'
 
 export const currentUserIsUSDRAdmin = (): boolean => {
   return context.currentUser?.roles?.includes(ROLES.USDR_ADMIN)
+}
+
+/***
+ * Validations for create and update actions that are based on user input (e.g. field presence, email validation, etc)
+ */
+export const runGeneralCreateOrUpdateValidations = async (input) => {
+  const { email, name, role, agencyId } = input
+
+  validate(email, {
+    email: { message: 'Please provide a valid email address' },
+  })
+
+  validate(name, {
+    presence: { allowEmptyString: false, message: 'Please provide a name' },
+  })
+
+  validate(role, {
+    presence: { allowEmptyString: false, message: 'Please provide a role' },
+    inclusion: {
+      in: Object.values(ROLES),
+      message: 'Please select a recognized role',
+    },
+  })
+
+  await validateWith(async () => {
+    await db.agency.findUniqueOrThrow({
+      where: { id: agencyId },
+      select: { organizationId: true },
+    })
+  })
+}
+
+/**
+ *
+ * @param input Validations for create and update actions that are based on user permissions (eg logged in user role, agency, etc.)
+ */
+export const runPermissionsCreateOrUpdateValidations = async (input) => {
+  // If current user is a USDR admin, we don't care about any other permissions checks
+  if (currentUserIsUSDRAdmin()) {
+    return
+  }
+
+  const { agencyId, role } = input
+  const { currentUser } = context
+
+  validateWithSync(() => {
+    if (!currentUser?.roles?.includes(ROLES.ORGANIZATION_ADMIN))
+      throw new AuthenticationError("You don't have permission to do that")
+  })
+
+  validate(role, {
+    exclusion: {
+      in: [ROLES.USDR_ADMIN],
+      message: "You don't have permission to update that role",
+    },
+  })
+
+  // User can only create or update a user in the same organization
+  await validateWith(async () => {
+    const targetUserOrgId = (
+      await db.agency.findUniqueOrThrow({
+        where: { id: agencyId },
+        select: { organizationId: true },
+      })
+    ).organizationId
+    if (targetUserOrgId !== (currentUser.agency as Agency)?.organizationId) {
+      throw new AuthenticationError("You don't have permission to do that")
+    }
+  })
+}
+
+/**
+ * Validations specific to updating a user
+ */
+export const runUpdateSpecificValidations = async (input, id) => {
+  // If not USDR admin, changes to agencyId are only allowed if the new agency ID is in the same organization
+  // as the user's current agency (e.g., you can't swap a user between organizations)
+  await validateWith(async () => {
+    if (!currentUserIsUSDRAdmin()) {
+      const currentAgency = (
+        await db.user.findUniqueOrThrow({
+          where: { id },
+          select: {
+            agency: {
+              select: { id: true, organizationId: true },
+            },
+          },
+        })
+      ).agency
+      console.log('current agency ' + currentAgency.id)
+      console.log(currentAgency)
+      console.log(
+        'current agency organization id ' + currentAgency.organizationId
+      )
+      console.log('input agency ' + input.agencyId)
+
+      if (input.agencyId === currentAgency.id) {
+        return
+      }
+
+      try {
+        await db.agency.findUniqueOrThrow({
+          where: {
+            id: input.agencyId,
+            organizationId: currentAgency.organizationId,
+          },
+        })
+      } catch (err) {
+        logger.error({ err }, 'change to user.agencyId is not allowed')
+        throw new Error('agencyId is invalid or unavailable to this user')
+      }
+    }
+  })
 }
 
 export const users: QueryResolvers['users'] = () => {
@@ -64,35 +183,10 @@ export const user: QueryResolvers['user'] = ({ id }) => {
 export const createUser: MutationResolvers['createUser'] = async ({
   input,
 }) => {
-  const { email, name, agencyId } = input
-  const { currentUser } = context
+  const { email } = input
 
-  validate(email, {
-    email: { message: 'Please provide a valid email address' },
-  })
-
-  validate(name, {
-    presence: { allowEmptyString: false, message: 'Please provide a name' },
-  })
-
-  validateWith(async () => {
-    if (currentUserIsUSDRAdmin()) {
-      return true
-    }
-
-    const newUserAgency = await db.agency.findUniqueOrThrow({
-      where: { id: agencyId },
-      select: { organizationId: true },
-    })
-    const loggedInUserAgency = await db.agency.findUniqueOrThrow({
-      where: { id: currentUser.agencyId as number },
-      select: { organizationId: true },
-    })
-
-    if (newUserAgency.organizationId !== loggedInUserAgency.organizationId) {
-      throw new AuthenticationError("You don't have permission to do that")
-    }
-  })
+  await runGeneralCreateOrUpdateValidations(input)
+  await runPermissionsCreateOrUpdateValidations(input)
 
   return validateUniqueness(
     'user',
@@ -102,7 +196,14 @@ export const createUser: MutationResolvers['createUser'] = async ({
   )
 }
 
-export const updateUser: MutationResolvers['updateUser'] = ({ id, input }) => {
+export const updateUser: MutationResolvers['updateUser'] = async ({
+  id,
+  input,
+}) => {
+  await runGeneralCreateOrUpdateValidations(input)
+  await runPermissionsCreateOrUpdateValidations(input)
+  await runUpdateSpecificValidations(input, id)
+
   return db.user.update({
     data: input,
     where: { id },


### PR DESCRIPTION
**Note: the ticket asked for a mutation & resolver for updating a user, but these already existed, so I just updated them to match the ticket specs**

- Add a field for `isActive` to `UpdateUserInput` (input type already existed)
- Updated mutation resolver to validate on email, name, role, "good" agency id, logged in user role, logged in user org and new agency input
- Updated creation resolver to use the same validations as update (with the exception of new agency input, which isn't relevant for creation)
- Added unit tests for above