### PR TITLE
Update python errors schema

### DIFF
--- a/python/src/functions/validate_workbook.py
+++ b/python/src/functions/validate_workbook.py
@@ -12,7 +12,7 @@ from mypy_boto3_s3.client import S3Client
 from src.lib.logging import get_logger, reset_contextvars
 from src.lib.workbook_validator import validate
 
-type ValidationResults = Dict[str, Union[List[str], str, None]]
+type ValidationResults = Dict[str, Union[List[Dict[str,str]], str, None]]
 
 @reset_contextvars
 def handle(event: S3Event, context: Context):
@@ -89,7 +89,7 @@ def validate_workbook(file: IO[bytes]) -> ValidationResults:
         "successfully validated workbook", count_validation_errors=len(errors)
     )
     results: ValidationResults = {
-        "errors": errors,
+        "errors": list(map(lambda x: x.__dict__, errors)),
         "projectUseCode": project_use_code,
     }
     return results

--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -99,7 +99,7 @@ def validate(workbook: IO[bytes]) -> Tuple[Errors, Optional[str]]:
     """
     4. Ensure all project rows are validated with the schema
     """
-    project_errors = validate_project_sheet(wb[PROJECT_SHEET], project_schema, project_use_code)
+    project_errors = validate_project_sheet(wb[PROJECT_SHEET], project_schema)
 
     """
     5. Ensure all subrecipient rows are validated with the schema
@@ -144,7 +144,7 @@ def validate_cover_sheet(
     return (errors, project_schema)
 
 
-def validate_project_sheet(project_sheet: Worksheet, project_schema, project_use_code) -> Errors:
+def validate_project_sheet(project_sheet: Worksheet, project_schema) -> Errors:
     errors = []
     project_headers = get_headers(project_sheet, "C3:DS3")
     current_row = 12
@@ -158,7 +158,7 @@ def validate_project_sheet(project_sheet: Worksheet, project_schema, project_use
         try:
             project_schema(**row_dict)
         except ValidationError as e:
-            erroring_column = get_erroring_column(SCHEMA_BY_PROJECT[project_use_code], e)
+            erroring_column = get_erroring_column(project_schema, e)
             errors.append(WorkbookError(f"{PROJECT_SHEET} Sheet: Error {e}", f"{current_row}", f"{erroring_column}", PROJECT_SHEET))
     return errors
 

--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -8,9 +8,27 @@ from src.schemas.latest.schema import (
     CoverSheetRow,
     LogicSheetVersion,
     SubrecipientRow,
+    BaseProjectRow,
 )
 
-type Errors = List[str]
+type Errors = List[WorkbookError]
+
+LOGIC_SHEET = "Logic"
+COVER_SHEET = "Cover"
+PROJECT_SHEET = "Project"
+SUBRECIPIENTS_SHEET = "Subrecipients"
+
+class WorkbookError:
+    message: str
+    row: str
+    col: str
+    tab: str
+
+    def __init__(self, message: str, row: str, col: str, tab: str):
+        self.message = message
+        self.row = row
+        self.col = col
+        self.tab = tab
 
 
 def map_values_to_headers(headers: Tuple, values: Iterable[Any]):
@@ -30,7 +48,6 @@ def get_project_use_code(cover_sheet: Worksheet) -> str:
     row_dict = map_values_to_headers(cover_header, cover_row)
     return row_dict["Project Use Code"]
 
-
 def validate(workbook: IO[bytes]) -> Tuple[Errors, Optional[str]]:
     """Validates a given Excel workbook according to CPF validation rules.
 
@@ -48,28 +65,28 @@ def validate(workbook: IO[bytes]) -> Tuple[Errors, Optional[str]]:
     """
     2. Validate logic sheet to make sure the sheet has an appropriate version
     """
-    errors = validate_logic_sheet(wb["Logic"])
+    errors = validate_logic_sheet(wb[LOGIC_SHEET])
     if len(errors) > 0:
         return errors, None
 
     """
     3. Validate cover sheet and project selection. Pick the appropriate validator for the next step.
     """
-    errors, project_schema = validate_cover_sheet(wb["Cover"])
+    errors, project_schema = validate_cover_sheet(wb[COVER_SHEET])
     if len(errors) > 0:
         return errors, None
-
-    project_use_code = get_project_use_code(wb["Cover"])
+    
+    project_use_code = get_project_use_code(wb[COVER_SHEET])
 
     """
     4. Ensure all project rows are validated with the schema
     """
-    project_errors = validate_project_sheet(wb["Project"], project_schema)
+    project_errors = validate_project_sheet(wb[PROJECT_SHEET], project_schema, project_use_code)
 
     """
     5. Ensure all subrecipient rows are validated with the schema
     """
-    subrecipient_errors = validate_subrecipient_sheet(wb["Subrecipients"])
+    subrecipient_errors = validate_subrecipient_sheet(wb[SUBRECIPIENTS_SHEET])
 
     # Close the workbook after reading
     wb.close()
@@ -84,7 +101,7 @@ def validate_logic_sheet(logic_sheet: Worksheet) -> Errors:
         # Cell B1 contains the version
         LogicSheetVersion(**{"version": logic_sheet["B1"].value})
     except ValidationError as e:
-        errors.append(f"Logic Sheet: Invalid {e}")
+        errors.append(WorkbookError(f"{LOGIC_SHEET} Sheet: Invalid {e}", "1", "B", LOGIC_SHEET))
     return errors
 
 
