### PR TITLE
Set upload EC code

### DIFF
--- a/api/src/functions/processValidationJson/processValidationJson.ts
+++ b/api/src/functions/processValidationJson/processValidationJson.ts
@@ -20,6 +20,11 @@ type Response = {
   statusCode: number
 }
 
+type ResultSchema = {
+  errors: string[]
+  projectUseCode: string
+}
+
 type UploadValidationS3Client = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   send: (command: GetObjectCommand | DeleteObjectCommand) => Promise<any>
@@ -96,17 +101,44 @@ export const processRecord = async (
          /uploads/organization_id/agency_id/reporting_period_id/upload_id/{filename}
       */
     const strBody = await getObjectResponse.Body.transformToString()
-    const result = JSON.parse(strBody) || []
+    const result: ResultSchema = JSON.parse(strBody) || []
 
     // when the results array is empty then we know the file has passed validations
-    const passed = result.length === 0
+    const passed = result.errors.length === 0
 
     const uploadId = extractUploadIdFromKey(key)
-    const input = {
-      results: result,
-      uploadId: uploadId,
-      passed: passed,
+
+    // Verify valid expenditureCategory
+    /*
+    The category must be one of the following values:
+      {
+        name: '1A - Broadband Infrastructure',
+        code: '1A',
+      },
+      {
+        name: '1B - Digital Connectivity Technology',
+        code: '1B',
+      },
+      {
+        name: '1C - Multi-Purpose Community Facility',
+        code: '1C',
+      },
+    */
+    const expenditureCategory = await db.expenditureCategory.findFirst({
+      where: { code: result.projectUseCode },
+    })
+    if (!expenditureCategory) {
+      logger.error(
+        `Expenditure category not found: ${result.projectUseCode} - key: ${key}`
+      )
+      throw new Error('Expenditure category not found')
     }
+
+    // Update the Upload record with the expenditure category Id
+    await db.upload.update({
+      data: { expenditureCategoryId: expenditureCategory.id },
+      where: { id: uploadId },
+    })
 
     // There should be an existing validation Record in the DB that will need to be updated
     const validationRecord = await db.uploadValidation.findFirst({
@@ -118,9 +150,15 @@ export const processRecord = async (
       throw new Error('Validation record not found')
     }
 
+    const uploadValidationInput = {
+      results: result,
+      uploadId: uploadId,
+      passed: passed,
+    }
+
     try {
       await db.uploadValidation.update({
-        data: input,
+        data: uploadValidationInput,
         where: { id: validationRecord.id },
       })
     } catch (err) {

--- a/python/src/functions/validate_workbook.py
+++ b/python/src/functions/validate_workbook.py
@@ -1,6 +1,6 @@
 import json
 import tempfile
-from typing import IO
+from typing import IO, List, Union, Dict
 
 import boto3
 import structlog
@@ -11,6 +11,7 @@ from mypy_boto3_s3.client import S3Client
 from src.lib.logging import get_logger, reset_contextvars
 from src.lib.workbook_validator import validate
 
+type ValidationResults = Dict[str, Union[List[str], str, None]]
 
 @reset_contextvars
 def handle(event: S3Event, context: Context):
@@ -35,7 +36,7 @@ def handle(event: S3Event, context: Context):
                 event["Records"][0]["s3"]["object"]["key"],
                 file,
             )
-            results = validate_workbook(file)
+            results: ValidationResults = validate_workbook(file)
 
     # Save results to s3
     save_validation_results(
@@ -65,7 +66,7 @@ def download_workbook(client: S3Client, bucket: str, key: str, destination: IO[b
         raise
 
 
-def validate_workbook(file: IO[bytes]) -> list[str]:
+def validate_workbook(file: IO[bytes]) -> ValidationResults:
     """Wrapper for workbook validation with logging.
 
     Args:
@@ -78,18 +79,22 @@ def validate_workbook(file: IO[bytes]) -> list[str]:
     logger.debug("validating workbook")
 
     try:
-        results = validate(file)
+        errors, project_use_code = validate(file)
     except:
         logger.exception("unhandled exception validating workbook")
         raise
 
     logger.debug(
-        "successfully validated workbook", count_validation_errors=len(results)
+        "successfully validated workbook", count_validation_errors=len(errors)
     )
+    results: ValidationResults = {
+        "errors": errors,
+        "projectUseCode": project_use_code,
+    }
     return results
 
 
-def save_validation_results(client: S3Client, bucket, key: str, results: list[str]):
+def save_validation_results(client: S3Client, bucket, key: str, results: ValidationResults):
     """Persists workbook validation results to S3.
 
     Args:

--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -59,7 +59,7 @@ def validate(workbook: IO[bytes]) -> Tuple[Errors, Optional[str]]:
     if len(errors) > 0:
         return errors, None
 
-     project_use_code = get_project_use_code(wb["Cover"])
+    project_use_code = get_project_use_code(wb["Cover"])
 
     """
     4. Ensure all project rows are validated with the schema

--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -24,8 +24,14 @@ def is_empty_row(row_values: Tuple):
 def get_headers(sheet: Worksheet, cell_range: str) -> tuple:
     return tuple(header_cell.value for header_cell in sheet[cell_range][0])
 
+def get_project_use_code(cover_sheet: Worksheet) -> str:
+    cover_header = get_headers(cover_sheet, "A1:B1")
+    cover_row = map(lambda cell: cell.value, cover_sheet[2])
+    row_dict = map_values_to_headers(cover_header, cover_row)
+    return row_dict["Project Use Code"]
 
-def validate(workbook: IO[bytes]) -> Errors:
+
+def validate(workbook: IO[bytes]) -> Tuple[Errors, Optional[str]]:
     """Validates a given Excel workbook according to CPF validation rules.
 
     Args:
@@ -44,14 +50,16 @@ def validate(workbook: IO[bytes]) -> Errors:
     """
     errors = validate_logic_sheet(wb["Logic"])
     if len(errors) > 0:
-        return errors
+        return errors, None
 
     """
     3. Validate cover sheet and project selection. Pick the appropriate validator for the next step.
     """
     errors, project_schema = validate_cover_sheet(wb["Cover"])
     if len(errors) > 0:
-        return errors
+        return errors, None
+
+     project_use_code = get_project_use_code(wb["Cover"])
 
     """
     4. Ensure all project rows are validated with the schema
@@ -66,7 +74,7 @@ def validate(workbook: IO[bytes]) -> Errors:
     # Close the workbook after reading
     wb.close()
 
-    return project_errors + subrecipient_errors
+    return (project_errors + subrecipient_errors, project_use_code)
 
 
 # Accepts a workbook from openpyxl

--- a/python/tests/src/lib/test_workbook_validator.py
+++ b/python/tests/src/lib/test_workbook_validator.py
@@ -9,8 +9,10 @@ from src.lib.workbook_validator import (
     validate_cover_sheet,
     validate_project_sheet,
     validate_subrecipient_sheet,
+    get_project_use_code
 )
 
+SAMPLE_PROJECT_USE_CODE = "1A"
 
 class TestIsEmptyRow:
     @pytest.mark.parametrize(
@@ -37,15 +39,18 @@ class TestIsEmptyRow:
 
 class TestValidateWorkbook:
     def test_valid_full_workbook(self, valid_file: BinaryIO):
-        errors = validate(valid_file)
+        result = validate(valid_file)
+        errors = result[0]
+        project_use_code = result[1]
         assert errors == []
+        assert project_use_code == SAMPLE_PROJECT_USE_CODE
 
 
 class TestValidateCoverSheet:
     def test_valid_cover_sheet(self, valid_coversheet: Worksheet):
         errors, schema = validate_cover_sheet(valid_coversheet)
         assert errors == []
-        assert schema == SCHEMA_BY_PROJECT["1A"]
+        assert schema == SCHEMA_BY_PROJECT[SAMPLE_PROJECT_USE_CODE]
 
     def test_invalid_cover_sheet(self, invalid_cover_sheet: Worksheet):
         errors, schema = validate_cover_sheet(invalid_cover_sheet)
@@ -55,11 +60,11 @@ class TestValidateCoverSheet:
 
 class TestValidateproject_sheet:
     def test_valid_project_sheet(self, valid_project_sheet: Worksheet):
-        errors = validate_project_sheet(valid_project_sheet, SCHEMA_BY_PROJECT["1A"])
+        errors = validate_project_sheet(valid_project_sheet, SCHEMA_BY_PROJECT[SAMPLE_PROJECT_USE_CODE])
         assert errors == []
 
     def test_invalid_project_sheet(self, invalid_project_sheet: Worksheet):
-        errors = validate_project_sheet(invalid_project_sheet, SCHEMA_BY_PROJECT["1A"])
+        errors = validate_project_sheet(invalid_project_sheet, SCHEMA_BY_PROJECT[SAMPLE_PROJECT_USE_CODE])
         assert errors != []
 
 
@@ -71,3 +76,8 @@ class TestValidateSubrecipientSheet:
     def test_invalid_subrecipient_sheet(self, invalid_subrecipient_sheet: Worksheet):
         errors = validate_subrecipient_sheet(invalid_subrecipient_sheet)
         assert errors != []
+
+class TestGetProjectUseCode:
+    def test_get_project_use_code(self, valid_coversheet: Worksheet):
+        project_use_code = get_project_use_code(valid_coversheet)
+        assert project_use_code == SAMPLE_PROJECT_USE_CODE


### PR DESCRIPTION
- Set project use code on upload at time of validation
- Includes changes to the python workbook validators to derive the project use code from the cover sheet, as well as JS changes to set the use code on the upload
- Unit tests for JS & python