### PR TITLE
Change cache path for deploy config

### DIFF
--- a/terraform/web.tf
+++ b/terraform/web.tf
@@ -267,7 +267,7 @@ module "cdn" {
 
   ordered_cache_behavior = [
     {
-      path_pattern           = "/${aws_s3_object.website_deploy_config.key}"
+      path_pattern           = "/deploy-config.js"
       target_origin_id       = local.website_config_origin_path
       viewer_protocol_policy = "redirect-to-https"
 


### PR DESCRIPTION
- Per conversation in Slack, the path pattern for deploy-config in Cloudfront is `/config/deploy-config`, which doesn't match the key for the file in S3 (since the full URL mapped to the origin is then `/config/config/deploy-config.js` and thus results in 404s to the resource
- This hard codes the path to `deploy-config.js`, which results in a full URL of `/config/deploy-config.js`. This is consistent with similar behavior in the GOST repo and should enable us to access the config 