### PR TITLE
fix: add database credentials to processValidationJson function

### DIFF
--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -355,9 +355,12 @@ module "lambda_function-processValidationJson" {
   description   = "Reacts to S3 events and processes uploaded JSON files."
 
   // Networking
-  attach_network_policy  = false
-  vpc_subnet_ids         = null
-  vpc_security_group_ids = null
+  attach_network_policy = true
+  vpc_subnet_ids        = local.private_subnet_ids
+  vpc_security_group_ids = [
+    module.lambda_security_group.id,
+    module.postgres.security_group_id,
+  ]
 
   // Permissions
   role_permissions_boundary         = local.permissions_boundary_arn
@@ -398,7 +401,20 @@ module "lambda_function-processValidationJson" {
   timeout       = 300 # 5 minutes, in seconds
   memory_size   = 512 # MB
   environment_variables = merge(local.lambda_default_environment_variables, {
-    DD_LAMBDA_HANDLER = "processValidationJson.handler"
+    DATABASE_URL = format(
+      "postgres://%s@%s:%s/%s?%s",
+      module.postgres.cluster_master_username,
+      module.postgres.cluster_endpoint,
+      module.postgres.cluster_port,
+      module.postgres.cluster_database_name,
+      join("&", [
+        "sslmode=verify",
+        "connection_limit=1", // Can be tuned for parallel query performance: https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/databases-connections#serverless-environments-faas
+      ])
+    )
+    DATABASE_SECRET_SOURCE             = "ssm"
+    DATABASE_SECRET_SSM_PARAMETER_PATH = aws_ssm_parameter.postgres_master_password.name
+    DD_LAMBDA_HANDLER                  = "processValidationJson.handler"
   })
 
   // Triggers


### PR DESCRIPTION
#190 

This PR fixes the following error noticed in [Datadog](https://app.datadoghq.com/logs?query=service%3Acpf-reporter%20&cols=host%2Cservice&context_event=AY7UIYgYAAA3JW_0RVM8cwAB&event=AgAAAY7omaPyeOtsswAAAAAAAAAYAAAAAEFZN29tYVZIQUFBRHFuMWxtRXRhR1FBRQAAACQAAAAAMDE4ZWU4OWItMTE4NC00ZTliLWJjMWUtYTAxNWE0Njc3ZGNh&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=&from_ts=1713298485921&to_ts=1713299385921&live=true).
```
Handler error: PrismaClientInitializationError: 
Invalid `import_db.db.uploadValidation.findFirst()` invocation in
/var/task/api/dist/functions/processValidationJson/processValidationJson.js:82:66

  79   uploadId,
  80   passed
  81 };
→ 82 const validationRecord = await import_db.db.uploadValidation.findFirst(
error: Environment variable not found: DATABASE_URL.
  -->  schema.prisma:9
   | 
 8 |   provider = "postgresql"
 9 |   url      = env("DATABASE_URL")
   | 

Validation Error Count: 1
```