### PR TITLE
fix: ability to dump validation errors into json without type-errors

### DIFF
--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -1,13 +1,13 @@
 from enum import Enum
-from typing import IO, Any, Iterable, List, Optional, Tuple
+from typing import IO, Any, Iterable, List, Optional, Tuple, Union, Type, Dict
 
 from openpyxl import Workbook, load_workbook
 from openpyxl.worksheet.worksheet import Worksheet
 from pydantic import ValidationError
 from src.lib.logging import get_logger
 from src.schemas.latest.schema import (SCHEMA_BY_PROJECT, BaseModel,
-                                       CoverSheetRow, LogicSheetVersion,
-                                       SubrecipientRow)
+                                       CoverSheetRow, LogicSheetVersion, ProjectType,
+                                       SubrecipientRow, Project1ARow, Project1BRow, Project1CRow)
 
 type Errors = List[WorkbookError]
 
@@ -34,16 +34,16 @@ class WorkbookError:
     col: str
     tab: str
     field_name: str
-    severity: ErrorLevel = ErrorLevel.WARN
+    severity: str = ErrorLevel.WARN.name
 
     def __init__(
         self,
         message: str,
-        row: str,
-        col: str,
-        tab: str,
-        field_name: str,
-        severity: ErrorLevel = ErrorLevel.WARN,
+        row: str = 'N/A',
+        col: str = 'N/A',
+        tab: str = 'N/A',
+        field_name: str = 'N/A',
+        severity: str = ErrorLevel.WARN.name,
     ):
         self.message = message
         self.row = row
@@ -65,11 +65,17 @@ def get_headers(sheet: Worksheet, cell_range: str) -> tuple:
     return tuple(header_cell.value for header_cell in sheet[cell_range][0])
 
 
-def get_project_use_code(cover_sheet: Worksheet) -> str:
-    cover_header = get_headers(cover_sheet, "A1:B1")
-    cover_row = map(lambda cell: cell.value, cover_sheet[2])
-    row_dict = map_values_to_headers(cover_header, cover_row)
-    return row_dict["Project Use Code"]
+"""
+This function gets the Project Use Code from the cover sheet or uses the row provided.
+If the project use code is not found or if it does not match any of the ProjectType values, it raises an error.
+"""
+def get_project_use_code(cover_sheet: Worksheet, row_dict: Optional[Dict[str,str]] = None) -> ProjectType:
+    if not row_dict:
+        cover_header = get_headers(cover_sheet, "A1:B1")
+        cover_row = map(lambda cell: cell.value, cover_sheet[2])
+        row_dict = map_values_to_headers(cover_header, cover_row)
+    code = row_dict["Project Use Code"]
+    return ProjectType.from_project_name(code)
 
 
 """
@@ -84,7 +90,7 @@ defined in schema.py on a per-field basis, that contains the column for that par
 
 
 def get_workbook_errors_for_row(
-    SheetModelClass: BaseModel, e: ValidationError, row_num: int, sheet_name: str
+    SheetModelClass: Type[Union[CoverSheetRow, Project1ARow, Project1BRow, Project1CRow, SubrecipientRow]], e: ValidationError, row_num: int, sheet_name: str
 ) -> List[WorkbookError]:
     workbook_errors: List[WorkbookError] = []
     for error in e.errors():
@@ -99,12 +105,13 @@ def get_workbook_errors_for_row(
             'url': 'https://errors.pydantic.dev/2.6/v/string_type'
             }
         """
-        erroring_field_name = error["loc"][0]
-        erroring_field = SheetModelClass.__fields__[erroring_field_name]
-        if erroring_field and erroring_field.json_schema_extra:
-            erroring_column = erroring_field.json_schema_extra["column"]
-        else:
+        erroring_field_name: str = f'{error["loc"][0]}'
+        try:
+            erroring_column = SheetModelClass.model_json_schema()['properties'][erroring_field_name]['column']
+        except Exception as exception:
+            _logger.error(f"Encountered unexpected exception while getting column for field {erroring_field_name} with error {error}. Details: {exception}")
             erroring_column = "Unknown"