@@ -94,12 +111,18 @@ def validate_cover_sheet(
     errors = []
     project_schema = None
     cover_header = get_headers(cover_sheet, "A1:B1")
-    cover_row = map(lambda cell: cell.value, cover_sheet[2])
+    row_num = 2
+    cover_row = map(lambda cell: cell.value, cover_sheet[row_num])
     row_dict = map_values_to_headers(cover_header, cover_row)
     try:
         CoverSheetRow(**row_dict)
     except ValidationError as e:
-        errors.append(f"Cover Sheet: Invalid {e}")
+        erroring_field = CoverSheetRow.__fields__[e.errors()[0]['loc'][0]]
+        if (erroring_field and erroring_field.json_schema_extra):
+            erroring_column = erroring_field.json_schema_extra["column"]
+        else:
+            erroring_column = "Unknown"
+        errors.append(WorkbookError(f"{COVER_SHEET} Sheet: Invalid {e}", f"{row_num}", f"{erroring_column}", COVER_SHEET))
         return (errors, None)
 
         # This does not need to be a silent failure. This would be a critical error.
@@ -107,7 +130,7 @@ def validate_cover_sheet(
     return (errors, project_schema)
 
 
-def validate_project_sheet(project_sheet: Worksheet, project_schema) -> Errors:
+def validate_project_sheet(project_sheet: Worksheet, project_schema, project_use_code) -> Errors:
     errors = []
     project_headers = get_headers(project_sheet, "C3:DS3")
     current_row = 12
@@ -121,7 +144,14 @@ def validate_project_sheet(project_sheet: Worksheet, project_schema) -> Errors:
         try:
             project_schema(**row_dict)
         except ValidationError as e:
-            errors.append(f"Project Sheet: Row Num {current_row} Error: {e}")
+            # For some reason getattr doesn't reliably work here, so using __fields__ as a dict instead
+            #TODO figure out how to get the right row for the project use code
+            erroring_field = BaseProjectRow.__fields__[e.errors()[0]['loc'][0]]
+            if (erroring_field and erroring_field.json_schema_extra):
+                erroring_column = erroring_field.json_schema_extra["column"]
+            else:
+                erroring_column = "Unknown"
+            errors.append(WorkbookError(f"{PROJECT_SHEET} Sheet: Error {e}", f"{current_row}", f"{erroring_column}", PROJECT_SHEET))
     return errors
 
 
@@ -139,7 +169,12 @@ def validate_subrecipient_sheet(subrecipient_sheet: Worksheet) -> Errors:
         try:
             SubrecipientRow(**row_dict)
         except ValidationError as e:
-            errors.append(f"Subrecipients Sheet: Row Num {current_row} Error: {e}")
+            erroring_field = SubrecipientRow.__fields__[e.errors()[0]['loc'][0]]
+            if (erroring_field and erroring_field.json_schema_extra):
+                erroring_column = erroring_field.json_schema_extra["column"]
+            else:
+                erroring_column = "Unknown"
+            errors.append(WorkbookError(f"{SUBRECIPIENTS_SHEET} Sheet: Error {e}", f"{current_row}", f"{erroring_column}", SUBRECIPIENTS_SHEET))
 
     return errors
 

--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -49,6 +49,13 @@ def get_project_use_code(cover_sheet: Worksheet) -> str:
     row_dict = map_values_to_headers(cover_header, cover_row)
     return row_dict["Project Use Code"]
 
+"""
+This method maps the thrown error to the impacted column in the spreadsheet.
+It does so by first getting the error's location (the loc property), which is the field name,
+and then grabbing that field off of the relevant model class passed in.
+On the model class, the field definition has a property of json_schema_extra,
+defined in schema.py on a per-field basis, that contains the column for that particular field.
+"""
 def get_erroring_column(SheetModelClass: BaseModel, e: ValidationError) -> str:
     # For some reason getattr doesn't reliably work here, so using __fields__ as a dict instead
     erroring_field = SheetModelClass.__fields__[e.errors()[0]['loc'][0]]

--- a/python/src/schemas/latest/schema.py
+++ b/python/src/schemas/latest/schema.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field, condecimal, conint, validator, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, condecimal, conint, validator
 
 
 class StateAbbreviation(Enum):

--- a/python/src/schemas/latest/schema.py
+++ b/python/src/schemas/latest/schema.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field, condecimal, conint, validator
+from pydantic import BaseModel, ConfigDict, Field, condecimal, conint, validator, ValidationError
 
 
 class StateAbbreviation(Enum):
@@ -93,136 +93,140 @@ class ProjectInvestmentType(str, Enum):
 
 
 class BaseProjectRow(BaseModel):
-    model_config = ConfigDict(coerce_numbers_to_str=True)
+    model_config = ConfigDict(coerce_numbers_to_str=True, loc_by_alias=False)
 
     Project_Name__c: str = Field(
-        ..., serialization_alias="Project Name", max_length=100
+        ..., serialization_alias="Project Name", max_length=100, json_schema_extra={"column":"C"}
     )
     Identification_Number__c: str = Field(
-        ..., serialization_alias="Identification Number", max_length=20
+        ..., serialization_alias="Identification Number", max_length=20, json_schema_extra={"column":"D"}
     )
     Project_Description__c: str = Field(
-        ..., serialization_alias="Project Description", max_length=3000
+        ..., serialization_alias="Project Description", max_length=3000, json_schema_extra={"column":"E"}
     )
     Capital_Asset_Ownership_Type__c: CapitalAssetOwnershipType = Field(
-        ..., serialization_alias="Capital Asset Owenership Type"
+        ..., serialization_alias="Capital Asset Owenership Type", json_schema_extra={"column":"F"}
     )
     Total_CPF_Funding_for_Project__c: condecimal(max_digits=13, decimal_places=2) = (
-        Field(..., serialization_alias="Total CPF Funding for Project")
+        Field(..., serialization_alias="Total CPF Funding for Project", json_schema_extra={"column":"G"})
     )
     Total_from_all_funding_sources__c: condecimal(max_digits=13, decimal_places=2) = (
-        Field(..., serialization_alias="Total From all Funding Sources")
+        Field(..., serialization_alias="Total From all Funding Sources", json_schema_extra={"column":"H"})
     )
     Narrative_Description__c: Optional[str] = Field(
-        default=None, serialization_alias="Narrative Description", max_length=3000
+        default=None, serialization_alias="Narrative Description", max_length=3000, json_schema_extra={"column":"I"}
     )
     Current_Period_Obligation__c: condecimal(max_digits=12, decimal_places=2) = Field(
-        ..., serialization_alias="Current Period Obligation"
+        ..., serialization_alias="Current Period Obligation", json_schema_extra={"column":"J"}
     )
     Current_Period_Expenditure__c: condecimal(max_digits=12, decimal_places=2) = Field(
-        ..., serialization_alias="Current Period Expenditure"
+        ..., serialization_alias="Current Period Expenditure", json_schema_extra={"column":"K"}
     )
     Cumulative_Obligation__c: condecimal(max_digits=12, decimal_places=2) = Field(
-        ..., serialization_alias="Cumulative Obligation"
+        ..., serialization_alias="Cumulative Obligation", json_schema_extra={"column":"L"}
     )
     Cumulative_Expenditure__c: condecimal(max_digits=12, decimal_places=2) = Field(
-        ..., serialization_alias="Cumulative Expenditure"
+        ..., serialization_alias="Cumulative Expenditure", json_schema_extra={"column":"M"}
     )
     Cost_Overview__c: str = Field(
-        ..., serialization_alias="Cost Overview", max_length=3000
+        ..., serialization_alias="Cost Overview", max_length=3000, json_schema_extra={"column":"N"}
     )
     Project_Status__c: ProjectStatusType = Field(
-        ..., serialization_alias="Project Status"
+        ..., serialization_alias="Project Status", json_schema_extra={"column":"O"}
     )
     Projected_Con_Start_Date__c: Optional[datetime] = Field(
-        default=None, serialization_alias="Projected Con. Start Date"
+        default=None, serialization_alias="Projected Con. Start Date", json_schema_extra={"column":"P"}
     )
     Projected_Con_Completion__c: Optional[datetime] = Field(
-        default=None, serialization_alias="Projected Con. Completion"
+        default=None, serialization_alias="Projected Con. Completion", json_schema_extra={"column":"Q"}
     )
     Projected_Init_of_Operations__c: Optional[datetime] = Field(
-        default=None, serialization_alias="Projected Init. of Operations"
+        default=None, serialization_alias="Projected Init. of Operations", json_schema_extra={"column":"R"}
     )
     Actual_Con_Start_Date__c: Optional[datetime] = Field(
-        default=None, serialization_alias="Actual Con. Start Date"
+        default=None, serialization_alias="Actual Con. Start Date", json_schema_extra={"column":"S"}
     )
     Actual_Con_Completion__c: Optional[datetime] = Field(
-        default=None, serialization_alias="Actual Con. Completion"
+        default=None, serialization_alias="Actual Con. Completion", json_schema_extra={"column":"T"}
     )
     Operations_initiated__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Operations Initiated"
+        default=None, serialization_alias="Operations Initiated", json_schema_extra={"column":"U"}
     )
     Actual_operations_date__c: Optional[datetime] = Field(
-        default=None, serialization_alias="Actual operations date"
+        default=None, serialization_alias="Actual operations date", json_schema_extra={"column":"V"}
     )
     Operations_explanation__c: Optional[str] = Field(
-        default=None, serialization_alias="Operations explanation", max_length=3000
+        default=None, serialization_alias="Operations explanation", max_length=3000, json_schema_extra={"column":"W"}
     )
     Other_Federal_Funding__c: YesNoType = Field(
-        ..., serialization_alias="Other Federal Funding?"
+        ..., serialization_alias="Other Federal Funding?", json_schema_extra={"column":"X"}
     )
-    Matching_Funds__c: YesNoType = Field(..., serialization_alias="Matching Funds?")
+    Matching_Funds__c: YesNoType = Field(..., serialization_alias="Matching Funds?", json_schema_extra={"column":"Y"})
     Program_Information__c: Optional[str] = Field(
-        default=None, serialization_alias="Program Information", max_length=50
+        default=None, serialization_alias="Program Information", max_length=50, json_schema_extra={"column":"Z"}
     )
     Amount_of_Matching_Funds__c: Optional[
         condecimal(max_digits=12, decimal_places=2)
-    ] = Field(default=None, serialization_alias="Amount of Matching Funds")
+    ] = Field(default=None, serialization_alias="Amount of Matching Funds", json_schema_extra={"column":"AA"})
     Target_Project_Info__c: Optional[str] = Field(
-        default=None, serialization_alias="Target Project Info", max_length=3000
+        default=None, serialization_alias="Target Project Info", max_length=3000, json_schema_extra={"column":"AB"}
     )
     Davis_Bacon_Certification__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Davis Bacon Certification?"
