### PR TITLE
CPF-119 Passage API - getCurrentUser()

### DIFF
--- a/api/src/lib/auth.test.ts
+++ b/api/src/lib/auth.test.ts
@@ -1,0 +1,97 @@
+import { APIGatewayEvent } from 'aws-lambda'
+
+import { getCurrentUser } from 'src/lib/auth'
+import { db } from 'src/lib/db'
+
+jest.mock('src/lib/db', () => ({
+  db: {
+    user: {
+      findFirst: jest.fn(),
+    },
+  },
+}))
+
+describe('getCurrentUser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return the user when AUTH_PROVIDER is "local"', async () => {
+    process.env.AUTH_PROVIDER = 'local'
+    const mockUser = {
+      id: 1,
+      email: 'test@example.com',
+      role: 'ORGANIZATION_STAFF',
+      agency: { id: 1 },
+    }
+    db.user.findFirst.mockResolvedValue(mockUser)
+
+    const result = await getCurrentUser(
+      null,
+      { token: 'test@example.com' },
+      { event: {} as APIGatewayEvent }
+    )
+
+    expect(db.user.findFirst).toHaveBeenCalledWith({
+      where: { email: 'test@example.com' },
+      include: { agency: true },
+    })
+    expect(result).toEqual({
+      ...mockUser,
+      roles: [mockUser.role],
+    })
+  })
+
+  it('should return the user when AUTH_PROVIDER is "passage"', async () => {
+    process.env.AUTH_PROVIDER = 'passage'
+    const mockUser = {
+      id: 1,
+      email: 'test@example.com',
+      role: 'ORGANIZATION_STAFF',
+      agency: { id: 1 },
+    }
+    db.user.findFirst.mockResolvedValue(mockUser)
+
+    const event = {
+      requestContext: {
+        authorizer: {
+          jwt: {
+            claims: {
+              sub: 'passage-user-id',
+            },
+          },
+        },
+      },
+    } as unknown as APIGatewayEvent
+
+    const result = await getCurrentUser(null, { token: '' }, { event })
+
+    expect(db.user.findFirst).toHaveBeenCalledWith({
+      where: { passageId: 'passage-user-id' },
+      include: { agency: true },
+    })
+    expect(result).toEqual({
+      ...mockUser,
+      roles: [mockUser.role],
+    })
+  })
+
+  it('should throw an error when passageId is missing', async () => {
+    process.env.AUTH_PROVIDER = 'passage'
+
+    const event = {
+      requestContext: {
+        authorizer: {
+          jwt: {
+            claims: {},
+          },
+        },
+      },
+    } as unknown as APIGatewayEvent
+
+    const result = await getCurrentUser(null, { token: '' }, { event })
+
+    expect(db.user.findFirst).not.toHaveBeenCalled()
+    expect(result).toBeNull()
+  })
+})

--- a/web/src/pages/LoginPage/LoginPage.test.tsx
+++ b/web/src/pages/LoginPage/LoginPage.test.tsx
@@ -9,11 +9,13 @@ import LoginPage from './LoginPage'
 
 describe('LoginPage', () => {
   it('renders successfully for local auth', () => {
+    process.env.AUTH_PROVIDER = 'local'
     expect(() => {
       render(<LoginPage />)
     }).not.toThrow()
   })
   it('renders a login button for local auth', () => {
+    process.env.AUTH_PROVIDER = 'local'
     render(<LoginPage />)
     expect(screen.getByRole('button', { name: 'Login' })).toBeInTheDocument()
   })

--- a/web/types/graphql.d.ts
+++ b/web/types/graphql.d.ts
@@ -107,10 +107,8 @@ export type CreateSubrecipientInput = {
 
 export type CreateUploadInput = {
   agencyId: Scalars['Int'];
-  expenditureCategoryId?: InputMaybe<Scalars['Int']>;
   filename: Scalars['String'];
   reportingPeriodId: Scalars['Int'];
-  uploadedById: Scalars['Int'];
 };
 
 export type CreateUploadValidationInput = {


### PR DESCRIPTION
# Ticket #119 

## Overview

- Return currentUser based on the passage id retrieved through `event.requestContext.authorizer.jwt.claims.sub`
- Add `auth.test.ts` file to handle testing when passage ID is provided through jwt and when jwt is empty/null

Note: This functionality does not yet fully enable user authentication and should be verified when Passage is implemented.