### PR TITLE
fix: duplicate suffix in notification configuration

### DIFF
--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -236,7 +236,7 @@ resource "aws_s3_bucket_notification" "reporting_data" {
     lambda_function_arn = module.lambda_function-excelToJson.lambda_function_arn
     events              = ["s3:ObjectCreated:*"]
     filter_prefix       = "uploads/"
-    filter_suffix       = ".xlsm"
+    filter_suffix       = ".json"
   }
 
   lambda_function {


### PR DESCRIPTION
#144 

The goal of this PR is to fix the following issue during terraform-apply:
https://github.com/usdigitalresponse/cpf-reporter/actions/runs/8575359827/job/23504325633
```
Error: updating Lambda Function (cpfreporter-cpfValidation) configuration: operation error Lambda: UpdateFunctionConfiguration, https response error StatusCode: 403, RequestID: aa5fe281-137b-4afc-b82a-1772d273352d, api error AccessDeniedException: User: arn:aws:sts::357150818708:assumed-role/cpfreporter-cicd-20231201214238093500000001/GitHubActions is not authorized to perform: lambda:GetLayerVersion on resource: arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python312-x:91 because no resource-based policy allows the lambda:GetLayerVersion action

  with module.lambda_function-cpfValidation.aws_lambda_function.this[0],
  on .terraform/modules/lambda_function-cpfValidation/main.tf line 24, in resource "aws_lambda_function" "this":
  24: resource "aws_lambda_function" "this" {

```


## Why is this an issue?
As seen by the configuration below both lambda functions are being triggered by the same event notification. However, this is not valid since Amazon only allows one. I realized both these functions should _not_ be responding to the same event. Rather `excelToJson` should only respond to `.json` file PUTs rather than `.xlsm.`
```
  lambda_function {
    lambda_function_arn = module.lambda_function-excelToJson.lambda_function_arn
    events              = ["s3:ObjectCreated:*"]
    filter_prefix       = "uploads/"
    filter_suffix       = ".json"
  }

  lambda_function {
    lambda_function_arn = module.lambda_function-cpfValidation.lambda_function_arn
    events              = ["s3:ObjectCreated:*"]
    filter_prefix       = "uploads/"
    filter_suffix       = ".xlsm"
  }
```