### PR TITLE
fix: ensure cpfValidation lambda points to the python s3 object

### DIFF
--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -226,6 +226,9 @@ resource "aws_s3_object" "lambda_artifact-python" {
   bucket = module.lambda_artifacts_bucket.bucket_id
   key    = "python.${filemd5("${local.lambda_py_artifacts_base_path}/lambda.zip")}.zip"
   source = "${local.lambda_py_artifacts_base_path}/lambda.zip"
+  source_hash            = filemd5("${local.lambda_py_artifacts_base_path}/lambda.zip")
+  etag                   = filemd5("${local.lambda_py_artifacts_base_path}/lambda.zip")
+  server_side_encryption = "AES256"
 }
 
 resource "aws_s3_bucket_notification" "reporting_data" {
@@ -457,8 +460,8 @@ module "lambda_function-cpfValidation" {
   publish        = true
   create_package = false
   s3_existing_package = {
-    bucket = aws_s3_object.lambda_artifact-cpfValidation.bucket
-    key    = aws_s3_object.lambda_artifact-cpfValidation.key
+    bucket = aws_s3_object.lambda_artifact-python.bucket
+    key    = aws_s3_object.lambda_artifact-python.key
   }
 
   // Runtime

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -223,9 +223,9 @@ resource "aws_s3_object" "lambda_artifact-cpfValidation" {
 
 // Python Lambdas use a common (rather than function-specific) zip artifact
 resource "aws_s3_object" "lambda_artifact-python" {
-  bucket = module.lambda_artifacts_bucket.bucket_id
-  key    = "python.${filemd5("${local.lambda_py_artifacts_base_path}/lambda.zip")}.zip"
-  source = "${local.lambda_py_artifacts_base_path}/lambda.zip"
+  bucket                 = module.lambda_artifacts_bucket.bucket_id
+  key                    = "python.${filemd5("${local.lambda_py_artifacts_base_path}/lambda.zip")}.zip"
+  source                 = "${local.lambda_py_artifacts_base_path}/lambda.zip"
   source_hash            = filemd5("${local.lambda_py_artifacts_base_path}/lambda.zip")
   etag                   = filemd5("${local.lambda_py_artifacts_base_path}/lambda.zip")
   server_side_encryption = "AES256"


### PR DESCRIPTION
#144 

This PR is attempting to resolve the following error when creating a `lambda_artifact-python` object in the existing lambda-artifacts S3 bucket. This is important in order to be able to deploy the new Python cpfValidation code.

```
aws_ecs_task_definition.console: Creating...
aws_s3_object.lambda_artifact-python: Creating...
aws_s3_object.lambda_artifact-cpfValidation: Modifying... [id=cpfValidation.07bca370db6319ce03a40b0b1c0599bc.zip]
aws_s3_object.lambda_artifact-excelToJson: Modifying... [id=excelToJson.7b4544585eee7c04a389cb50376[75](https://github.com/usdigitalresponse/cpf-reporter/actions/runs/8604013573/job/23580957301#step:16:76)9fb.zip]
aws_s3_object.lambda_artifact-graphql: Modifying... [id=graphql.1d3fd0f3db4f66fe2ce5bc04f4f8d75c.zip]
aws_ecs_task_definition.console: Creation complete after 0s [id=cpfreporter-console]

Error: uploading S3 Object (python.5f9392c98a0399010e716812e2da8d2a.zip) to Bucket (cpfreporter-lambdaartifacts-357150818708-us-west-2): operation error S3: CreateMultipartUpload, https response error StatusCode: 403, RequestID: 2NFHT5ZMK55N6XEG, HostID: X+MnLeBs0KI6VFw+Hjqlwxkq/hhigvdMprUyS1Ow6O0tDYk6eg6mAgQmG5UtrBnLXcO+BuZMWzk=, api error AccessDenied: Access Denied

  with aws_s3_object.lambda_artifact-python,
  on functions.tf line 225, in resource "aws_s3_object" "lambda_artifact-python":
 225: resource "aws_s3_object" "lambda_artifact-python" {
```

## Why will the solution work?
My hypothesis is that the reason we're getting the 403 error is because `server_side_encryption` value was empty in the original object configuration.

## Why the other changes?
- Since we should be pointing the lambda function to use the code from the new python zip folder, I updated the lambda configuration for `s3_existing_package` to point to `/lambda.zip`.