### PR TITLE
CPF-213 Hide features 2024-05-13 milestone

### DIFF
--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -22,29 +22,32 @@ const Routes = () => {
         <Route path="/uploads/{id:Int}/edit" page={UploadEditUploadPage} name="editUpload" />
         <Route path="/uploads/{id:Int}" page={UploadUploadPage} name="upload" />
         <Route path="/upload-template/{id:Int}" page={UploadTemplatePage} name="uploadTemplate" />
-        {/* Agencies */}
-        <Route path="/agencies/{id:Int}/edit" page={AgencyEditAgencyPage} name="editAgency" />
-        <Route path="/agencies/{id:Int}" page={AgencyAgencyPage} name="agency" />
-        <Route path="/agencies/new" page={AgencyNewAgencyPage} name="newAgency" />
-        <Route path="/agencies" page={AgencyAgenciesPage} name="agencies" />
-        {/* Users */}
-        <PrivateSet unauthenticated="forbidden" roles={['USDR_ADMIN', 'ORGANIZATION_ADMIN']}>
-          <Route path="/users/new" page={UserNewUserPage} name="newUser" />
-          <Route path="/users/{id:Int}/edit" page={UserEditUserPage} name="editUser" />
-          <Route path="/users/{id:Int}" page={UserUserPage} name="user" />
-          <Route path="/users" page={UserUsersPage} name="users" />
-        </PrivateSet>
-        {/* Reporting Periods */}
-        <Route path="/reporting-periods/new" page={ReportingPeriodNewReportingPeriodPage} name="newReportingPeriod" />
-        <Route path="/reporting-periods/{id:Int}/edit" page={ReportingPeriodEditReportingPeriodPage} name="editReportingPeriod" />
-        <Route path="/reporting-periods/{id:Int}" page={ReportingPeriodReportingPeriodPage} name="reportingPeriod" />
-        <Route path="/reporting-periods" page={ReportingPeriodReportingPeriodsPage} name="reportingPeriods" />
-        {/* Organizations */}
+        {/* TODO: Remove USDR_ADMIN check when ready || 2024-05-13 Milestone */}
         <PrivateSet unauthenticated="forbidden" roles="USDR_ADMIN">
-          <Route path="/organizations/new" page={OrganizationNewOrganizationPage} name="newOrganization" />
-          <Route path="/organizations/{id:Int}/edit" page={OrganizationEditOrganizationPage} name="editOrganization" />
-          <Route path="/organizations/{id:Int}" page={OrganizationOrganizationPage} name="organization" />
-          <Route path="/organizations" page={OrganizationOrganizationsPage} name="organizations" />
+          {/* Agencies */}
+          <Route path="/agencies/{id:Int}/edit" page={AgencyEditAgencyPage} name="editAgency" />
+          <Route path="/agencies/{id:Int}" page={AgencyAgencyPage} name="agency" />
+          <Route path="/agencies/new" page={AgencyNewAgencyPage} name="newAgency" />
+          <Route path="/agencies" page={AgencyAgenciesPage} name="agencies" />
+          {/* Users */}
+          <PrivateSet unauthenticated="forbidden" roles={['USDR_ADMIN', 'ORGANIZATION_ADMIN']}>
+            <Route path="/users/new" page={UserNewUserPage} name="newUser" />
+            <Route path="/users/{id:Int}/edit" page={UserEditUserPage} name="editUser" />
+            <Route path="/users/{id:Int}" page={UserUserPage} name="user" />
+            <Route path="/users" page={UserUsersPage} name="users" />
+          </PrivateSet>
+          {/* Reporting Periods */}
+          <Route path="/reporting-periods/new" page={ReportingPeriodNewReportingPeriodPage} name="newReportingPeriod" />
+          <Route path="/reporting-periods/{id:Int}/edit" page={ReportingPeriodEditReportingPeriodPage} name="editReportingPeriod" />
+          <Route path="/reporting-periods/{id:Int}" page={ReportingPeriodReportingPeriodPage} name="reportingPeriod" />
+          <Route path="/reporting-periods" page={ReportingPeriodReportingPeriodsPage} name="reportingPeriods" />
+          {/* Organizations */}
+          <PrivateSet unauthenticated="forbidden" roles="USDR_ADMIN">
+            <Route path="/organizations/new" page={OrganizationNewOrganizationPage} name="newOrganization" />
+            <Route path="/organizations/{id:Int}/edit" page={OrganizationEditOrganizationPage} name="editOrganization" />
+            <Route path="/organizations/{id:Int}" page={OrganizationOrganizationPage} name="organization" />
+            <Route path="/organizations" page={OrganizationOrganizationsPage} name="organizations" />
+          </PrivateSet>
         </PrivateSet>
         {/* Forbidden page */}
         <Route path="/forbidden" page={ForbiddenPage} name="forbidden" />

--- a/web/src/components/Navigation/Navigation.tsx
+++ b/web/src/components/Navigation/Navigation.tsx
@@ -8,6 +8,7 @@ const Navigation = () => {
   const { hasRole } = useAuth()
   const canViewUsersTab =
     hasRole(ROLES.USDR_ADMIN) || hasRole(ROLES.ORGANIZATION_ADMIN)
+  const canViewAdminTabs = hasRole(ROLES.USDR_ADMIN)
 
   return (
     <div className="tabs-wrapper row">
@@ -21,58 +22,63 @@ const Navigation = () => {
             Uploads
           </NavLink>
         </Nav.Item>
-        <Nav.Item>
-          <NavLink
-            to={routes.agencies()}
-            activeClassName="active"
-            className="nav-link"
-          >
-            Agencies
-          </NavLink>
-        </Nav.Item>
-        <Nav.Item>
-          <div className="nav-link disabled">Subrecipients</div>
-        </Nav.Item>
-        {/* TODO: Use the code below when "Subrecipients" page is ready */}
-        {/* <Nav.Item>
-          <NavLink
-            to={routes.subrecipients()}
-            activeClassName="active"
-            className="nav-link"
-          >
-            Subrecipients
-          </NavLink>
-        </Nav.Item> */}
-        {canViewUsersTab && (
-          <Nav.Item>
-            <NavLink
-              to={routes.users()}
-              activeClassName="active"
-              className="nav-link"
-            >
-              Users
-            </NavLink>
-          </Nav.Item>
-        )}
-        <Nav.Item>
-          <NavLink
-            to={routes.reportingPeriods()}
-            activeClassName="active"
-            className="nav-link"
-          >
-            Reporting Periods
-          </NavLink>
-        </Nav.Item>
-        {hasRole(ROLES.USDR_ADMIN) && (
-          <Nav.Item>
-            <NavLink
-              to={routes.organizations()}
-              activeClassName="active"
-              className="nav-link"
-            >
-              Organizations
-            </NavLink>
-          </Nav.Item>
+        {/* TODO: Remove USDR_ADMIN check when ready || 2024-05-13 Milestone */}
+        {canViewAdminTabs && (
+          <>
+            <Nav.Item>
+              <NavLink
+                to={routes.agencies()}
+                activeClassName="active"
+                className="nav-link"
+              >
+                Agencies
+              </NavLink>
+            </Nav.Item>
+            <Nav.Item>
+              <div className="nav-link disabled">Subrecipients</div>
+            </Nav.Item>
+            {/* TODO: Use the code below when "Subrecipients" page is ready */}
+            {/* <Nav.Item>
+              <NavLink
+                to={routes.subrecipients()}
+                activeClassName="active"
+                className="nav-link"
+              >
+                Subrecipients
+              </NavLink>
+            </Nav.Item> */}
+            {canViewUsersTab && (
+              <Nav.Item>
+                <NavLink
+                  to={routes.users()}
+                  activeClassName="active"
+                  className="nav-link"
+                >
+                  Users
+                </NavLink>
+              </Nav.Item>
+            )}
+            <Nav.Item>
+              <NavLink
+                to={routes.reportingPeriods()}
+                activeClassName="active"
+                className="nav-link"
+              >
+                Reporting Periods
+              </NavLink>
+            </Nav.Item>
+            {hasRole(ROLES.USDR_ADMIN) && (
+              <Nav.Item>
+                <NavLink
+                  to={routes.organizations()}
+                  activeClassName="active"
+                  className="nav-link"
+                >
+                  Organizations
+                </NavLink>
+              </Nav.Item>
+            )}
+          </>
         )}
       </Nav>
     </div>

--- a/web/src/components/Upload/UploadValidationButtonGroup/UploadValidationButtonGroup.tsx
+++ b/web/src/components/Upload/UploadValidationButtonGroup/UploadValidationButtonGroup.tsx
@@ -1,4 +1,6 @@
 import Button from 'react-bootstrap/Button'
+import { useAuth } from 'web/src/auth'
+import { ROLES } from 'api/src/lib/constants'
 
 interface ValidationError {
   message: string
@@ -25,6 +27,8 @@ const UploadValidationButtonGroup = ({
   handleForceInvalidate,
   handleValidate,
 }: UploadValidationButtonGroupProps) => {
+  const { hasRole } = useAuth()
+
   /*
     If the upload has been validated, renders "Invalidate" and "Re-validate" buttons
     If the upload has been invalidated, renders the "Validate" button
@@ -56,7 +60,8 @@ const UploadValidationButtonGroup = ({
         <Button variant="primary" size="sm" onClick={handleFileDownload}>
           Download file
         </Button>{' '}
-        {latestValidation?.results && renderValidationButtons()}
+        {/* TODO: Remove USDR_ADMIN check when ready || 2024-05-13 Milestone */}
+        {(hasRole(ROLES.USDR_ADMIN) && latestValidation?.results) && renderValidationButtons()}
       </div>
     </li>
   )

--- a/web/src/components/Upload/UploadValidationButtonGroup/UploadValidationButtonGroup.tsx
+++ b/web/src/components/Upload/UploadValidationButtonGroup/UploadValidationButtonGroup.tsx
@@ -1,6 +1,6 @@
+import { ROLES } from 'api/src/lib/constants'
 import Button from 'react-bootstrap/Button'
 import { useAuth } from 'web/src/auth'
-import { ROLES } from 'api/src/lib/constants'
 
 interface ValidationError {
   message: string
@@ -61,7 +61,9 @@ const UploadValidationButtonGroup = ({
           Download file
         </Button>{' '}
         {/* TODO: Remove USDR_ADMIN check when ready || 2024-05-13 Milestone */}
-        {(hasRole(ROLES.USDR_ADMIN) && latestValidation?.results) && renderValidationButtons()}
+        {hasRole(ROLES.USDR_ADMIN) &&
+          latestValidation?.results &&
+          renderValidationButtons()}
       </div>
     </li>
   )

--- a/web/src/pages/Upload/UploadsPage/UploadsPage.tsx
+++ b/web/src/pages/Upload/UploadsPage/UploadsPage.tsx
@@ -1,10 +1,14 @@
 import { Button, ButtonGroup } from 'react-bootstrap'
+import { useAuth } from 'web/src/auth'
+import { ROLES } from 'api/src/lib/constants'
 
 import { MetaTags } from '@redwoodjs/web'
 
 import UploadsCell from 'src/components/Upload/UploadsCell'
 
 const UploadsPage = () => {
+  const { hasRole } = useAuth()
+
   return (
     <>
       <MetaTags title="Uploads Page" description="Uploads page" />
@@ -12,9 +16,12 @@ const UploadsPage = () => {
       <h2>Uploads</h2>
 
       <ButtonGroup className="my-2 mb-4">
-        <Button size="sm" variant="primary">
-          Download Empty Template
-        </Button>
+        {/* TODO: Remove USDR_ADMIN check when ready || 2024-05-13 Milestone */}
+        {hasRole(ROLES.USDR_ADMIN) && (
+          <Button size="sm" variant="primary">
+            Download Empty Template
+          </Button>
+        )}
         <Button
           size="sm"
           variant=""
@@ -23,9 +30,12 @@ const UploadsPage = () => {
         >
           Upload Workbook
         </Button>
-        <Button size="sm" variant="" className="btn-outline-primary">
-          Send Treasury and/ Audit Reports by Email
-        </Button>
+        {/* TODO: Remove USDR_ADMIN check when ready || 2024-05-13 Milestone */}
+        {hasRole(ROLES.USDR_ADMIN) && (
+          <Button size="sm" variant="" className="btn-outline-primary">
+            Send Treasury and/ Audit Reports by Email
+          </Button>
+        )}
       </ButtonGroup>
 
       <UploadsCell />

--- a/web/src/pages/Upload/UploadsPage/UploadsPage.tsx
+++ b/web/src/pages/Upload/UploadsPage/UploadsPage.tsx
@@ -1,6 +1,6 @@
+import { ROLES } from 'api/src/lib/constants'
 import { Button, ButtonGroup } from 'react-bootstrap'
 import { useAuth } from 'web/src/auth'
-import { ROLES } from 'api/src/lib/constants'
 
 import { MetaTags } from '@redwoodjs/web'
 


### PR DESCRIPTION
# Ticket #213 

## Changes

For users who are not `USDR_Admin`, this PR:
- Hides the "Send Treasury/Audit Report" and "Download Empty Template" buttons on the Uploads page
- Hides the following tabs: Agencies, Users, Subrecipients, Reporting Periods and Organizations
- Hides the "Invalidate" and "Validate" buttons on the Upload Detail page
- Secures authenticated routes that are not upload routes and wraps pages in <PrivateSet /> to make them accessible only to USDR admins

## Reverting the changes in the future
To easily find every feature, component, or route that was hidden or secured as part of this ticket, you can search for `2024-05-13 Milestone` in the repository.