+        default=None, serialization_alias="Davis Bacon Certification?", json_schema_extra={"column":"AC"}
     )
     Number_of_Direct_Employees__c: Optional[conint(ge=0, le=99999999999)] = Field(
-        default=None, serialization_alias="Number of Direct Employees"
+        default=None, serialization_alias="Number of Direct Employees", json_schema_extra={"column":"AD"}
     )
     Number_of_Contractor_Employees__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Number of Contractor Employees"
+        default=None, serialization_alias="Number of Contractor Employees", json_schema_extra={"column":"AE"}
     )
     Number_of_3rd_Party_Employees__c: Optional[conint(ge=0, le=999999999999)] = Field(
-        default=None, serialization_alias="Number of 3rd Party Employees"
+        default=None, serialization_alias="Number of 3rd Party Employees", json_schema_extra={"column":"AF"}
     )
     Any_Wages_Less_Than_Prevailing__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Any Wages Less Than Prevailing?"
+        default=None, serialization_alias="Any Wages Less Than Prevailing?", json_schema_extra={"column":"AG"}
     )
     Wages_and_benefits__c: Optional[str] = Field(
         default=None,
         serialization_alias="Wages and benefits of workers on the project by classification",
         max_length=3000,
+        json_schema_extra={"column":"AH"}
     )
     Project_Labor_Certification__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Project Labor Certification?"
