### PR TITLE
CPF-159 handle undefined EC Code in Upload Detail view

### DIFF
--- a/web/src/components/ReportingPeriodsCell/ReportingPeriodsCell.tsx
+++ b/web/src/components/ReportingPeriodsCell/ReportingPeriodsCell.tsx
@@ -74,7 +74,7 @@ export const Success = ({
                 )}
               </td>
               <td>
-                <nav className="rw-table-actions">
+                <nav>
                   <Link
                     to={routes.editReportingPeriod({ id: item.id })}
                     title={'Edit reporting period ' + item.id}

--- a/web/src/components/Upload/Upload/Upload.stories.tsx
+++ b/web/src/components/Upload/Upload/Upload.stories.tsx
@@ -66,7 +66,7 @@ export const InvalidUpload: Story = {
             row: '1',
             tab: 'Logic',
             message:
-              '!!!Upload template version is older than the latest input template',
+              'Upload template version is older than the latest input template',
             severity: 'warn',
           },
           {

--- a/web/src/components/Upload/Upload/Upload.tsx
+++ b/web/src/components/Upload/Upload/Upload.tsx
@@ -41,11 +41,11 @@ const Upload = ({ upload }) => {
             </li>
             <li
               className={`list-group-item ${
-                !upload.expenditureCategory.code && 'list-group-item-warning'
+                !upload.expenditureCategory?.code && 'list-group-item-warning'
               }`}
             >
               <span className="fw-bold">EC Code: </span>
-              {upload.expenditureCategory.code || 'Not set'}
+              {upload.expenditureCategory?.code || 'Not set'}
             </li>
             <li className="list-group-item">
               <span className="fw-bold">Created: </span>

--- a/web/src/components/Upload/Uploads/columns.tsx
+++ b/web/src/components/Upload/Uploads/columns.tsx
@@ -47,7 +47,7 @@ export const columnDefs = [
     header: 'Agency',
   }),
   columnHelper.accessor('expenditureCategory.code', {
-    cell: (info) => info.getValue(),
+    cell: (info) => info.getValue() ?? 'Not set',
     header: 'EC Code',
   }),
   columnHelper.accessor('uploadedBy.email', {


### PR DESCRIPTION
## About

This PR:
- fixes `TypeError: Cannot read properties of null (reading 'code')` when accessing expenditureCategory.code if `expenditureCategory` is null
- adds "Not set" display when EC Category is not set in the Uploads table