### PR TITLE
fix: rendering issues due to user permissions

### DIFF
--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -84,10 +84,7 @@ export const createUser: MutationResolvers['createUser'] = async ({
       where: { id: agencyId },
       select: { organizationId: true },
     })
-    const loggedInUserAgency = await db.agency.findUniqueOrThrow({
-      where: { id: currentUser.agencyId as number },
-      select: { organizationId: true },
-    })
+    const loggedInUserAgency = currentUser.agency as Agency
 
     if (newUserAgency.organizationId !== loggedInUserAgency.organizationId) {
       throw new AuthenticationError("You don't have permission to do that")

--- a/web/src/auth.ts
+++ b/web/src/auth.ts
@@ -50,10 +50,20 @@ const client = {
   logout: () => {},
   getToken: () => 'super-secret-short-lived-token',
   getUserMetadata: () => ({
-    id: 1,
-    email: 'email@example.com',
-    organizationId: 1,
-    roles: [],
+    email: 'usdr-admin@usdr.dev',
+    name: 'USDR Admin',
+    role: 'USDR_ADMIN',
+    roles: ['USDR_ADMIN'],
+    agency: {
+      name: 'Main Agency',
+      abbreviation: 'MAUSDR',
+      code: 'MAUSDR',
+      organizationId: 1,
+    },
+    agencyId: 1, // TO_DEPRECATE
+    organizationId: 1, // TO_DEPRECATE
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
   }),
 }
 


### PR DESCRIPTION
## Context
This PR emerged from going through the staging and local experience trying to figure out permissions discrepancies when rendering the `Uploads` list view and the `Users` page.

It fixes the following issues:
1. Any user that does not have a `USDR_ADMIN` role was unable to create/update users. Previously this could not be done because `agency` was not a property that was available on the `context.currentUser`.
2. The front-end was not rendering the /users page due to a permissions error for any user when `AUTH_PROVIDER=local`. This was because the RedwoodJS `<PrivateSet>` route-component requires there to be a `roles` attribute explicitly defined on the `User` object. For now, I have added an explicit casting of the existing `role` into a `roles` array, but we may want to consider a more elegant solution in the future.


### Before
USDR_Admin user attempting to view the list of available tabs. As seen here the Users tab is missing. This is due to the lack of a `roles = ["USDR_ADMIN"]` array on the returned `currentUser` object.
<img width="1551" alt="image" src="https://github.com/usdigitalresponse/cpf-reporter/assets/6497366/d77e59ef-7e0b-48ce-859b-4db054068693">

### After
USDR_Admin user is able to see the Users tab
<img width="1526" alt="image" src="https://github.com/usdigitalresponse/cpf-reporter/assets/6497366/35e7ef59-dc63-4df8-a5ab-f6d076ceb157">