+        default=None, serialization_alias="Project Labor Certification?", json_schema_extra={"column":"AI"}
     )
     Assurance_of_Adequate_Labor__c: Optional[str] = Field(
         default=None,
         serialization_alias="Assurance of Adequate Labor?",
         max_length=3000,
+        json_schema_extra={"column":"AJ"}
     )
     Minimizing_Risks__c: Optional[str] = Field(
-        default=None, serialization_alias="Minimizing Risks?", max_length=3000
+        default=None, serialization_alias="Minimizing Risks?", max_length=3000, json_schema_extra={"column":"AK"}
     )
     Safe_and_Healthy_Workplace__c: Optional[str] = Field(
         default=None,
         serialization_alias="Explain Safe and Healthy Workplace",
         max_length=3000,
+        json_schema_extra={"column":"AL"}
     )
     Adequate_Wages__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Adequate Wages?"
+        default=None, serialization_alias="Adequate Wages?", json_schema_extra={"column":"AM"}
     )
     Project_Labor_Agreement__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Project Labor Agreement?"
+        default=None, serialization_alias="Project Labor Agreement?", json_schema_extra={"column":"AN"}
     )
     Prioritize_Local_Hires__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Prioritize Local Hires?"
+        default=None, serialization_alias="Prioritize Local Hires?", json_schema_extra={"column":"AO"}
     )
     Community_Benefit_Agreement__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Community Benefit Agreement?"
+        default=None, serialization_alias="Community Benefit Agreement?", json_schema_extra={"column":"AP"}
     )
     Description_of_Community_Ben_Agr__c: Optional[str] = Field(
         default=None,
         serialization_alias="Description of Community Ben. Agr.",
         max_length=3000,
+        json_schema_extra={"column":"AQ"}
     )
 
     @validator(
@@ -245,307 +249,319 @@ class BaseProjectRow(BaseModel):
 
 class Project1ARow(BaseProjectRow):
     Technology_Type_Planned__c: TechType = Field(
-        ..., serialization_alias="Technology Type (Planned)"
+        ..., serialization_alias="Technology Type (Planned)", json_schema_extra={"column":"AR"}
     )
     Technology_Type_Actual__c: Optional[TechType] = Field(
-        default=None, serialization_alias="Technology Type (Actual)"
+        default=None, serialization_alias="Technology Type (Actual)", json_schema_extra={"column":"AS"}
     )
     If_Other_Specify_Planned__c: Optional[str] = Field(
         default=None,
         serialization_alias="If Other, Specify (Planned)?",
         max_length=3000,
+        json_schema_extra={"column":"AT"}
     )
     If_Other_Specify_Actual__c: Optional[str] = Field(
         default=None,
         serialization_alias="If Other, Specify (Actual?)?",
         max_length=3000,
+        json_schema_extra={"column":"AU"}
     )
     Total_Miles_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="Total Miles of Fiber Deployed (Planned)"
+        ..., serialization_alias="Total Miles of Fiber Deployed (Planned)", json_schema_extra={"column":"AV"}
     )
     Total_Miles_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
-        default=None, serialization_alias="Total Miles of Fiber Deployed (Actual)"
+        default=None, serialization_alias="Total Miles of Fiber Deployed (Actual)", json_schema_extra={"column":"AW"}
     )
     Locations_Served_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="A) Total Number of Locations Served (Planned)"
+        ..., serialization_alias="A) Total Number of Locations Served (Planned)", json_schema_extra={"column":"AX"}
     )
     Locations_Served_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
-        default=None, serialization_alias="A) Total Number of Locations Served (Actual)"
+        default=None, serialization_alias="A) Total Number of Locations Served (Actual)", json_schema_extra={"column":"AY"}
     )
     X25_3_Mbps_or_below_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="B) Less than 25/3 Mbps (Planned)"
+        ..., serialization_alias="B) Less than 25/3 Mbps (Planned)", json_schema_extra={"column":"AZ"}
     )
     X25_3_Mbps_and_100_20_Mbps_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="C) 25/3 Mbps and 100/20 Mbps (Planned)"
+        ..., serialization_alias="C) 25/3 Mbps and 100/20 Mbps (Planned)", json_schema_extra={"column":"BA"}
     )
     Minimum_100_100_Mbps_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="D) Minimum 100/100 Mbps (Planned) "
+        ..., serialization_alias="D) Minimum 100/100 Mbps (Planned) ", json_schema_extra={"column":"BB"}
     )
     Minimum_100_100_Mbps_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
-        default=None, serialization_alias="D) Minimum 100/100 Mbps (Actual) "
+        default=None, serialization_alias="D) Minimum 100/100 Mbps (Actual) ", json_schema_extra={"column":"BC"}
     )
     X100_20_Mbps_to_100_100_Mbps_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="E) 100/20 Mbps to 100/100 Mbps (Planned)"
+        ..., serialization_alias="E) 100/20 Mbps to 100/100 Mbps (Planned)", json_schema_extra={"column":"BD"}
     )
     X100_20_Mbps_to_100_100_Mbps_Actual__c: Optional[conint(ge=0, le=999999999)] = (
         Field(
-            default=None, serialization_alias="E) 100/20 Mbps to 100/100 Mbps (Actual)"
+            default=None, serialization_alias="E) 100/20 Mbps to 100/100 Mbps (Actual)", json_schema_extra={"column":"BE"}
         )
     )
     Explanation_of_Discrepancy__c: Optional[str] = Field(
         default=None,
         serialization_alias="Explanation of Discrepancy (Location by Speed)",
         max_length=3000,
+        json_schema_extra={"column":"BF"}
     )
     Number_of_Locations_Planned__c: conint(ge=0, le=999999999) = Field(
         ...,
         serialization_alias="F) Total Number of Locations Served by Type - Residential (Planned)",
+        json_schema_extra={"column":"BG"}
     )
     Number_of_Locations_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
         default=None,
         serialization_alias="F) Total Number of Locations Served by Type - Residential (Actual)",
