### PR TITLE
Navigate to individual upload page after submission

### DIFF
--- a/web/src/components/Upload/NewUpload/NewUpload.tsx
+++ b/web/src/components/Upload/NewUpload/NewUpload.tsx
@@ -25,9 +25,9 @@ const NewUpload = () => {
     CreateUploadMutation,
     CreateUploadMutationVariables
   >(CREATE_UPLOAD_MUTATION, {
-    onCompleted: () => {
+    onCompleted: ({ createUpload }) => {
       toast.success('Upload created')
-      navigate(routes.uploads())
+      navigate(routes.upload({ id: createUpload?.id }))
     },
     onError: (error) => {
       toast.error(error.message)

--- a/web/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/web/src/components/Upload/UploadForm/UploadForm.tsx
@@ -47,9 +47,9 @@ const UploadForm = (props: UploadFormProps) => {
     CreateUploadMutation,
     CreateUploadMutationVariables
   >(CREATE_UPLOAD, {
-    onCompleted: () => {
+    onCompleted: ({ createUpload }) => {
       toast.success('Upload created')
-      navigate(routes.uploads())
+      navigate(routes.upload({ id: createUpload?.id }))
     },
     onError: (error) => {
       toast.error(error.message)


### PR DESCRIPTION
- After creating an upload, navigate to the page for that upload rather than back to the "all uploads" page