### PR TITLE
CPF-214 Scope uploads by user role

### DIFF
--- a/api/src/services/uploads/uploads.scenarios.ts
+++ b/api/src/services/uploads/uploads.scenarios.ts
@@ -1,4 +1,4 @@
-import type { Prisma, Upload } from '@prisma/client'
+import type { Prisma, Upload, User, Organization, Agency, ReportingPeriod } from '@prisma/client'
 
 import type { ScenarioData } from '@redwoodjs/testing/api'
 
@@ -15,6 +15,11 @@ export const standard = defineScenario<
         name: 'USDR',
       },
     },
+    two: {
+      data: {
+        name: 'Example Organization',
+      },
+    },
   },
   agency: {
     one: (scenario) => ({
@@ -22,6 +27,16 @@ export const standard = defineScenario<
         name: 'Agency1',
         organizationId: scenario.organization.one.id,
         code: 'A1',
+      },
+      include: {
+        organization: true,
+      },
+    }),
+    two: (scenario) => ({
+      data: {
+        name: 'Agency2',
+        organizationId: scenario.organization.two.id,
+        code: 'A2',
       },
       include: {
         organization: true,
@@ -44,8 +59,19 @@ export const standard = defineScenario<
       data: {
         email: 'uniqueemail25@test.com',
         name: 'String',
-        role: 'ORGANIZATION_STAFF',
+        role: 'USDR_ADMIN',
         agencyId: scenario.agency.one.id,
+      },
+      include: {
+        agency: true,
+      },
+    }),
+    three: (scenario) => ({
+      data: {
+        email: 'uniqueemail3@test.com',
+        name: 'String',
+        role: 'ORGANIZATION_STAFF',
+        agencyId: scenario.agency.two.id,
       },
       include: {
         agency: true,
@@ -106,7 +132,7 @@ export const standard = defineScenario<
     two: (scenario) => ({
       data: {
         filename: 'String',
-        uploadedById: scenario.user.one.id,
+        uploadedById: scenario.user.two.id,
         agencyId: scenario.agency.one.id,
         reportingPeriodId: scenario.reportingPeriod.one.id,
         validations: {
@@ -114,13 +140,13 @@ export const standard = defineScenario<
             {
               passed: true,
               results: '{error:false}',
-              initiatedById: scenario.user.one.id,
+              initiatedById: scenario.user.two.id,
               createdAt: '2024-01-29T18:13:25.000Z',
             },
             {
               passed: true,
               results: '{error:false}',
-              initiatedById: scenario.user.one.id,
+              initiatedById: scenario.user.two.id,
               createdAt: '2024-01-29T17:10:22.000Z',
             },
           ],
@@ -129,7 +155,22 @@ export const standard = defineScenario<
         updatedAt: '2024-01-21T18:10:17.000Z',
       },
     }),
+    three: (scenario) => ({
+      data: {
+        filename: 'String',
+        uploadedById: scenario.user.three.id,
+        agencyId: scenario.agency.two.id,
+        reportingPeriodId: scenario.reportingPeriod.one.id,
+        validations: {},
+        createdAt: '2024-01-21T18:10:17.000Z',
+        updatedAt: '2024-01-21T18:10:17.000Z',
+      },
+    }),
   },
 })
 
-export type StandardScenario = ScenarioData<Upload, 'upload'>
+export type StandardScenario = ScenarioData<Upload, 'upload'> &
+  ScenarioData<User, 'user'> &
+  ScenarioData<Organization, 'organization'> &
+  ScenarioData<Agency, 'agency'> &
+  ScenarioData<ReportingPeriod, 'reportingPeriod'>

--- a/api/src/services/uploads/uploads.scenarios.ts
+++ b/api/src/services/uploads/uploads.scenarios.ts
@@ -1,4 +1,11 @@
-import type { Prisma, Upload, User, Organization, Agency, ReportingPeriod } from '@prisma/client'
+import type {
+  Prisma,
+  Upload,
+  User,
+  Organization,
+  Agency,
+  ReportingPeriod,
+} from '@prisma/client'
 
 import type { ScenarioData } from '@redwoodjs/testing/api'
 

--- a/api/src/services/uploads/uploads.test.ts
+++ b/api/src/services/uploads/uploads.test.ts
@@ -20,47 +20,67 @@ import type { StandardScenario } from './uploads.scenarios'
 // https://redwoodjs.com/docs/testing#jest-expect-type-considerations
 
 describe('uploads', () => {
+  async function uploadsBelongToOrganization(uploads, expectedOrganizationId) {
+    const uploadOrganizationIds = await Promise.all(
+      uploads.map(async (upload) => {
+        const agency = await db.agency.findUnique({
+          where: { id: upload.agencyId },
+        })
+        return agency?.organizationId
+      })
+    )
+
+    return uploadOrganizationIds.every(
+      (orgId) => orgId === expectedOrganizationId
+    )
+  }
+
   scenario('returns a single upload', async (scenario: StandardScenario) => {
     const result = await upload({ id: scenario.upload.one.id })
 
     expect(result).toEqual(scenario.upload.one)
   })
 
-scenario('returns all uploads in their organization for organization admins', async (scenario: StandardScenario) => {
-  mockCurrentUser(scenario.user.one);
-  const result = await uploads();
-  const uploadOrganizationIds = await Promise.all(
-    result.map(async (upload) => {
-      const agency = await db.agency.findUnique({ where: { id: upload.agencyId } });
-      return agency?.organizationId;
-    })
-  );
-  
-  expect(result.length).toEqual(2);
-  expect(uploadOrganizationIds.every((orgId) => orgId === scenario.organization.one.id)).toBe(true);
-});
+  scenario(
+    'returns all uploads in their organization for organization admins',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser(scenario.user.one)
+      const result = await uploads()
+      const uploadsBelongToOrg = await uploadsBelongToOrganization(
+        result,
+        scenario.organization.one.id
+      )
 
-scenario('returns all uploads in their organization for USDR admins', async (scenario: StandardScenario) => {
-  mockCurrentUser(scenario.user.two);
-  const result = await uploads();
-  
-  const uploadOrganizationIds = await Promise.all(
-    result.map(async (upload) => {
-      const agency = await db.agency.findUnique({ where: { id: upload.agencyId } });
-      return agency?.organizationId;
-    })
-  );
-  
-  expect(result.length).toEqual(2);
-  expect(uploadOrganizationIds.every((orgId) => orgId === scenario.organization.one.id)).toBe(true);
-});
+      expect(result.length).toEqual(2)
+      expect(uploadsBelongToOrg).toBe(true)
+    }
+  )
 
-  scenario('returns uploads for organization staff, only their own', async (scenario: StandardScenario) => {
-    mockCurrentUser(scenario.user.three);
-    const result = await uploads();
-    expect(result.length).toEqual(1);
-    expect(result[0].uploadedById).toEqual(scenario.user.three.id);
-  });
+  scenario(
+    'returns all uploads in their organization for USDR admins',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser(scenario.user.two)
+      const result = await uploads()
+      const uploadsBelongToOrg = await uploadsBelongToOrganization(
+        result,
+        scenario.organization.one.id
+      )
+
+      expect(result.length).toEqual(2)
+      expect(uploadsBelongToOrg).toBe(true)
+    }
+  )
+
+  scenario(
+    'returns uploads for organization staff, only their own',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser(scenario.user.three)
+      const result = await uploads()
+
+      expect(result.length).toEqual(1)
+      expect(result[0].uploadedById).toEqual(scenario.user.three.id)
+    }
+  )
 
   scenario('creates an upload', async (scenario: StandardScenario) => {
     mockCurrentUser(scenario.user.one)

--- a/api/src/services/uploads/uploads.test.ts
+++ b/api/src/services/uploads/uploads.test.ts
@@ -20,17 +20,47 @@ import type { StandardScenario } from './uploads.scenarios'
 // https://redwoodjs.com/docs/testing#jest-expect-type-considerations
 
 describe('uploads', () => {
-  scenario('returns all uploads', async (scenario: StandardScenario) => {
-    const result = await uploads()
-
-    expect(result.length).toEqual(Object.keys(scenario.upload).length)
-  })
-
   scenario('returns a single upload', async (scenario: StandardScenario) => {
     const result = await upload({ id: scenario.upload.one.id })
 
     expect(result).toEqual(scenario.upload.one)
   })
+
+scenario('returns all uploads in their organization for organization admins', async (scenario: StandardScenario) => {
+  mockCurrentUser(scenario.user.one);
+  const result = await uploads();
+  const uploadOrganizationIds = await Promise.all(
+    result.map(async (upload) => {
+      const agency = await db.agency.findUnique({ where: { id: upload.agencyId } });
+      return agency?.organizationId;
+    })
+  );
+  
+  expect(result.length).toEqual(2);
+  expect(uploadOrganizationIds.every((orgId) => orgId === scenario.organization.one.id)).toBe(true);
+});
+
+scenario('returns all uploads in their organization for USDR admins', async (scenario: StandardScenario) => {
+  mockCurrentUser(scenario.user.two);
+  const result = await uploads();
+  
+  const uploadOrganizationIds = await Promise.all(
+    result.map(async (upload) => {
+      const agency = await db.agency.findUnique({ where: { id: upload.agencyId } });
+      return agency?.organizationId;
+    })
+  );
+  
+  expect(result.length).toEqual(2);
+  expect(uploadOrganizationIds.every((orgId) => orgId === scenario.organization.one.id)).toBe(true);
+});
+
+  scenario('returns uploads for organization staff, only their own', async (scenario: StandardScenario) => {
+    mockCurrentUser(scenario.user.three);
+    const result = await uploads();
+    expect(result.length).toEqual(1);
+    expect(result[0].uploadedById).toEqual(scenario.user.three.id);
+  });
 
   scenario('creates an upload', async (scenario: StandardScenario) => {
     mockCurrentUser(scenario.user.one)
@@ -43,7 +73,7 @@ describe('uploads', () => {
     })
 
     expect(result.filename).toEqual('String')
-    expect(result.uploadedById).toEqual(scenario.upload.two.uploadedById)
+    expect(result.uploadedById).toEqual(scenario.upload.one.uploadedById)
     expect(result.agencyId).toEqual(scenario.upload.two.agencyId)
     expect(result.reportingPeriodId).toEqual(
       scenario.upload.two.reportingPeriodId

--- a/api/src/services/uploads/uploads.test.ts
+++ b/api/src/services/uploads/uploads.test.ts
@@ -76,9 +76,14 @@ describe('uploads', () => {
     async (scenario: StandardScenario) => {
       mockCurrentUser(scenario.user.three)
       const result = await uploads()
+      const uploadsBelongToOrg = await uploadsBelongToOrganization(
+        result,
+        scenario.organization.two.id
+      )
 
       expect(result.length).toEqual(1)
       expect(result[0].uploadedById).toEqual(scenario.user.three.id)
+      expect(uploadsBelongToOrg).toBe(true)
     }
   )
 

--- a/api/src/services/uploads/uploads.ts
+++ b/api/src/services/uploads/uploads.ts
@@ -7,28 +7,31 @@ import type {
 
 import { s3PutSignedUrl } from 'src/lib/aws'
 import aws from 'src/lib/aws'
+import { ROLES } from 'src/lib/constants'
 import { db } from 'src/lib/db'
 import { logger } from 'src/lib/logger'
 import { ValidationError } from 'src/lib/validation-error'
-import { ROLES } from 'src/lib/constants'
 
 export const uploads: QueryResolvers['uploads'] = () => {
-  const currentUser = context.currentUser;
+  const currentUser = context.currentUser
 
   if (currentUser.role === ROLES.ORGANIZATION_STAFF) {
     return db.upload.findMany({
       where: {
-        uploadedById: currentUser.id
-      }
-    });
-  } else if (currentUser.role === ROLES.ORGANIZATION_ADMIN || currentUser.role === ROLES.USDR_ADMIN) {
+        uploadedById: currentUser.id,
+      },
+    })
+  } else if (
+    currentUser.role === ROLES.ORGANIZATION_ADMIN ||
+    currentUser.role === ROLES.USDR_ADMIN
+  ) {
     return db.upload.findMany({
       where: {
         agency: {
-          organizationId: currentUser.agency.organizationId
-        }
-      }
-    });
+          organizationId: currentUser.agency.organizationId,
+        },
+      },
+    })
   }
 }
 

--- a/api/src/services/uploads/uploads.ts
+++ b/api/src/services/uploads/uploads.ts
@@ -10,9 +10,26 @@ import aws from 'src/lib/aws'
 import { db } from 'src/lib/db'
 import { logger } from 'src/lib/logger'
 import { ValidationError } from 'src/lib/validation-error'
+import { ROLES } from 'src/lib/constants'
 
 export const uploads: QueryResolvers['uploads'] = () => {
-  return db.upload.findMany()
+  const currentUser = context.currentUser;
+
+  if (currentUser.role === ROLES.ORGANIZATION_STAFF) {
+    return db.upload.findMany({
+      where: {
+        uploadedById: currentUser.id
+      }
+    });
+  } else if (currentUser.role === ROLES.ORGANIZATION_ADMIN || currentUser.role === ROLES.USDR_ADMIN) {
+    return db.upload.findMany({
+      where: {
+        agency: {
+          organizationId: currentUser.agency.organizationId
+        }
+      }
+    });
+  }
 }
 
 export const upload: QueryResolvers['upload'] = ({ id }) => {


### PR DESCRIPTION
# Ticket #214 

## Overview

This PR implements the following functionality:
* Staff users can only see their own uploads (user.id == upload.uploadedById)
* Organization Admin and USDR Admin users can see any upload within their Organization (user.agency.organizationId == upload.agency.organizationId)
* Testing for all 3 roles (since organization admins and USDR admins have similar permissions, I added a reusable `uploadsBelongToOrganization()` function to follow DRY convention)