+        json_schema_extra={"column":"BH"}
     )
     Housing_Units_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="G) Total Housing Units (Planned)"
+        ..., serialization_alias="G) Total Housing Units (Planned)", json_schema_extra={"column":"BI"}
     )
     Housing_Units_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
-        default=None, serialization_alias="G) Total Housing Units (Actual)"
+        default=None, serialization_alias="G) Total Housing Units (Actual)", json_schema_extra={"column":"BJ"}
     )
     Number_of_Bus_Locations_Planned__c: conint(ge=0, le=999999999) = Field(
         ...,
         serialization_alias="H) Total Number of Locations Served by Type - Business (Planned)",
+        json_schema_extra={"column":"BK"}
     )
     Number_of_Bus_Locations_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
         default=None,
         serialization_alias="H) Total Number of Locations Served by Type - Business (Actual)",
+        json_schema_extra={"column":"BL"}
     )
     Number_of_CAI_Planned__c: conint(ge=0, le=999999999) = Field(
         ...,
         serialization_alias="I) Total Number of Locations Served by Type - Community Anchor Institution (Planned)",
+        json_schema_extra={"column":"BM"}
     )
     Number_of_CAI_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
         default=None,
         serialization_alias="I) Total Number of Locations Served by Type - Community Anchor Institution (Actual)",
+        json_schema_extra={"column":"BN"}
     )
     Explanation_Planned__c: Optional[str] = Field(
-        default=None, serialization_alias="Explanation (Planned)", max_length=3000
+        default=None, serialization_alias="Explanation (Planned)", max_length=3000, json_schema_extra={"column":"BO"}
     )
     Affordable_Connectivity_Program_ACP__c: YesNoType = Field(
-        ..., serialization_alias="Affordable Connectivity Program (ACP)?"
+        ..., serialization_alias="Affordable Connectivity Program (ACP)?", json_schema_extra={"column":"BP"}
     )
 
 
 class AddressFields(BaseModel):
     Street_1_Planned__c: str = Field(
-        ..., serialization_alias="Street 1 (Planned)", max_length=40
+        ..., serialization_alias="Street 1 (Planned)", max_length=40, json_schema_extra={"column":"BQ"}
     )
     Street_2_Planned__c: str = Field(
-        default=None, serialization_alias="Street 2 (Planned)", max_length=40
+        default=None, serialization_alias="Street 2 (Planned)", max_length=40, json_schema_extra={"column":"BR"}
     )
-    Same_Address__c: YesNoType = Field(default=None, serialization_alias="Same Address")
+    Same_Address__c: YesNoType = Field(default=None, serialization_alias="Same Address", json_schema_extra={"column":"BS"})
     Street_1_Actual__c: str = Field(
-        default=None, serialization_alias="Street 1 (Actual)", max_length=40
+        default=None, serialization_alias="Street 1 (Actual)", max_length=40, json_schema_extra={"column":"BT"}
     )
     Street_2_Actual__c: str = Field(
-        default=None, serialization_alias="Street 2 (Actual)", max_length=40
+        default=None, serialization_alias="Street 2 (Actual)", max_length=40, json_schema_extra={"column":"BU"}
     )
     City_Planned__c: str = Field(
-        ..., serialization_alias="City (Planned)", max_length=40
+        ..., serialization_alias="City (Planned)", max_length=40, json_schema_extra={"column":"BV"}
     )
     City_Actual__c: str = Field(
-        default=None, serialization_alias="City (Actual)", max_length=40
+        default=None, serialization_alias="City (Actual)", max_length=40, json_schema_extra={"column":"BW"}
     )
     State_Planned__c: StateAbbreviation = Field(
-        ..., serialization_alias="State (Planned)"
+        ..., serialization_alias="State (Planned)", json_schema_extra={"column":"BX"}
     )
     State_Actual__c: StateAbbreviation = Field(
-        default=None, serialization_alias="State (Actual)"
+        default=None, serialization_alias="State (Actual)", json_schema_extra={"column":"BY"}
     )
     Zip_Code_Planned__c: str = Field(
-        ..., serialization_alias="Zip Code (Planned)", max_length=5
+        ..., serialization_alias="Zip Code (Planned)", max_length=5, json_schema_extra={"column":"BZ"}
     )
     Zip_Code_Actual__c: str = Field(
-        default=None, serialization_alias="Zip Code (Actual)", max_length=5
+        default=None, serialization_alias="Zip Code (Actual)", max_length=5, json_schema_extra={"column":"CA"}
     )
 
 
 class Project1BRow(BaseProjectRow, AddressFields):
     Laptops_Planned__c: conint(ge=0, le=9999999999) = Field(
-        ..., serialization_alias="Laptops (Planned)"
+        ..., serialization_alias="Laptops (Planned)", json_schema_extra={"column":"CB"}
     )
     Laptops_Actual__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Laptops (Actual)"
+        default=None, serialization_alias="Laptops (Actual)", json_schema_extra={"column":"CC"}
     )
     Laptops_Expenditures_Planned__c: condecimal(max_digits=13, decimal_places=2) = (
-        Field(..., serialization_alias="Laptops Expenditure (Planned)")
+        Field(..., serialization_alias="Laptops Expenditure (Planned)", json_schema_extra={"column":"CD"})
     )
     Laptops_Expenditures_Actual__c: condecimal(max_digits=13, decimal_places=2) = Field(
-        default=None, serialization_alias="Laptops Expenditure (Actual)"
+        default=None, serialization_alias="Laptops Expenditure (Actual)", json_schema_extra={"column":"CE"}
     )
     Tablets_Planned__c: conint(ge=0, le=9999999999) = Field(
-        ..., serialization_alias="Tablets (Planned)"
+        ..., serialization_alias="Tablets (Planned)", json_schema_extra={"column":"CF"}
     )
     Tablets_Actual__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Tablets (Actual)"
