### PR TITLE
Only attempt to save expenditure category if there is a project use code

### DIFF
--- a/api/src/functions/processValidationJson/processValidationJson.test.ts
+++ b/api/src/functions/processValidationJson/processValidationJson.test.ts
@@ -116,13 +116,16 @@ describe('cpfValidation function', () => {
     expect(existingRecord.passed).toEqual(false)
   })
 
-  scenario('no expenditure category found for result project use code', async (scenario) => {
-    const expectedResult = { errors: [], projectUseCode: '13A' }
-    const mocks3 = new MockS3Client(JSON.stringify(expectedResult))
-    const record = buildRecord(scenario.uploadValidation.one.uploadId)
+  scenario(
+    'no expenditure category found for result project use code',
+    async (scenario) => {
+      const expectedResult = { errors: [], projectUseCode: '13A' }
+      const mocks3 = new MockS3Client(JSON.stringify(expectedResult))
+      const record = buildRecord(scenario.uploadValidation.one.uploadId)
 
-    expect(
-      async () => await processRecord(record, mocks3)
-    ).rejects.toThrow('Expenditure category not found')
-  })
+      expect(async () => await processRecord(record, mocks3)).rejects.toThrow(
+        'Expenditure category not found'
+      )
+    }
+  )
 })

--- a/api/src/functions/processValidationJson/processValidationJson.ts
+++ b/api/src/functions/processValidationJson/processValidationJson.ts
@@ -108,8 +108,9 @@ export const processRecord = async (
 
     const uploadId = extractUploadIdFromKey(key)
 
-    // Verify valid expenditureCategory
-    /*
+    if (result.projectUseCode) {
+      // Verify valid expenditureCategory
+      /*
     The category must be one of the following values:
       {
         name: '1A - Broadband Infrastructure',
@@ -124,21 +125,22 @@ export const processRecord = async (
         code: '1C',
       },
     */
-    const expenditureCategory = await db.expenditureCategory.findFirst({
-      where: { code: result.projectUseCode },
-    })
-    if (!expenditureCategory) {
-      logger.error(
-        `Expenditure category not found: ${result.projectUseCode} - key: ${key}`
-      )
-      throw new Error('Expenditure category not found')
-    }
+      const expenditureCategory = await db.expenditureCategory.findFirst({
+        where: { code: result.projectUseCode },
+      })
+      if (!expenditureCategory) {
+        logger.error(
+          `Expenditure category not found: ${result.projectUseCode} - key: ${key}`
+        )
+        throw new Error('Expenditure category not found')
+      }
 
-    // Update the Upload record with the expenditure category Id
-    await db.upload.update({
-      data: { expenditureCategoryId: expenditureCategory.id },
-      where: { id: uploadId },
-    })
+      // Update the Upload record with the expenditure category Id
+      await db.upload.update({
+        data: { expenditureCategoryId: expenditureCategory.id },
+        where: { id: uploadId },
+      })
+    }
 
     // There should be an existing validation Record in the DB that will need to be updated
     const validationRecord = await db.uploadValidation.findFirst({


### PR DESCRIPTION
- Only attempt to find & save expenditure category on an upload if there is a project use code returned in the validation JSON