+
         message = f'Error in field {erroring_field_name}-{error["msg"]}'
         workbook_errors.append(
             WorkbookError(
@@ -113,7 +120,7 @@ def get_workbook_errors_for_row(
                 erroring_column,
                 sheet_name,
                 erroring_field_name,
-                severity=ErrorLevel.ERR,
+                severity=ErrorLevel.ERR.name,
             )
         )
     return workbook_errors
@@ -136,12 +143,12 @@ def validate(workbook: IO[bytes]) -> Tuple[Errors, Optional[str]]:
         return validate_workbook(wb)
     except Exception as e:
         _logger.error(f"Unexpected Validation Error: {e}")
-        return [
+        return ([
             WorkbookError(
                 "Unable to validate workbook. Please reach out to grants-helpdesk@usdigitalresponse.org",
-                severity=ErrorLevel.ERR,
+                severity=ErrorLevel.ERR.name,
             )
-        ]
+        ], 'Unkown')
 
     finally:
         workbook.close()
@@ -153,20 +160,22 @@ def validate_workbook(workbook: Workbook) -> Tuple[Errors, Optional[str]]:
     Args:
         workbook: The Excel workbook to validate.
     """
+    """
+    0. Validate that the workbook has all the appropriate sheets
+    """
+    errors: Errors = []
+    errors += validate_workbook_sheets(workbook)
 
     """
     1. Validate logic sheet to make sure the sheet has an appropriate version
     """
-    errors: Errors = []
     errors += validate_logic_sheet(workbook[LOGIC_SHEET])
 
     """
     2. Validate cover sheet and project selection. Pick the appropriate validator for the next step.
     """
-    cover_errors, project_schema = validate_cover_sheet(workbook[COVER_SHEET])
+    cover_errors, project_schema, project_use_code = validate_cover_sheet(workbook[COVER_SHEET])
     errors += cover_errors
-
-    project_use_code = get_project_use_code(workbook[COVER_SHEET])
 
     """
     3. Ensure all project rows are validated with the schema
@@ -180,6 +189,19 @@ def validate_workbook(workbook: Workbook) -> Tuple[Errors, Optional[str]]:
     errors += validate_subrecipient_sheet(workbook[SUBRECIPIENTS_SHEET])
 
     return (errors, project_use_code)
+
+def validate_workbook_sheets(workbook: Workbook) -> Errors:
+    errors = []
+    expected_sheets = {LOGIC_SHEET, COVER_SHEET, PROJECT_SHEET, SUBRECIPIENTS_SHEET}
+    for sheet in workbook.sheetnames:
+        if sheet not in expected_sheets:
+            errors.append(
+                WorkbookError(
+                    f"Workbook contains unexpected sheet: {sheet}",
+                    severity=ErrorLevel.ERR.name,
+                )
+            )
+    return errors
 
 
 # Accepts a workbook from openpyxl
@@ -196,7 +218,7 @@ def validate_logic_sheet(logic_sheet: Worksheet) -> Errors:
                 "B",
                 LOGIC_SHEET,
                 "version",
-                severity=ErrorLevel.WARN,
+                severity=ErrorLevel.WARN.name,
             )
         )
     return errors
@@ -204,7 +226,7 @@ def validate_logic_sheet(logic_sheet: Worksheet) -> Errors:
 
 def validate_cover_sheet(
     cover_sheet: Worksheet,
-) -> Tuple[Errors, Optional[Any]]:
+) -> Tuple[Errors, Optional[Type[Union[Project1ARow, Project1BRow, Project1CRow]]], Optional[ProjectType]]:
     errors = []
     project_schema = None
     cover_header = get_headers(cover_sheet, "A1:B1")