+        default=None, serialization_alias="Tablets (Actual)", json_schema_extra={"column":"CG"}
     )
     Tablet_Expenditures_Planned__c: condecimal(max_digits=13, decimal_places=2) = Field(
-        ..., serialization_alias="Tablets Expenditure (Planned)"
+        ..., serialization_alias="Tablets Expenditure (Planned)", json_schema_extra={"column":"CH"}
     )
     Tablets_Expenditures_Actual__c: condecimal(max_digits=13, decimal_places=2) = Field(
-        default=None, serialization_alias="Tablets Expenditure (Actual)"
+        default=None, serialization_alias="Tablets Expenditure (Actual)", json_schema_extra={"column":"CI"}
     )
     Desktop_Computers_Planned__c: conint(ge=0, le=9999999999) = Field(
-        ..., serialization_alias="Desktop Computers (Planned)"
+        ..., serialization_alias="Desktop Computers (Planned)", json_schema_extra={"column":"CJ"}
     )
     Desktop_Computers_Actual__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Desktop Computers (Actual)"
+        default=None, serialization_alias="Desktop Computers (Actual)", json_schema_extra={"column":"CK"}
     )
     Desktop_Computers_Expenditures_Planned__c: condecimal(
         max_digits=13, decimal_places=2
-    ) = Field(..., serialization_alias="Desktop Computers Expenditure (Planned)")
+    ) = Field(..., serialization_alias="Desktop Computers Expenditure (Planned)", json_schema_extra={"column":"CL"})
     Desktop_Computers_Expenditures_Actual__c: condecimal(
         max_digits=13, decimal_places=2
     ) = Field(
-        default=None, serialization_alias="Desktop Computers Expenditure (Actual)"
+        default=None, serialization_alias="Desktop Computers Expenditure (Actual)", json_schema_extra={"column":"CM"}
     )
     Public_WiFi_Planned__c: conint(ge=0, le=9999999999) = Field(
-        ..., serialization_alias="Public WiFi (Planned)"
+        ..., serialization_alias="Public WiFi (Planned)", json_schema_extra={"column":"CN"}
     )
     Public_WiFi_Actual__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Public WiFi (Actual)"
+        default=None, serialization_alias="Public WiFi (Actual)", json_schema_extra={"column":"CO"}
     )
     Public_WiFi_Expenditures_Planned__c: condecimal(max_digits=13, decimal_places=2) = (
-        Field(..., serialization_alias="Public Wifi Expenditures (Planned)")
+        Field(..., serialization_alias="Public Wifi Expenditures (Planned)", json_schema_extra={"column":"CP"})
     )
     Public_WiFi_Expenditures_Actual__c: condecimal(max_digits=13, decimal_places=2) = (
-        Field(default=None, serialization_alias="Public Wifi Expenditures (Actual)")
+        Field(default=None, serialization_alias="Public Wifi Expenditures (Actual)", json_schema_extra={"column":"CQ"})
     )
     Other_Devices_Planned__c: conint(ge=0, le=9999999999) = Field(
-        ..., serialization_alias="Other Devices (Planned)"
+        ..., serialization_alias="Other Devices (Planned)", json_schema_extra={"column":"CR"}
     )
     Other_Devices_Actual__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Other Devices (Actual)"
+        default=None, serialization_alias="Other Devices (Actual)", json_schema_extra={"column":"CS"}
     )
     Other_Expenditures_Planned__c: condecimal(max_digits=7, decimal_places=2) = Field(
-        ..., serialization_alias="Other Expenditures (Planned)"
+        ..., serialization_alias="Other Expenditures (Planned)", json_schema_extra={"column":"CT"}
     )
     Other_Expenditures_Actual__c: condecimal(max_digits=7, decimal_places=2) = Field(
-        default=None, serialization_alias="Other Expenditures (Actual)"
+        default=None, serialization_alias="Other Expenditures (Actual)", json_schema_extra={"column":"CU"}
     )
     Explanation_of_Other_Expend__c: str = Field(
         default=None,
         serialization_alias="Explanation of Other Expenditures",
         max_length=3000,
+        json_schema_extra={"column":"CV"}
     )
     Number_of_Users_Planned__c: conint(ge=0, le=9999999999) = Field(
-        ..., serialization_alias="Number of Users (Planned)"
+        ..., serialization_alias="Number of Users (Planned)", json_schema_extra={"column":"CW"}
     )
     Number_of_Users_Actual__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Number of Users (Actual)"
+        default=None, serialization_alias="Number of Users (Actual)", json_schema_extra={"column":"CX"}
     )
     Brief_Narrative_Planned__c: str = Field(
-        ..., serialization_alias="Brief Narrative (Planned)", max_length=3000
+        ..., serialization_alias="Brief Narrative (Planned)", max_length=3000, json_schema_extra={"column":"CY"}
     )
     Brief_Narrative_Actual__c: str = Field(
-        default=None, serialization_alias="Brief Narrative (Actual)", max_length=3000
+        default=None, serialization_alias="Brief Narrative (Actual)", max_length=3000, json_schema_extra={"column":"CZ"}
     )
     Measurement_of_Effectiveness__c: YesNoType = Field(
-        ..., serialization_alias="Measurement of Effectiveness?"
+        ..., serialization_alias="Measurement of Effectiveness?", json_schema_extra={"column":"DA"}
     )
 
 
 class Project1CRow(BaseProjectRow, AddressFields):
     Type_of_Investment__c: str = Field(
-        default=None, serialization_alias="Type of Investment"
+        default=None, serialization_alias="Type of Investment", json_schema_extra={"column":"DB"}
     )
     Additional_Address__c: str = Field(
-        default=None, serialization_alias="Additional Addresses", max_length=32000
+        default=None, serialization_alias="Additional Addresses", max_length=32000, json_schema_extra={"column":"DC"}
     )
     Classrooms_Planned__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Classrooms (Planned)"
