### PR TITLE
Unique constraint on upload id with null results

### DIFF
--- a/api/db/migrations/20240328182356_add_upload_validation_constraint/migration.sql
+++ b/api/db/migrations/20240328182356_add_upload_validation_constraint/migration.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX "UploadValidation_unique_null_results_per_uploadid" ON "UploadValidation"("uploadId") WHERE results IS NULL;

--- a/api/src/services/uploadValidations/uploadValidations.test.ts
+++ b/api/src/services/uploadValidations/uploadValidations.test.ts
@@ -1,0 +1,31 @@
+import { upload } from '../uploads'
+
+import { createUploadValidation } from './uploadValidations'
+import { StandardScenario } from './uploadValidations.scenarios'
+
+describe('upload validations', () => {
+  scenario(
+    'throws on duplicate null results upload creation',
+    async (scenario: StandardScenario) => {
+      const uploadResult = await upload({ id: scenario.upload.one.id })
+
+      await createUploadValidation({
+        input: {
+          uploadId: uploadResult.id,
+          passed: false,
+          initiatedById: uploadResult.uploadedById,
+        },
+      })
+      expect(
+        async () =>
+          await createUploadValidation({
+            input: {
+              uploadId: uploadResult.id,
+              passed: false,
+              initiatedById: uploadResult.uploadedById,
+            },
+          })
+      ).rejects.toThrow('Unique constraint failed on the fields: (`uploadId`)')
+    }
+  )
+})


### PR DESCRIPTION
* Add custom migration SQL for a partial index on `UploadValidation.uploadId` where results are null
* Per comment [here](https://github.com/usdigitalresponse/cpf-reporter/issues/132#issuecomment-2023683026) this involved adding a param to env to ensure that Redwood runs migrations on the test DB prior to running tests -- otherwise the custom SQL won't be applied