### PR TITLE
Fix: 182 Avoid reading workbooks into memory before validation

### DIFF
--- a/python/src/functions/validate_workbook.py
+++ b/python/src/functions/validate_workbook.py
@@ -58,7 +58,6 @@ def download_workbook(client: S3Client, bucket: str, key: str, destination: temp
     logger.debug("downloading workbook from s3")
 
     try:
-        client: S3Client = boto3.client("s3")
         client.download_fileobj(bucket, key, destination)
     except:
         logger.exception("failed to download workbook from S3")

--- a/python/src/functions/validate_workbook.py
+++ b/python/src/functions/validate_workbook.py
@@ -1,4 +1,3 @@
-import io
 import json
 import tempfile
 
@@ -46,7 +45,7 @@ def handle(event: S3Event, context: Context):
     )
 
 
-def download_workbook(client: S3Client, bucket: str, key: str, destination: io.FileIO):
+def download_workbook(client: S3Client, bucket: str, key: str, destination: tempfile._TemporaryFileWrapper):
     """Downloads an S3 object to a local file.
 
     Args:
@@ -66,7 +65,7 @@ def download_workbook(client: S3Client, bucket: str, key: str, destination: io.F
         raise
 
 
-def validate_workbook(file) -> list[str]:
+def validate_workbook(file: tempfile._TemporaryFileWrapper) -> list[str]:
     """Wrapper for workbook validation with logging.
 
     Args:

--- a/python/src/functions/validate_workbook.py
+++ b/python/src/functions/validate_workbook.py
@@ -8,7 +8,7 @@ from aws_lambda_typing.events import S3Event
 from mypy_boto3_s3.client import S3Client
 
 from src.lib.logging import get_logger, reset_contextvars
-from src.lib.workbook_validator import validate
+from src.lib.workbook_validator import validate, BinaryTempFile
 
 
 @reset_contextvars
@@ -45,7 +45,7 @@ def handle(event: S3Event, context: Context):
     )
 
 
-def download_workbook(client: S3Client, bucket: str, key: str, destination: tempfile._TemporaryFileWrapper):
+def download_workbook(client: S3Client, bucket: str, key: str, destination: BinaryTempFile):
     """Downloads an S3 object to a local file.
 
     Args:
@@ -64,7 +64,7 @@ def download_workbook(client: S3Client, bucket: str, key: str, destination: temp
         raise
 
 
-def validate_workbook(file: tempfile._TemporaryFileWrapper) -> list[str]:
+def validate_workbook(file: BinaryTempFile) -> list[str]:
     """Wrapper for workbook validation with logging.
 
     Args:

--- a/python/src/functions/validate_workbook.py
+++ b/python/src/functions/validate_workbook.py
@@ -1,5 +1,6 @@
 import json
 import tempfile
+from typing import IO
 
 import boto3
 import structlog
@@ -8,7 +9,7 @@ from aws_lambda_typing.events import S3Event
 from mypy_boto3_s3.client import S3Client
 
 from src.lib.logging import get_logger, reset_contextvars
-from src.lib.workbook_validator import validate, BinaryTempFile
+from src.lib.workbook_validator import validate
 
 
 @reset_contextvars
@@ -45,14 +46,14 @@ def handle(event: S3Event, context: Context):
     )
 
 
-def download_workbook(client: S3Client, bucket: str, key: str, destination: BinaryTempFile):
+def download_workbook(client: S3Client, bucket: str, key: str, destination: IO[bytes]):
     """Downloads an S3 object to a local file.
 
     Args:
         client: Client facilitating download from S3
         bucket: Name of the S3 bucket containing the workbook
         key: S3 object key for the file to download
-        destination: File-like object where the S3 object will be written
+        destination: File-like object (in binary mode) where the S3 object will be written
     """
     logger = get_logger()
     logger.debug("downloading workbook from s3")
