### PR TITLE
fix: remove expenditure-code from s3 url

### DIFF
--- a/api/src/lib/aws.ts
+++ b/api/src/lib/aws.ts
@@ -64,7 +64,7 @@ export function uploadWorkbook(
   uploadId: number,
   body: StreamingBlobPayloadInputTypes
 ) {
-  const folderName = `uploads/${upload.organizationId}/${upload.agencyId}/${upload.reportingPeriodId}/${upload.expenditureCategoryId}/${uploadId}/${upload.filename}`
+  const folderName = `uploads/${upload.organizationId}/${upload.agencyId}/${upload.reportingPeriodId}/${uploadId}/${upload.filename}`
   return sendPutObjectToS3Bucket(REPORTING_DATA_BUCKET_NAME, folderName, body)
 }
 
@@ -104,12 +104,12 @@ export async function s3PutSignedUrl(
   uploadId: number
 ): Promise<string> {
   const s3 = getS3Client()
-  const key = `uploads/${upload.organizationId}/${upload.agencyId}/${upload.reportingPeriodId}/${upload.expenditureCategoryId}/${uploadId}/${upload.filename}`
+  const key = `uploads/${upload.organizationId}/${upload.agencyId}/${upload.reportingPeriodId}/${uploadId}/${upload.filename}`
   const baseParams: PutObjectCommandInput = {
     Bucket: REPORTING_DATA_BUCKET_NAME,
     Key: key,
     ContentType:
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'application/vnd.ms-excel.sheet.macroenabled.12',
     ServerSideEncryption: 'AES256',
   }
   const url = await awsGetSignedUrl(s3, new PutObjectCommand(baseParams), {


### PR DESCRIPTION
#139

As seen in the issue, this PR removes the expenditure category code from the S3 url for where the file is stored.