+        default=None, serialization_alias="Classrooms (Planned)", json_schema_extra={"column":"DD"}
     )
     Classrooms_Actual__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Classrooms (Actual)"
+        default=None, serialization_alias="Classrooms (Actual)", json_schema_extra={"column":"DE"}
     )
     Computer_labs_Planned__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Computer labs (Planned)"
+        default=None, serialization_alias="Computer labs (Planned)", json_schema_extra={"column":"DF"}
     )
     Computer_labs_Actual__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Computer labs (Actual)"
+        default=None, serialization_alias="Computer labs (Actual)", json_schema_extra={"column":"DG"}
     )
     Multi_purpose_Spaces_Planned__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Multi-purpose Spaces (Planned)"
+        default=None, serialization_alias="Multi-purpose Spaces (Planned)", json_schema_extra={"column":"DH"}
     )
     Multi_purpose_Spaces_Actual__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Multi-purpose Spaces (Actual)"
+        default=None, serialization_alias="Multi-purpose Spaces (Actual)", json_schema_extra={"column":"DI"}
     )
     Telemedicine_Rooms_Planned__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Telemedicine Rooms (Planned)"
+        default=None, serialization_alias="Telemedicine Rooms (Planned)", json_schema_extra={"column":"DJ"}
     )
     Telemedicine_Rooms_Actual__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Telemedicine Rooms (Actual)"
+        default=None, serialization_alias="Telemedicine Rooms (Actual)", json_schema_extra={"column":"DK"}
     )
     Other_Capital_Assets_Planned__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Other Capital Assets (Planned)"
+        default=None, serialization_alias="Other Capital Assets (Planned)", json_schema_extra={"column":"DL"}
     )
     Other_Capital_Assets_Actual__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Other Capital Assets (Actual)"
+        default=None, serialization_alias="Other Capital Assets (Actual)", json_schema_extra={"column":"DM"}
     )
     Type_and_Features__c: str = Field(
-        default=None, serialization_alias="Type and Features", max_length=3000
+        default=None, serialization_alias="Type and Features", max_length=3000, json_schema_extra={"column":"DN"}
     )
     Total_square_footage_Planned__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Total square footage (Planned)"
+        default=None, serialization_alias="Total square footage (Planned)", json_schema_extra={"column":"DO"}
     )
     Total_square_footage_Actual__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Total square footage (Actual)"
+        default=None, serialization_alias="Total square footage (Actual)", json_schema_extra={"column":"DP"}
     )
     Total_Number_of_Users_Actual__c: conint(ge=0, le=9999999999) = Field(
-        default=None, serialization_alias="Total Number of Users (Actual)"
+        default=None, serialization_alias="Total Number of Users (Actual)", json_schema_extra={"column":"DQ"}
     )
     Further_Explanation__c: str = Field(
-        default=None, serialization_alias="Further Explanation", max_length=2000
+        default=None, serialization_alias="Further Explanation", max_length=2000, json_schema_extra={"column":"DR"}
     )
     Access_to_Public_Transit__c: YesNoType = Field(
-        ..., serialization_alias="Access to Public Transit?"
+        ..., serialization_alias="Access to Public Transit?", json_schema_extra={"column":"DS"}
     )
 
 
 class SubrecipientRow(BaseModel):
-    model_config = ConfigDict(coerce_numbers_to_str=True)
+    model_config = ConfigDict(coerce_numbers_to_str=True, loc_by_alias=False)
 
-    Name: str = Field(..., serialization_alias="Subrecipient Name", max_length=80)
+    Name: str = Field(..., serialization_alias="Subrecipient Name", max_length=80, json_schema_extra={"column":"C"})
     EIN__c: str = Field(
         ...,
         serialization_alias="Subrecipient Tax ID Number (TIN)",
         min_length=9,
         max_length=9,
+        json_schema_extra={"column":"D"}
     )
     Unique_Entity_Identifier__c: str = Field(
         ...,
         serialization_alias="Unique Entity Identifier (UEI)",
         min_length=12,
         max_length=12,
+        json_schema_extra={"column":"E"}
     )
-    POC_Name__c: str = Field(..., serialization_alias="POC Name", max_length=100)
+    POC_Name__c: str = Field(..., serialization_alias="POC Name", max_length=100, json_schema_extra={"column":"F"})
     POC_Phone_Number__c: str = Field(
-        ..., serialization_alias="POC Phone Number", max_length=10
+        ..., serialization_alias="POC Phone Number", max_length=10, json_schema_extra={"column":"G"}
     )
     POC_Email_Address__c: str = Field(
-        ..., serialization_alias="POC Email Address", max_length=80
+        ..., serialization_alias="POC Email Address", max_length=80, json_schema_extra={"column":"H"}
     )
-    Zip__c: str = Field(..., serialization_alias="Zip5", max_length=5)
-    Zip_4__c: str = Field(default=None, serialization_alias="Zip4", max_length=4)
-    Address__c: str = Field(..., serialization_alias="Address Line 1", max_length=40)
+    Zip__c: str = Field(..., serialization_alias="Zip5", max_length=5, json_schema_extra={"column":"I"})
+    Zip_4__c: str = Field(default=None, serialization_alias="Zip4", max_length=4, json_schema_extra={"column":"J"})
+    Address__c: str = Field(..., serialization_alias="Address Line 1", max_length=40, json_schema_extra={"column":"K"})
     Address_2__c: str = Field(
-        default=None, serialization_alias="Address Line 2", max_length=40
+        default=None, serialization_alias="Address Line 2", max_length=40, json_schema_extra={"column":"L"}
     )
     Address_3__c: str = Field(
-        default=None, serialization_alias="Address Line 3", max_length=40
+        default=None, serialization_alias="Address Line 3", max_length=40, json_schema_extra={"column":"M"}
     )
