### PR TITLE
UploadValidation database changes

### DIFF
--- a/api/db/migrations/20240326182611_upload_validation_changes/migration.sql
+++ b/api/db/migrations/20240326182611_upload_validation_changes/migration.sql
@@ -1,0 +1,31 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `agencyId` on the `UploadValidation` table. All the data in the column will be lost.
+  - You are about to drop the column `inputTemplateId` on the `UploadValidation` table. All the data in the column will be lost.
+  - You are about to drop the column `organizationId` on the `UploadValidation` table. All the data in the column will be lost.
+  - You are about to drop the column `validationResults` on the `UploadValidation` table. All the data in the column will be lost.
+  - Added the required column `initiatedById` to the `UploadValidation` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `passed` to the `UploadValidation` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "UploadValidation" DROP CONSTRAINT "UploadValidation_agencyId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "UploadValidation" DROP CONSTRAINT "UploadValidation_inputTemplateId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "UploadValidation" DROP CONSTRAINT "UploadValidation_organizationId_fkey";
+
+-- AlterTable
+ALTER TABLE "UploadValidation" DROP COLUMN "agencyId",
+DROP COLUMN "inputTemplateId",
+DROP COLUMN "organizationId",
+DROP COLUMN "validationResults",
+ADD COLUMN     "initiatedById" INTEGER NOT NULL,
+ADD COLUMN     "passed" BOOLEAN NOT NULL,
+ADD COLUMN     "results" JSONB;
+
+-- AddForeignKey
+ALTER TABLE "UploadValidation" ADD CONSTRAINT "UploadValidation_initiatedById_fkey" FOREIGN KEY ("initiatedById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/db/migrations/20240326192321_add_upload_validation_constraint/migration.sql
+++ b/api/db/migrations/20240326192321_add_upload_validation_constraint/migration.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX unique_null_results_per_uploadid ON "UploadValidation" ("uploadId") WHERE results IS NULL;

--- a/api/db/migrations/20240326192321_add_upload_validation_constraint/migration.sql
+++ b/api/db/migrations/20240326192321_add_upload_validation_constraint/migration.sql
@@ -1,1 +1,1 @@
-CREATE UNIQUE INDEX unique_null_results_per_uploadid ON "UploadValidation" ("uploadId") WHERE results IS NULL;
+CREATE UNIQUE INDEX "UploadValidation_unique_null_results_per_uploadid" ON "UploadValidation" ("uploadId") WHERE results IS NULL;

--- a/api/db/migrations/20240326192321_add_upload_validation_constraint/migration.sql
+++ b/api/db/migrations/20240326192321_add_upload_validation_constraint/migration.sql
@@ -1,1 +1,0 @@
-CREATE UNIQUE INDEX "UploadValidation_unique_null_results_per_uploadid" ON "UploadValidation" ("uploadId") WHERE results IS NULL;

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -130,7 +130,7 @@ model Upload {
 model UploadValidation {
   id                  Int            @id @default(autoincrement())
   uploadId            Int
-  upload              Upload         @relation(fields: [uploadId], references: [id])
+  upload              Upload         @relation(fields: [uploadId], references: [id], onDelete: Cascade)
   results             Json?         @db.JsonB
   passed              Boolean
   initiatedById       Int

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -18,7 +18,6 @@ model Agency {
   organizationId    Int?
   users             User[]
   uploads           Upload[]
-  uploadValidations UploadValidation[]
   projects          Project[]
 }
 
@@ -28,7 +27,6 @@ model Organization {
   name              String
   reportingPeriods  ReportingPeriod[]
   uploads           Upload[]
-  uploadValidations UploadValidation[]
   subrecipients     Subrecipient[]
   projects          Project[]
 }
@@ -46,6 +44,7 @@ model User {
   agency         Agency              @relation(fields: [agencyId], references: [id])
   certified      ReportingPeriod[]
   uploaded       Upload[]
+  initiated      UploadValidation[]
 
   @@index(fields: [passageId])
 }
@@ -65,7 +64,6 @@ model InputTemplate {
   createdAt           DateTime           @default(now()) @db.Timestamptz(6)
   updatedAt           DateTime           @default(now()) @db.Timestamptz(6)
   reportingPeriods    ReportingPeriod[]
-  uploadValidations   UploadValidation[]
 }
 
 model OutputTemplate {
@@ -133,13 +131,10 @@ model UploadValidation {
   id                  Int            @id @default(autoincrement())
   uploadId            Int
   upload              Upload         @relation(fields: [uploadId], references: [id])
-  agencyId            Int
-  agency              Agency         @relation(fields: [agencyId], references: [id])
-  organizationId      Int
-  organization        Organization   @relation(fields: [organizationId], references: [id])
-  inputTemplateId     Int
-  inputTemplate       InputTemplate @relation(fields: [inputTemplateId], references: [id])
-  validationResults   Json?         @db.JsonB
+  results             Json?         @db.JsonB
+  passed              Boolean
+  initiatedById       Int
+  initiatedBy         User          @relation(fields: [initiatedById], references: [id])
   validatedAt         DateTime?     @db.Timestamptz(6)
   invalidationResults Json?         @db.JsonB
   invalidatedAt       DateTime?     @db.Timestamptz(6)

--- a/api/src/graphql/uploadValidations.sdl.ts
+++ b/api/src/graphql/uploadValidations.sdl.ts
@@ -3,20 +3,13 @@ export const schema = gql`
     id: Int!
     uploadId: Int!
     upload: Upload!
-    agencyId: Int!
-    agency: Agency!
-    organizationId: Int!
-    organization: Organization!
-    inputTemplateId: Int!
-    inputTemplate: InputTemplate!
-    validationResults: JSON
+    results: JSON
+    passed: Boolean!
+    initiatedById: Int!
+    initiatedBy: User!
     validatedAt: DateTime
-    validatedById: Int
-    validatedBy: User
     invalidationResults: JSON
     invalidatedAt: DateTime
-    invalidatedById: Int
-    invalidatedBy: User
     createdAt: DateTime!
     updatedAt: DateTime!
   }
@@ -28,28 +21,22 @@ export const schema = gql`
 
   input CreateUploadValidationInput {
     uploadId: Int!
-    agencyId: Int!
-    organizationId: Int!
-    inputTemplateId: Int!
-    validationResults: JSON
+    results: JSON
+    passed: Boolean!
+    initiatedById: Int!
     validatedAt: DateTime
-    validatedById: Int
     invalidationResults: JSON
     invalidatedAt: DateTime
-    invalidatedById: Int
   }
 
   input UpdateUploadValidationInput {
     uploadId: Int
-    agencyId: Int
-    organizationId: Int
-    inputTemplateId: Int
-    validationResults: JSON
+    results: JSON
+    passed: Boolean
+    initiatedById: Int
     validatedAt: DateTime
-    validatedById: Int
     invalidationResults: JSON
     invalidatedAt: DateTime
-    invalidatedById: Int
   }
 
   type Mutation {

--- a/api/src/services/uploadValidations/uploadValidations.scenarios.ts
+++ b/api/src/services/uploadValidations/uploadValidations.scenarios.ts
@@ -7,15 +7,18 @@ export const standard = defineScenario<Prisma.UploadValidationCreateArgs>({
     one: {
       data: {
         updatedAt: '2023-12-08T21:03:20.706Z',
+        passed: true,
         upload: {
           create: {
             filename: 'String',
             updatedAt: '2023-12-08T21:03:20.706Z',
             uploadedBy: {
               create: {
-                email: 'String',
+                name: 'String',
+                email: 'String1',
+                role: 'USDR_ADMIN',
                 updatedAt: '2023-12-08T21:03:20.706Z',
-                organization: { create: { name: 'String' } },
+                agency: { create: { name: 'String', code: 'String' } },
               },
             },
             agency: { create: { name: 'String', code: 'String' } },
@@ -42,6 +45,7 @@ export const standard = defineScenario<Prisma.UploadValidationCreateArgs>({
                     updatedAt: '2023-12-08T21:03:20.706Z',
                   },
                 },
+                organization: { create: { name: 'String' } },
               },
             },
             expenditureCategory: {
@@ -53,14 +57,13 @@ export const standard = defineScenario<Prisma.UploadValidationCreateArgs>({
             },
           },
         },
-        agency: { create: { name: 'String', code: 'String' } },
-        organization: { create: { name: 'String' } },
-        inputTemplate: {
+        initiatedBy: {
           create: {
             name: 'String',
-            version: 'String',
-            effectiveDate: '2023-12-08T21:03:20.706Z',
+            email: 'String2',
+            role: 'USDR_ADMIN',
             updatedAt: '2023-12-08T21:03:20.706Z',
+            agency: { create: { name: 'String', code: 'String' } },
           },
         },
       },
@@ -68,15 +71,18 @@ export const standard = defineScenario<Prisma.UploadValidationCreateArgs>({
     two: {
       data: {
         updatedAt: '2023-12-08T21:03:20.706Z',
+        passed: true,
         upload: {
           create: {
             filename: 'String',
             updatedAt: '2023-12-08T21:03:20.706Z',
             uploadedBy: {
               create: {
-                email: 'String',
+                name: 'String',
+                email: 'String3',
+                role: 'USDR_ADMIN',
                 updatedAt: '2023-12-08T21:03:20.706Z',
-                organization: { create: { name: 'String' } },
+                agency: { create: { name: 'String', code: 'String' } },
               },
             },
             agency: { create: { name: 'String', code: 'String' } },
@@ -103,6 +109,7 @@ export const standard = defineScenario<Prisma.UploadValidationCreateArgs>({
                     updatedAt: '2023-12-08T21:03:20.706Z',
                   },
                 },
+                organization: { create: { name: 'String' } },
               },
             },
             expenditureCategory: {
@@ -114,14 +121,13 @@ export const standard = defineScenario<Prisma.UploadValidationCreateArgs>({
             },
           },
         },
-        agency: { create: { name: 'String', code: 'String' } },
-        organization: { create: { name: 'String' } },
-        inputTemplate: {
+        initiatedBy: {
           create: {
             name: 'String',
-            version: 'String',
-            effectiveDate: '2023-12-08T21:03:20.706Z',
+            email: 'String2',
+            role: 'USDR_ADMIN',
             updatedAt: '2023-12-08T21:03:20.706Z',
+            agency: { create: { name: 'String', code: 'String' } },
           },
         },
       },

--- a/api/src/services/uploadValidations/uploadValidations.scenarios.ts
+++ b/api/src/services/uploadValidations/uploadValidations.scenarios.ts
@@ -124,7 +124,7 @@ export const standard = defineScenario<Prisma.UploadValidationCreateArgs>({
         initiatedBy: {
           create: {
             name: 'String',
-            email: 'String2',
+            email: 'String4',
             role: 'USDR_ADMIN',
             updatedAt: '2023-12-08T21:03:20.706Z',
             agency: { create: { name: 'String', code: 'String' } },

--- a/api/src/services/uploadValidations/uploadValidations.scenarios.ts
+++ b/api/src/services/uploadValidations/uploadValidations.scenarios.ts
@@ -1,8 +1,10 @@
-import type { Prisma, UploadValidation } from '@prisma/client'
+import type { Prisma, UploadValidation, Upload } from '@prisma/client'
 
 import type { ScenarioData } from '@redwoodjs/testing/api'
 
-export const standard = defineScenario<Prisma.UploadValidationCreateArgs>({
+export const standard = defineScenario<
+  Prisma.UploadValidationCreateArgs | Prisma.UploadCreateArgs
+>({
   uploadValidation: {
     one: {
       data: {
@@ -133,9 +135,61 @@ export const standard = defineScenario<Prisma.UploadValidationCreateArgs>({
       },
     },
   },
+  upload: {
+    one: {
+      data: {
+        filename: 'String',
+        updatedAt: '2023-12-08T21:03:20.706Z',
+        uploadedBy: {
+          create: {
+            name: 'String',
+            email: 'String5',
+            role: 'USDR_ADMIN',
+            updatedAt: '2023-12-08T21:03:20.706Z',
+            agency: { create: { name: 'String', code: 'String' } },
+          },
+        },
+        agency: { create: { name: 'String', code: 'String' } },
+        organization: { create: { name: 'String' } },
+        reportingPeriod: {
+          create: {
+            name: 'String',
+            startDate: '2023-12-08T21:03:20.706Z',
+            endDate: '2023-12-08T21:03:20.706Z',
+            updatedAt: '2023-12-08T21:03:20.706Z',
+            inputTemplate: {
+              create: {
+                name: 'String',
+                version: 'String',
+                effectiveDate: '2023-12-08T21:03:20.706Z',
+                updatedAt: '2023-12-08T21:03:20.706Z',
+              },
+            },
+            outputTemplate: {
+              create: {
+                name: 'String',
+                version: 'String',
+                effectiveDate: '2023-12-08T21:03:20.706Z',
+                updatedAt: '2023-12-08T21:03:20.706Z',
+              },
+            },
+            organization: { create: { name: 'String' } },
+          },
+        },
+        expenditureCategory: {
+          create: {
+            name: 'String',
+            code: 'String',
+            updatedAt: '2023-12-08T21:03:20.706Z',
+          },
+        },
+      },
+    },
+  },
 })
 
 export type StandardScenario = ScenarioData<
   UploadValidation,
   'uploadValidation'
->
+> &
+  ScenarioData<Upload, 'upload'>

--- a/api/src/services/uploadValidations/uploadValidations.ts
+++ b/api/src/services/uploadValidations/uploadValidations.ts
@@ -44,27 +44,9 @@ export const UploadValidation: UploadValidationRelationResolvers = {
   upload: (_obj, { root }) => {
     return db.uploadValidation.findUnique({ where: { id: root?.id } }).upload()
   },
-  agency: (_obj, { root }) => {
-    return db.uploadValidation.findUnique({ where: { id: root?.id } }).agency()
-  },
-  organization: (_obj, { root }) => {
+  initiatedBy: (_obj, { root }) => {
     return db.uploadValidation
       .findUnique({ where: { id: root?.id } })
-      .organization()
-  },
-  inputTemplate: (_obj, { root }) => {
-    return db.uploadValidation
-      .findUnique({ where: { id: root?.id } })
-      .inputTemplate()
-  },
-  validatedBy: (_obj, { root }) => {
-    return db.uploadValidation
-      .findUnique({ where: { id: root?.id } })
-      .validatedBy()
-  },
-  invalidatedBy: (_obj, { root }) => {
-    return db.uploadValidation
-      .findUnique({ where: { id: root?.id } })
-      .invalidatedBy()
+      .initiatedBy()
   },
 }

--- a/api/src/services/uploads/uploads.scenarios.ts
+++ b/api/src/services/uploads/uploads.scenarios.ts
@@ -42,28 +42,28 @@ export const standard = defineScenario<Prisma.UploadCreateArgs>({
         validations: {
           create: [
             {
-              agency: { create: { name: 'String', code: 'String' } },
-              organization: { create: { name: 'String' } },
-              inputTemplate: {
+              passed: true,
+              createdAt: '2024-01-26T15:11:27.000Z',
+              initiatedBy: {
                 create: {
+                  email: 'uniqueemail2@test.com',
                   name: 'String',
-                  version: 'String',
-                  effectiveDate: '2024-01-26T00:00:00.000Z',
+                  role: 'USDR_ADMIN',
+                  agency: { create: { name: 'String', code: 'String' } },
                 },
               },
-              createdAt: '2024-01-26T15:11:27.000Z',
             },
             {
-              agency: { create: { name: 'String', code: 'String' } },
-              organization: { create: { name: 'String' } },
-              inputTemplate: {
+              passed: true,
+              createdAt: '2024-01-27T10:32:00.000Z',
+              initiatedBy: {
                 create: {
+                  email: 'uniqueemail3@test.com',
                   name: 'String',
-                  version: 'String',
-                  effectiveDate: '2024-01-26T15:11:27.688Z',
+                  role: 'USDR_ADMIN',
+                  agency: { create: { name: 'String', code: 'String' } },
                 },
               },
-              createdAt: '2024-01-27T10:32:00.000Z',
             },
           ],
         },
@@ -76,7 +76,7 @@ export const standard = defineScenario<Prisma.UploadCreateArgs>({
         filename: 'String',
         uploadedBy: {
           create: {
-            email: 'uniqueemail2@test.com',
+            email: 'uniqueemail4@test.com',
             name: 'String',
             role: 'USDR_ADMIN',
             agency: { create: { name: 'String', code: 'String' } },
@@ -109,25 +109,25 @@ export const standard = defineScenario<Prisma.UploadCreateArgs>({
         validations: {
           create: [
             {
-              agency: { create: { name: 'String', code: 'String' } },
-              organization: { create: { name: 'String' } },
-              inputTemplate: {
+              passed: true,
+              initiatedBy: {
                 create: {
+                  email: 'uniqueemail5@test.com',
                   name: 'String',
-                  version: 'String',
-                  effectiveDate: '2023-12-07T18:17:24.389Z',
+                  role: 'USDR_ADMIN',
+                  agency: { create: { name: 'String', code: 'String' } },
                 },
               },
               createdAt: '2024-01-29T18:13:25.000Z',
             },
             {
-              agency: { create: { name: 'String', code: 'String' } },
-              organization: { create: { name: 'String' } },
-              inputTemplate: {
+              passed: true,
+              initiatedBy: {
                 create: {
+                  email: 'uniqueemail6@test.com',
                   name: 'String',
-                  version: 'String',
-                  effectiveDate: '2023-12-07T18:17:24.389Z',
+                  role: 'USDR_ADMIN',
+                  agency: { create: { name: 'String', code: 'String' } },
                 },
               },
               createdAt: '2024-01-29T17:10:22.000Z',

--- a/api/types/graphql.d.ts
+++ b/api/types/graphql.d.ts
@@ -136,16 +136,13 @@ export type CreateUploadInput = {
 };
 
 export type CreateUploadValidationInput = {
-  agencyId: Scalars['Int'];
-  inputTemplateId: Scalars['Int'];
+  initiatedById: Scalars['Int'];
   invalidatedAt?: InputMaybe<Scalars['DateTime']>;
-  invalidatedById?: InputMaybe<Scalars['Int']>;
   invalidationResults?: InputMaybe<Scalars['JSON']>;
-  organizationId: Scalars['Int'];
+  passed: Scalars['Boolean'];
+  results?: InputMaybe<Scalars['JSON']>;
   uploadId: Scalars['Int'];
   validatedAt?: InputMaybe<Scalars['DateTime']>;
-  validatedById?: InputMaybe<Scalars['Int']>;
-  validationResults?: InputMaybe<Scalars['JSON']>;
 };
 
 export type CreateUserInput = {
@@ -680,21 +677,19 @@ export type UpdateUploadInput = {
 };
 
 export type UpdateUploadValidationInput = {
-  agencyId?: InputMaybe<Scalars['Int']>;
-  inputTemplateId?: InputMaybe<Scalars['Int']>;
+  initiatedById?: InputMaybe<Scalars['Int']>;
   invalidatedAt?: InputMaybe<Scalars['DateTime']>;
-  invalidatedById?: InputMaybe<Scalars['Int']>;
   invalidationResults?: InputMaybe<Scalars['JSON']>;
-  organizationId?: InputMaybe<Scalars['Int']>;
+  passed?: InputMaybe<Scalars['Boolean']>;
+  results?: InputMaybe<Scalars['JSON']>;
   uploadId?: InputMaybe<Scalars['Int']>;
   validatedAt?: InputMaybe<Scalars['DateTime']>;
-  validatedById?: InputMaybe<Scalars['Int']>;
-  validationResults?: InputMaybe<Scalars['JSON']>;
 };
 
 export type UpdateUserInput = {
   agencyId?: InputMaybe<Scalars['Int']>;
   email?: InputMaybe<Scalars['String']>;
+  isActive?: InputMaybe<Scalars['Boolean']>;
   name?: InputMaybe<Scalars['String']>;
   role?: InputMaybe<RoleEnum>;
 };
@@ -723,25 +718,18 @@ export type Upload = {
 
 export type UploadValidation = {
   __typename?: 'UploadValidation';
-  agency: Agency;
-  agencyId: Scalars['Int'];
   createdAt: Scalars['DateTime'];
   id: Scalars['Int'];
-  inputTemplate: InputTemplate;
-  inputTemplateId: Scalars['Int'];
+  initiatedBy: User;
+  initiatedById: Scalars['Int'];
   invalidatedAt?: Maybe<Scalars['DateTime']>;
-  invalidatedBy?: Maybe<User>;
-  invalidatedById?: Maybe<Scalars['Int']>;
   invalidationResults?: Maybe<Scalars['JSON']>;
-  organization: Organization;
-  organizationId: Scalars['Int'];
+  passed: Scalars['Boolean'];
+  results?: Maybe<Scalars['JSON']>;
   updatedAt: Scalars['DateTime'];
   upload: Upload;
   uploadId: Scalars['Int'];
   validatedAt?: Maybe<Scalars['DateTime']>;
-  validatedBy?: Maybe<User>;
-  validatedById?: Maybe<Scalars['Int']>;
-  validationResults?: Maybe<Scalars['JSON']>;
 };
 
 export type User = {
@@ -1382,48 +1370,34 @@ export type UploadRelationResolvers<ContextType = RedwoodGraphQLContext, ParentT
 };
 
 export type UploadValidationResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['UploadValidation'] = ResolversParentTypes['UploadValidation']> = {
-  agency: OptArgsResolverFn<ResolversTypes['Agency'], ParentType, ContextType>;
-  agencyId: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
   createdAt: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
   id: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
-  inputTemplate: OptArgsResolverFn<ResolversTypes['InputTemplate'], ParentType, ContextType>;
-  inputTemplateId: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  initiatedBy: OptArgsResolverFn<ResolversTypes['User'], ParentType, ContextType>;
+  initiatedById: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
   invalidatedAt: OptArgsResolverFn<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
-  invalidatedBy: OptArgsResolverFn<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  invalidatedById: OptArgsResolverFn<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   invalidationResults: OptArgsResolverFn<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
-  organization: OptArgsResolverFn<ResolversTypes['Organization'], ParentType, ContextType>;
-  organizationId: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  passed: OptArgsResolverFn<ResolversTypes['Boolean'], ParentType, ContextType>;
+  results: OptArgsResolverFn<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   updatedAt: OptArgsResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
   upload: OptArgsResolverFn<ResolversTypes['Upload'], ParentType, ContextType>;
   uploadId: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
   validatedAt: OptArgsResolverFn<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
-  validatedBy: OptArgsResolverFn<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  validatedById: OptArgsResolverFn<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  validationResults: OptArgsResolverFn<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type UploadValidationRelationResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['UploadValidation'] = ResolversParentTypes['UploadValidation']> = {
-  agency?: RequiredResolverFn<ResolversTypes['Agency'], ParentType, ContextType>;
-  agencyId?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
   createdAt?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
   id?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
-  inputTemplate?: RequiredResolverFn<ResolversTypes['InputTemplate'], ParentType, ContextType>;
-  inputTemplateId?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  initiatedBy?: RequiredResolverFn<ResolversTypes['User'], ParentType, ContextType>;
+  initiatedById?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
   invalidatedAt?: RequiredResolverFn<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
-  invalidatedBy?: RequiredResolverFn<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  invalidatedById?: RequiredResolverFn<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   invalidationResults?: RequiredResolverFn<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
-  organization?: RequiredResolverFn<ResolversTypes['Organization'], ParentType, ContextType>;
-  organizationId?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
+  passed?: RequiredResolverFn<ResolversTypes['Boolean'], ParentType, ContextType>;
+  results?: RequiredResolverFn<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   updatedAt?: RequiredResolverFn<ResolversTypes['DateTime'], ParentType, ContextType>;
   upload?: RequiredResolverFn<ResolversTypes['Upload'], ParentType, ContextType>;
   uploadId?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
   validatedAt?: RequiredResolverFn<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
-  validatedBy?: RequiredResolverFn<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  validatedById?: RequiredResolverFn<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  validationResults?: RequiredResolverFn<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/web/types/graphql.d.ts
+++ b/web/types/graphql.d.ts
@@ -117,16 +117,13 @@ export type CreateUploadInput = {
 };
 
 export type CreateUploadValidationInput = {
-  agencyId: Scalars['Int'];
-  inputTemplateId: Scalars['Int'];
+  initiatedById: Scalars['Int'];
   invalidatedAt?: InputMaybe<Scalars['DateTime']>;
-  invalidatedById?: InputMaybe<Scalars['Int']>;
   invalidationResults?: InputMaybe<Scalars['JSON']>;
-  organizationId: Scalars['Int'];
+  passed: Scalars['Boolean'];
+  results?: InputMaybe<Scalars['JSON']>;
   uploadId: Scalars['Int'];
   validatedAt?: InputMaybe<Scalars['DateTime']>;
-  validatedById?: InputMaybe<Scalars['Int']>;
-  validationResults?: InputMaybe<Scalars['JSON']>;
 };
 
 export type CreateUserInput = {
@@ -661,21 +658,19 @@ export type UpdateUploadInput = {
 };
 
 export type UpdateUploadValidationInput = {
-  agencyId?: InputMaybe<Scalars['Int']>;
-  inputTemplateId?: InputMaybe<Scalars['Int']>;
+  initiatedById?: InputMaybe<Scalars['Int']>;
   invalidatedAt?: InputMaybe<Scalars['DateTime']>;
-  invalidatedById?: InputMaybe<Scalars['Int']>;
   invalidationResults?: InputMaybe<Scalars['JSON']>;
-  organizationId?: InputMaybe<Scalars['Int']>;
+  passed?: InputMaybe<Scalars['Boolean']>;
+  results?: InputMaybe<Scalars['JSON']>;
   uploadId?: InputMaybe<Scalars['Int']>;
   validatedAt?: InputMaybe<Scalars['DateTime']>;
-  validatedById?: InputMaybe<Scalars['Int']>;
-  validationResults?: InputMaybe<Scalars['JSON']>;
 };
 
 export type UpdateUserInput = {
   agencyId?: InputMaybe<Scalars['Int']>;
   email?: InputMaybe<Scalars['String']>;
+  isActive?: InputMaybe<Scalars['Boolean']>;
   name?: InputMaybe<Scalars['String']>;
   role?: InputMaybe<RoleEnum>;
 };
@@ -704,25 +699,18 @@ export type Upload = {
 
 export type UploadValidation = {
   __typename?: 'UploadValidation';
-  agency: Agency;
-  agencyId: Scalars['Int'];
   createdAt: Scalars['DateTime'];
   id: Scalars['Int'];
-  inputTemplate: InputTemplate;
-  inputTemplateId: Scalars['Int'];
+  initiatedBy: User;
+  initiatedById: Scalars['Int'];
   invalidatedAt?: Maybe<Scalars['DateTime']>;
-  invalidatedBy?: Maybe<User>;
-  invalidatedById?: Maybe<Scalars['Int']>;
   invalidationResults?: Maybe<Scalars['JSON']>;
-  organization: Organization;
-  organizationId: Scalars['Int'];
+  passed: Scalars['Boolean'];
+  results?: Maybe<Scalars['JSON']>;
   updatedAt: Scalars['DateTime'];
   upload: Upload;
   uploadId: Scalars['Int'];
   validatedAt?: Maybe<Scalars['DateTime']>;
-  validatedBy?: Maybe<User>;
-  validatedById?: Maybe<Scalars['Int']>;
-  validationResults?: Maybe<Scalars['JSON']>;
 };
 
 export type User = {


### PR DESCRIPTION
* This PR includes _most_ of the changes requested to `UploadValidation` in this [issue](https://github.com/usdigitalresponse/cpf-reporter/issues/132)
* I have left the validated / invalidated fields in place for now, until the work is done to implement the logic based on `passed`, at which point they can be removed
* Per comment [here](https://github.com/usdigitalresponse/cpf-reporter/issues/132#issuecomment-2023683026), I am proposing to add a separate application layer validation for uniqueness of `uploadId` where `results` is null -- will implement that in a further PR to come
* Will also implement changes to `Upload` in a future PR -- they are causing some grief with type generators which I want to resolve separately