### PR TITLE
fix: ensure users can only upload .xlsm files

### DIFF
--- a/web/src/components/Upload/UploadForm/UploadForm.tsx
+++ b/web/src/components/Upload/UploadForm/UploadForm.tsx
@@ -105,7 +105,7 @@ const UploadForm = (props: UploadFormProps) => {
         listClassName="rw-form-error-list"
       />
       <OrganizationPickListsCell id={props.organizationId} />
-      <FileField name="file" validation={{ required: true }} />
+      <FileField name="file" validation={{ required: true }} accept=".xlsm" />
       <FieldError name="file" className="rw-field-error" />
       <div className="rw-button-group">
         <Submit disabled={props.loading} className="rw-button rw-button-blue">


### PR DESCRIPTION
#228 

## Before
Users can select any file locally. Here's an example of being able to select a `.png`.
<img width="374" alt="image" src="https://github.com/usdigitalresponse/cpf-reporter/assets/6497366/ea09373f-43f3-41ac-b053-f4d2eeed6f1c">

## After
Users can only select files with `.xlsm` extension.
<img width="341" alt="image" src="https://github.com/usdigitalresponse/cpf-reporter/assets/6497366/56017db7-1475-4573-8cd3-7b738b93ef61">
