### PR TITLE
CPF-137 remove validatedAt and invalidatedAt, use passed instead

### DIFF
--- a/web/src/components/Upload/Uploads/columns.tsx
+++ b/web/src/components/Upload/Uploads/columns.tsx
@@ -21,18 +21,20 @@ function valueAsLink(cell): JSX.Element {
 }
 
 function validationDisplay(row) {
-  const latestValidation = row.latestValidation
+  const { latestValidation } = row
 
-  if (latestValidation.invalidatedAt) {
-    const formattedDate = formatDateString(latestValidation.createdAt)
+  if (!latestValidation) {
+    return 'Not set'
+  }
+
+  const { passed, createdAt } = latestValidation
+  const formattedDate = formatDateString(createdAt)
+
+  if (!passed) {
     return <span className="text-danger">Invalidated at {formattedDate}</span>
   }
 
-  if (latestValidation.validatedAt) {
-    return formatDateString(latestValidation.createdAt)
-  }
-
-  return 'Not set'
+  return formattedDate
 }
 
 export const columnDefs = [

--- a/web/src/components/Upload/UploadsCell/UploadsCell.tsx
+++ b/web/src/components/Upload/UploadsCell/UploadsCell.tsx
@@ -24,8 +24,7 @@ export const QUERY = gql`
       }
       latestValidation {
         createdAt
-        invalidatedAt
-        validatedAt
+        passed
       }
       createdAt
       updatedAt

--- a/web/types/graphql.d.ts
+++ b/web/types/graphql.d.ts
@@ -911,7 +911,7 @@ export type FindUploadById = { __typename?: 'Query', upload?: { __typename?: 'Up
 export type FindUploadsVariables = Exact<{ [key: string]: never; }>;
 
 
-export type FindUploads = { __typename?: 'Query', uploads: Array<{ __typename?: 'Upload', id: number, filename: string, createdAt: string, updatedAt: string, uploadedBy: { __typename?: 'User', id: number, email: string }, agency: { __typename?: 'Agency', id: number, code: string }, expenditureCategory?: { __typename?: 'ExpenditureCategory', id: number, code: string } | null, latestValidation?: { __typename?: 'UploadValidation', createdAt: string, invalidatedAt?: string | null, validatedAt?: string | null } | null }> };
+export type FindUploads = { __typename?: 'Query', uploads: Array<{ __typename?: 'Upload', id: number, filename: string, createdAt: string, updatedAt: string, uploadedBy: { __typename?: 'User', id: number, email: string }, agency: { __typename?: 'Agency', id: number, code: string }, expenditureCategory?: { __typename?: 'ExpenditureCategory', id: number, code: string } | null, latestValidation?: { __typename?: 'UploadValidation', createdAt: string, passed: boolean } | null }> };
 
 export type EditUserByIdVariables = Exact<{
   id: Scalars['Int'];


### PR DESCRIPTION
This PR removes `validatedAt` and `invalidatedAt` references from the frontend and replaces them with required `passed` to determine whether the upload is valid or not.