### PR TITLE
Ensure an UploadValidation is created during creation of an Upload

### DIFF
--- a/api/src/services/uploads/uploads.test.ts
+++ b/api/src/services/uploads/uploads.test.ts
@@ -1,5 +1,7 @@
 import type { Upload } from '@prisma/client'
 
+import { db } from 'src/lib/db'
+
 import {
   uploads,
   upload,
@@ -8,7 +10,6 @@ import {
   deleteUpload,
   Upload as UploadRelationResolver,
 } from './uploads'
-import { db } from 'src/lib/db'
 import type { StandardScenario } from './uploads.scenarios'
 
 // Generated boilerplate tests do not account for all circumstances
@@ -47,7 +48,9 @@ describe('uploads', () => {
       scenario.upload.two.reportingPeriodId
     )
 
-    const validations = await db.upload.findUnique({ where: { id: result.id } }).validations()
+    const validations = await db.upload
+      .findUnique({ where: { id: result.id } })
+      .validations()
     expect(validations.length).toBe(1)
     expect(validations[0].passed).toBeFalsy()
     expect(validations[0].results).toBeNull()

--- a/api/src/services/uploads/uploads.test.ts
+++ b/api/src/services/uploads/uploads.test.ts
@@ -8,6 +8,7 @@ import {
   deleteUpload,
   Upload as UploadRelationResolver,
 } from './uploads'
+import { db } from 'src/lib/db'
 import type { StandardScenario } from './uploads.scenarios'
 
 // Generated boilerplate tests do not account for all circumstances
@@ -29,7 +30,7 @@ describe('uploads', () => {
     expect(result).toEqual(scenario.upload.one)
   })
 
-  scenario('creates a upload', async (scenario: StandardScenario) => {
+  scenario('creates an upload', async (scenario: StandardScenario) => {
     const result = await createUpload({
       input: {
         filename: 'String',
@@ -45,9 +46,14 @@ describe('uploads', () => {
     expect(result.reportingPeriodId).toEqual(
       scenario.upload.two.reportingPeriodId
     )
+
+    const validations = await db.upload.findUnique({ where: { id: result.id } }).validations()
+    expect(validations.length).toBe(1)
+    expect(validations[0].passed).toBeFalsy()
+    expect(validations[0].results).toBeNull()
   })
 
-  scenario('updates a upload', async (scenario: StandardScenario) => {
+  scenario('updates an upload', async (scenario: StandardScenario) => {
     const original = (await upload({ id: scenario.upload.one.id })) as Upload
     const result = await updateUpload({
       id: original.id,
@@ -57,7 +63,7 @@ describe('uploads', () => {
     expect(result.filename).toEqual('String2')
   })
 
-  scenario('deletes a upload', async (scenario: StandardScenario) => {
+  scenario('deletes an upload', async (scenario: StandardScenario) => {
     const original = (await deleteUpload({
       id: scenario.upload.one.id,
     })) as Upload

--- a/api/src/services/uploads/uploads.ts
+++ b/api/src/services/uploads/uploads.ts
@@ -23,7 +23,9 @@ export const createUpload: MutationResolvers['createUpload'] = async ({
   const upload = await db.upload.create({
     data: input,
   })
-  const uploadValidation = await db.uploadValidation.create({
+  // We don't need to store the result of the validation creation, it will be provided via
+  // the relation resolver below
+  await db.uploadValidation.create({
     data: {
       uploadId: upload.id,
       initiatedById: upload.uploadedById,

--- a/api/src/services/uploads/uploads.ts
+++ b/api/src/services/uploads/uploads.ts
@@ -23,6 +23,14 @@ export const createUpload: MutationResolvers['createUpload'] = async ({
   const upload = await db.upload.create({
     data: input,
   })
+  const uploadValidation = await db.uploadValidation.create({
+    data: {
+      uploadId: upload.id,
+      initiatedById: upload.uploadedById,
+      passed: false,
+      results: null,
+    },
+  })
   const signedUrl = await s3PutSignedUrl(upload, upload.id)
 
   return { ...upload, signedUrl }

--- a/web/src/components/Upload/NewUpload/NewUpload.tsx
+++ b/web/src/components/Upload/NewUpload/NewUpload.tsx
@@ -10,6 +10,12 @@ const CREATE_UPLOAD_MUTATION = gql`
     createUpload(input: $input) {
       id
       signedUrl
+      validations {
+        id
+        passed
+        initiatedById
+        results
+      }
     }
   }
 `

--- a/web/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/web/src/components/Upload/UploadForm/UploadForm.tsx
@@ -21,6 +21,12 @@ const CREATE_UPLOAD = gql`
     createUpload(input: $input) {
       id
       signedUrl
+      validations {
+        id
+        passed
+        initiatedById
+        results
+      }
     }
   }
 `


### PR DESCRIPTION
- When creating an `Upload`, create a "blank" associated `UploadValidation` with `results=null` and `passed=false`
- Add in the validations to the frontend mutation payload request (happy to remove these if reviewers would prefer; not sure if necessary but I tested with them and figured fine to leave in?)
- Add a unit test to ensure the validation is created

**UploadValidation present in DB after upload creation**
<img width="1280" alt="Screenshot 2024-04-09 at 3 48 05 PM" src="https://github.com/usdigitalresponse/cpf-reporter/assets/19584337/eb913dbb-0879-49a3-b692-a1fd749e678a">

**UploadValidation present on result payload**
<img width="346" alt="Screenshot 2024-04-09 at 3 49 24 PM" src="https://github.com/usdigitalresponse/cpf-reporter/assets/19584337/95e6c762-2502-4ebd-b002-b9c51f90c264">