@@ -64,7 +65,7 @@ def download_workbook(client: S3Client, bucket: str, key: str, destination: Bina
         raise
 
 
-def validate_workbook(file: BinaryTempFile) -> list[str]:
+def validate_workbook(file: IO[bytes]) -> list[str]:
     """Wrapper for workbook validation with logging.
 
     Args:

--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -1,4 +1,4 @@
-from typing import Any, BinaryIO, List, Optional, Tuple
+from typing import Any, BinaryIO, Iterable, List, Optional, Tuple
 
 from openpyxl import load_workbook
 from openpyxl.worksheet.worksheet import Worksheet
@@ -13,7 +13,7 @@ from src.schemas.latest.schema import (
 type Errors = List[str]
 
 
-def map_values_to_headers(headers: Tuple, values: List[any]):
+def map_values_to_headers(headers: Tuple, values: Iterable[Any]):
     return dict(zip(headers, values))
 
 

--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -1,4 +1,5 @@
 from typing import Any, BinaryIO, Iterable, List, Optional, Tuple
+from tempfile import _TemporaryFileWrapper
 
 from openpyxl import load_workbook
 from openpyxl.worksheet.worksheet import Worksheet
@@ -11,6 +12,7 @@ from src.schemas.latest.schema import (
 )
 
 type Errors = List[str]
+type BinaryTempFile = _TemporaryFileWrapper[bytes]
 
 
 def map_values_to_headers(headers: Tuple, values: Iterable[Any]):
@@ -25,7 +27,7 @@ def get_headers(sheet: Worksheet, cell_range: str) -> tuple:
     return tuple(header_cell.value for header_cell in sheet[cell_range][0])
 
 
-def validate(workbook: BinaryIO) -> Errors:
+def validate(workbook: BinaryTempFile | BinaryIO) -> Errors:
     """Validates a given Excel workbook according to CPF validation rules.
 
     Args:

--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -1,6 +1,4 @@
-from io import BytesIO
-from tempfile import TemporaryFile
-from typing import Any, List, Optional, Tuple
+from typing import Any, BinaryIO, List, Optional, Tuple
 
 from openpyxl import load_workbook
 from openpyxl.worksheet.worksheet import Worksheet
@@ -27,14 +25,19 @@ def get_headers(sheet: Worksheet, cell_range: str) -> tuple:
     return tuple(header_cell.value for header_cell in sheet[cell_range][0])
 
 
-def validate(workbook: TemporaryFile):
+def validate(workbook: BinaryIO) -> Errors:
+    """Validates a given Excel workbook according to CPF validation rules.
+
+    Args:
+        workbook: The Excel workbook file to read and validate.
     """
+
+    """TemporaryFile
     1. Load workbook in read-only mode
     See: https://openpyxl.readthedocs.io/en/stable/optimized.html
     If there is any trouble loading files from memory please see here: https://stackoverflow.com/questions/20635778/using-openpyxl-to-read-file-from-memory
     """
-    file_bytes = workbook.read()
-    wb = load_workbook(filename=BytesIO(file_bytes), read_only=True)
+    wb = load_workbook(filename=workbook, read_only=True)
 
     """
     2. Validate logic sheet to make sure the sheet has an appropriate version

--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -1,5 +1,4 @@
-from typing import Any, BinaryIO, Iterable, List, Optional, Tuple
-from tempfile import _TemporaryFileWrapper
+from typing import Any, IO, Iterable, List, Optional, Tuple
 
 from openpyxl import load_workbook
 from openpyxl.worksheet.worksheet import Worksheet
@@ -12,7 +11,6 @@ from src.schemas.latest.schema import (
 )
 
 type Errors = List[str]
-type BinaryTempFile = _TemporaryFileWrapper[bytes]
 
 
 def map_values_to_headers(headers: Tuple, values: Iterable[Any]):
@@ -27,7 +25,7 @@ def get_headers(sheet: Worksheet, cell_range: str) -> tuple:
     return tuple(header_cell.value for header_cell in sheet[cell_range][0])
 
 
-def validate(workbook: BinaryTempFile | BinaryIO) -> Errors:
+def validate(workbook: IO[bytes]) -> Errors:
     """Validates a given Excel workbook according to CPF validation rules.
 
     Args:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,4 +1,4 @@
-from tempfile import TemporaryFile
+from typing import BinaryIO
 
 import openpyxl
 import pytest
@@ -7,7 +7,7 @@ _SAMPLE_VALID_XLSM = "tests/data/sample_valid.xlsm"
 
 
 @pytest.fixture
-def valid_file() -> TemporaryFile:
+def valid_file() -> BinaryIO:
     file_path = _SAMPLE_VALID_XLSM
     return open(file_path, "rb")
 

--- a/python/tests/src/lib/test_workbook_validator.py
+++ b/python/tests/src/lib/test_workbook_validator.py
@@ -1,5 +1,4 @@
-from tempfile import TemporaryFile
-
+from typing import BinaryIO
 
 import pytest
 from openpyxl.worksheet.worksheet import Worksheet
@@ -37,7 +36,7 @@ class TestIsEmptyRow:
 
 
 class TestValidateWorkbook:
-    def test_valid_full_workbook(self, valid_file: TemporaryFile):
+    def test_valid_full_workbook(self, valid_file: BinaryIO):
         errors = validate(valid_file)
         assert errors == []
 


### PR DESCRIPTION
This PR is a fix for #182 and a follow-up to #183. It avoids reading the entire Excel workbook (temporary) file into memory by removing a step where an `io.BytesIO` object is populated and provided to `openpyxl.load_workbook()`. Instead, we just provide the file directly to `openpyxl.load_workbook()`, which lets us benefit from using `openpyxl`'s [optimized read-only mode](https://openpyxl.readthedocs.io/en/stable/optimized.html?highlight=read-only#read-only-mode).

Additionally, this PR updates Python type annotations that referenced the `tempfile.TemporaryFile` function as a type (it is not, although it seems like it should be) to instead use [`typing.IO[bytes]`](https://docs.python.org/3/library/typing.html#abcs-for-working-with-io), which represents that the workbook file passed to `src.lib.workbook_validator.validate()` can be any file-like object opened in binary mode.