### PR TITLE
Fix: Invalid Datadog layer ARN for Python lambdas

### DIFF
--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -35,7 +35,7 @@ locals {
     data.aws_region.current.name,
     { aws = "464622532012", aws-us-gov = "002406178527" }[data.aws_partition.current.id],
     "layer",
-    "Datadog-Python312-x",
+    format("Datadog-Python312%s", var.lambda_arch == "arm64" ? "-ARM" : ""),
     var.datadog_lambda_py_tracer_version,
   ])
   lambda_default_environment_variables = merge(


### PR DESCRIPTION
This PR fixes a typo that is currently resulting in an incorrect Lambda layer ARN being referenced, which manifests in a permissions error:
> User: arn:aws:sts::357150818708:assumed-role/cpfreporter-cicd-20231201214238093500000001/GitHubActions is not authorized to perform: lambda:GetLayerVersion on resource: arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python312-x:91 because no resource-based policy allows the lambda:GetLayerVersion action

The role identified in the above error message is unimportant; no layer with an ARN of `arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python312-x:91` exists in Datadog's AWS account, which is the core problem. Specifically `Datadog-Python312-x` doesn't conform to Datadog's [documented](https://docs.datadoghq.com/serverless/aws_lambda/installation/python/?tab=terraform), architecture-specific ARNs for Python layers.

In this PR, we remove the invalid `-x` suffix (which is a [Node.js convention](https://docs.datadoghq.com/serverless/aws_lambda/installation/nodejs/?tab=terraform) that was mistakenly carried over in #140) and replace it with a proper suffix convention for Python: either `-ARM` for arm64-based runtimes, or nothing, which results in a layer named `Datadog-Python312` or `Datadog-Python312-ARM`, both of which [do exist](https://github.com/DataDog/serverless-plugin-datadog/blob/416c2f15a0c1b2e5dd7a0b4e6c35ec305a31f6a8/src/layers.json). 