-    City__c: str = Field(..., serialization_alias="City", max_length=100)
+    City__c: str = Field(..., serialization_alias="City", max_length=100, json_schema_extra={"column":"N"})
     State_Abbreviated__c: StateAbbreviation = Field(
-        ..., serialization_alias="State Abbreviated"
+        ..., serialization_alias="State Abbreviated", json_schema_extra={"column":"O"}
     )
 
 
@@ -601,8 +617,10 @@ class LogicSheetVersion(BaseModel):
 
 
 class CoverSheetRow(BaseModel):
-    project_use_code: str = Field(..., alias="Project Use Code")
-    project_use_name: str = Field(..., alias="Project Use Name")
+    model_config = ConfigDict(loc_by_alias=False)
+
+    project_use_code: str = Field(..., alias="Project Use Code", json_schema_extra={"column":"A"})
+    project_use_name: str = Field(..., alias="Project Use Name", json_schema_extra={"column":"B"})
 
     @validator("project_use_name")
     def validate_code_name_pair(cls, v, values, **kwargs):

--- a/python/tests/src/lib/test_workbook_validator.py
+++ b/python/tests/src/lib/test_workbook_validator.py
@@ -55,18 +55,27 @@ class TestValidateCoverSheet:
     def test_invalid_cover_sheet(self, invalid_cover_sheet: Worksheet):
         errors, schema = validate_cover_sheet(invalid_cover_sheet)
         assert errors != []
+        error = errors[0]
+        print(error.message)
+        assert "Project use code 'INVALID' is not recognized." in error.message
+        assert error.col == "B"
+        assert error.row == "2"
+        assert error.tab == "Cover"
         assert schema is None
 
 
 class TestValidateproject_sheet:
     def test_valid_project_sheet(self, valid_project_sheet: Worksheet):
-        errors = validate_project_sheet(valid_project_sheet, SCHEMA_BY_PROJECT[SAMPLE_PROJECT_USE_CODE])
+        errors = validate_project_sheet(valid_project_sheet, SCHEMA_BY_PROJECT[SAMPLE_PROJECT_USE_CODE], SAMPLE_PROJECT_USE_CODE)
         assert errors == []
 
     def test_invalid_project_sheet(self, invalid_project_sheet: Worksheet):
-        errors = validate_project_sheet(invalid_project_sheet, SCHEMA_BY_PROJECT[SAMPLE_PROJECT_USE_CODE])
+        errors = validate_project_sheet(invalid_project_sheet, SCHEMA_BY_PROJECT[SAMPLE_PROJECT_USE_CODE], SAMPLE_PROJECT_USE_CODE)
         assert errors != []
-
+        error = errors[0]
+        assert error.row == "13"
+        assert error.col == "D"
+        assert "string_too_long" in error.message
 
 class TestValidateSubrecipientSheet:
     def test_valid_subrecipient_sheet(self, valid_subrecipientsheet: Worksheet):
@@ -76,6 +85,10 @@ class TestValidateSubrecipientSheet:
     def test_invalid_subrecipient_sheet(self, invalid_subrecipient_sheet: Worksheet):
         errors = validate_subrecipient_sheet(invalid_subrecipient_sheet)
         assert errors != []
+        error = errors[0]
+        assert "String should have at least 9 characters" in error.message
+        assert error.row == "13"
+        assert error.col == "D"
 
 class TestGetProjectUseCode:
     def test_get_project_use_code(self, valid_coversheet: Worksheet):

--- a/python/tests/src/lib/test_workbook_validator.py
+++ b/python/tests/src/lib/test_workbook_validator.py
@@ -75,7 +75,7 @@ class TestValidateproject_sheet:
         error = errors[0]
         assert error.row == "13"
         assert error.col == "D"
-        assert "string_too_long" in error.message
+        assert "Error in field Identification_Number__c-String should have at most 20 characters" in error.message
 
 class TestValidateSubrecipientSheet:
     def test_valid_subrecipient_sheet(self, valid_subrecipientsheet: Worksheet):

--- a/python/tests/src/lib/test_workbook_validator.py
+++ b/python/tests/src/lib/test_workbook_validator.py
@@ -66,11 +66,11 @@ class TestValidateCoverSheet:
 
 class TestValidateproject_sheet:
     def test_valid_project_sheet(self, valid_project_sheet: Worksheet):
-        errors = validate_project_sheet(valid_project_sheet, SCHEMA_BY_PROJECT[SAMPLE_PROJECT_USE_CODE], SAMPLE_PROJECT_USE_CODE)
+        errors = validate_project_sheet(valid_project_sheet, SCHEMA_BY_PROJECT[SAMPLE_PROJECT_USE_CODE])
         assert errors == []
 
     def test_invalid_project_sheet(self, invalid_project_sheet: Worksheet):
-        errors = validate_project_sheet(invalid_project_sheet, SCHEMA_BY_PROJECT[SAMPLE_PROJECT_USE_CODE], SAMPLE_PROJECT_USE_CODE)
+        errors = validate_project_sheet(invalid_project_sheet, SCHEMA_BY_PROJECT[SAMPLE_PROJECT_USE_CODE])
         assert errors != []
         error = errors[0]
         assert error.row == "13"


### PR DESCRIPTION
- This adds more detail to validator error messages, including the tab, row and column as well as the message
- The tab and the row were straightforward to get already, column was a bit trickier. I ended up mapping the columns from the google doc from @as1729 straight to the Pydantic `Field` definitions. This means that we can access them by field in the event of an error by mapping the error's `loc` property to the field def, and accessing the `json_schema_extra` which stores the column
- To make this work consistently, I also specified in the model configs that we want to loc by field name and not by alias (see [here](https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.loc_by_alias) 