### PR TITLE
fix: more url corrections across lambdas

### DIFF
--- a/api/src/functions/processValidationJson/processValidationJson.ts
+++ b/api/src/functions/processValidationJson/processValidationJson.ts
@@ -82,7 +82,7 @@ export const processRecord = async (
   s3Client: UploadValidationS3Client
 ): Promise<void> => {
   const bucket = record.s3.bucket.name
-  const key = record.s3.object.key
+  const key = decodeURIComponent(record.s3.object.key.replace(/\+/g, ' '))
 
   // Download the JSON errors file from S3
   let getObjectResponse

--- a/python/src/functions/validate_workbook.py
+++ b/python/src/functions/validate_workbook.py
@@ -125,7 +125,7 @@ def save_validation_results(client: S3Client, bucket, key: str, results: Validat
     try:
         client.put_object(
             Bucket=bucket,
-            Key=key,
+            Key=unquote_plus(key),
             Body=data,
             ContentEncoding=encoding,
             ServerSideEncryption="AES256",


### PR DESCRIPTION
Fixes #201 
- This PR ensures that the S3 object keys are decoded correctly across both the `cpfValdiation` and `processValidationJson` lambda functions.