@@ -215,14 +237,29 @@ def validate_cover_sheet(
         CoverSheetRow(**row_dict)
     except ValidationError as e:
         errors += get_workbook_errors_for_row(CoverSheetRow, e, row_num, COVER_SHEET)
-        return (errors, None)
+        return (errors, None, None)
 
-        # This does not need to be a silent failure. This would be a critical error.
-    project_schema = SCHEMA_BY_PROJECT[row_dict["Project Use Code"]]
-    return (errors, project_schema)
+    try:
+        project_use_code: ProjectType = get_project_use_code(cover_sheet, row_dict)
+    except Exception as e:
+        _logger.error(f"Unrecognized project use code: {e}")
+        errors.append(
+            WorkbookError(
+                f"{COVER_SHEET} Sheet: Project Use Code is not recognized",
+                "2",
+                "B",
+                COVER_SHEET,
+                "Project Use Code",
+                severity=ErrorLevel.ERR.name,
+            )
+        )
+        return (errors, None, None)
+
+    project_schema = SCHEMA_BY_PROJECT[project_use_code]
+    return (errors, project_schema, project_use_code)
 
 
-def validate_project_sheet(project_sheet: Worksheet, project_schema) -> Errors:
+def validate_project_sheet(project_sheet: Worksheet, project_schema: Type[Union[Project1ARow, Project1BRow, Project1CRow]]) -> Errors:
     errors = []
     project_headers = get_headers(project_sheet, "C3:DS3")
     current_row = 12

--- a/python/src/schemas/latest/schema.py
+++ b/python/src/schemas/latest/schema.py
@@ -577,6 +577,13 @@ class ProjectType(str, Enum):
     _1B = "1B"
     _1C = "1C"
 
+    @classmethod
+    def from_project_name(cls, project_name: str) -> "ProjectType":
+        for project_type in cls:
+            if project_type.value == project_name:
+                return project_type
+        raise ValueError(f"Project name '{project_name}' is not a recognized project type.")
+
 
 SCHEMA_BY_PROJECT = {
     ProjectType._1A: Project1ARow,

--- a/python/tests/src/lib/test_workbook_validator.py
+++ b/python/tests/src/lib/test_workbook_validator.py
@@ -8,7 +8,8 @@ from src.lib.workbook_validator import (SCHEMA_BY_PROJECT, ErrorLevel,
                                         validate, validate_cover_sheet,
                                         validate_project_sheet,
                                         validate_subrecipient_sheet,
-                                        validate_workbook)
+                                        validate_workbook,
+                                        validate_workbook_sheets)
 
 SAMPLE_PROJECT_USE_CODE = "1A"
 
@@ -62,6 +63,20 @@ class TestValidateWorkbook:
         assert errors[0].severity == ErrorLevel.WARN.name
         assert errors[1].tab == "Project"
 
+class TestWorkbookSheets:
+    def test_valid_set_of_sheets(self, valid_workbook: Workbook):
+        errors = validate_workbook_sheets(valid_workbook)
+        assert errors == []
+    
+    def test_missing_sheets(self, valid_workbook: Workbook):
+        valid_workbook.remove(valid_workbook["Cover"])
+        errors = validate_workbook_sheets(valid_workbook)
+        print(errors[0].message)
+        assert errors != []
+        assert len(errors) == 1
+        assert errors[0].message == "Workbook is missing expected sheet: Cover"
+        assert errors[0].tab == "N/A"
+        assert errors[0].severity == ErrorLevel.ERR.name
 
 class TestValidateCoverSheet:
     def test_valid_cover_sheet(self, valid_coversheet: Worksheet):

--- a/python/tests/src/lib/test_workbook_validator.py
+++ b/python/tests/src/lib/test_workbook_validator.py
@@ -59,27 +59,29 @@ class TestValidateWorkbook:
         assert errors != []
         assert len(errors) == 2
         assert errors[0].tab == "Logic"
-        assert errors[0].severity == ErrorLevel.WARN
+        assert errors[0].severity == ErrorLevel.WARN.name
         assert errors[1].tab == "Project"
 
 
 class TestValidateCoverSheet:
     def test_valid_cover_sheet(self, valid_coversheet: Worksheet):
-        errors, schema = validate_cover_sheet(valid_coversheet)
+        errors, schema, project_use_code = validate_cover_sheet(valid_coversheet)
         assert errors == []
+        assert project_use_code == SAMPLE_PROJECT_USE_CODE
         assert schema == SCHEMA_BY_PROJECT[SAMPLE_PROJECT_USE_CODE]
 
     def test_invalid_cover_sheet(self, invalid_cover_sheet: Worksheet):
-        errors, schema = validate_cover_sheet(invalid_cover_sheet)
+        errors, schema, project_use_code = validate_cover_sheet(invalid_cover_sheet)
         assert errors != []
         error = errors[0]
-        print(error.message)
+        print(error)
         assert "Project use code 'INVALID' is not recognized." in error.message
         assert error.col == "B"
         assert error.row == "2"
         assert error.tab == "Cover"
-        assert error.severity == ErrorLevel.ERR
+        assert error.severity == ErrorLevel.ERR.name
         assert schema is None
+        assert project_use_code is None
 
 
 class TestValidateproject_sheet:
@@ -101,7 +103,7 @@ class TestValidateproject_sheet:
             "Error in field Identification_Number__c-String should have at most 20 characters"
             in error.message
         )
-        assert error.severity == ErrorLevel.ERR
+        assert error.severity == ErrorLevel.ERR.name
 
 
 class TestValidateSubrecipientSheet:
@@ -116,10 +118,14 @@ class TestValidateSubrecipientSheet:
         assert "String should have at least 9 characters" in error.message
         assert error.row == "13"
         assert error.col == "D"
-        assert error.severity == ErrorLevel.ERR
+        assert error.severity == ErrorLevel.ERR.name
 
 
 class TestGetProjectUseCode:
     def test_get_project_use_code(self, valid_coversheet: Worksheet):
         project_use_code = get_project_use_code(valid_coversheet)
         assert project_use_code == SAMPLE_PROJECT_USE_CODE
+
+    def test_get_project_use_code_raises_error(self, invalid_cover_sheet: Worksheet):
+        with pytest.raises(ValueError):
+            get_project_use_code(invalid_cover_sheet)

--- a/web/src/components/Upload/UploadValidationResultsTable/UploadValidationResultsTable.tsx
+++ b/web/src/components/Upload/UploadValidationResultsTable/UploadValidationResultsTable.tsx
@@ -1,9 +1,9 @@
 import Table from 'react-bootstrap/Table'
 
 enum Severity {
-  Error = 'err',
-  Warning = 'warn',
-  Info = 'info',
+  Error = 'ERR',
+  Warning = 'WARN',
+  Info = 'INFO',
 }
 interface Props {
   errors: {
@@ -46,12 +46,12 @@ const UploadValidationResultsTable = ({ errors }: Props) => {
                   <td>{i + 1}</td>
                   <td
                     className={
-                      error.severity === 'err'
+                      error.severity === Severity.Error
                         ? 'table-danger'
                         : 'table-warning'
                     }
                   >
-                    {error.severity === 'err' ? 'Error' : 'Warning'}
+                    {error.severity === Severity.Error ? 'Error' : 'Warning'}
                   </td>
                   <td>{error.message}</td>
                   <td>{error.tab}</td>


### PR DESCRIPTION
#221

https://app.datadoghq.com/logs?query=service%3Acpf-reporter&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAY8vZ_rAuaptIAAAAAAAAAAYAAAAAEFZOHZaX3ZYQUFBbkloaFJWRHJ2clFBRQAAACQAAAAAMDE4ZjJmNjctZmFjMS00ODA1LThlZjQtOGRkZmJiNjczZmJi&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1714486414068&to_ts=1714487314068&live=true

Fixes the following error:
```
[ERROR] TypeError: Object of type ErrorLevel is not JSON serializable
Traceback (most recent call last):
  File "/opt/python/lib/python3.12/site-packages/datadog_lambda/wrapper.py", line 232, in __call__
    self.response = self.func(event, context, **kwargs)
  File "/var/task/src/lib/logging.py", line 54, in inner
    def inner(*args, **kwargs):
  File "/opt/python/lib/python3.12/site-packages/ddtrace/contrib/aws_lambda/patch.py", line 120, in __call__
    self.response = self.func(*args, **kwargs)
  File "/var/task/src/lib/logging.py", line 56, in inner
    return func(*args, **kwargs)
  File "/var/task/src/functions/validate_workbook.py", line 43, in handle
    save_validation_results(
  File "/var/task/src/functions/validate_workbook.py", line 108, in save_validation_results
    serialized = json.dumps(results)
  File "/var/lang/lib/python3.12/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/var/lang/lib/python3.12/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/var/lang/lib/python3.12/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
  File "/var/lang/lib/python3.12/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
``` 