### PR TITLE
Release drafter updates

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -28,6 +28,10 @@ categories:
     collapse-after: 10
     labels:
       - bug
+  - title: 🗂️ Database Changes
+    collapse-after: 1
+    labels:
+      - database
   - title: 📖 Documentation improvements
     collapse-after: 10
     labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,8 +1,21 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/release-drafter/release-drafter/master/schema.json
+
+# NOTES:
+# - The value of the `version` action input is NOT made directly available to this template.
+# - Components like $MAJOR/$MINOR/$PATCH are derived either by parsing the `version` action input
+#   or else computed by incrementing the previous release if no `version` input is given.
+# - $RESOLVED_VERSION is the result of rendering the below `version-template` config value
+#   once the individual version number components have been derived.
+# - We compute our YYYY.inc versions separately and passed the result as `version` input;
+#   while it is NOT incremented by this action, it is still parsed into components, where:
+#   - $MAJOR = YYYY value of `version` input
+#   - $MINOR = inc value of `version` input
+#   - $PATCH will always be 0 (and is not used in this template)
+
+version-template: '$MAJOR.$MINOR'
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'release/$RESOLVED_VERSION'
 tag-prefix: 'release/'
-version-template: '2023.$MINOR'
 version-resolver:
   default: minor
 prerelease: true


### PR DESCRIPTION
This PR brings some of the recent improvements to `.github/release-drafter.yml` configuration that were initially developed for the [usdigitalresponse/usdr-gost](https://github.com/usdigitalresponse/usdr-gost) repository:
- Make automatic versioning strategy less finicky and more automatic (based on https://github.com/usdigitalresponse/usdr-gost/commit/63703195a83738f54fff49b71091d889eb4db329)
- Add a `🗂️ Database Changes` section to release notes to call out release that contain migrations (based on https://github.com/usdigitalresponse/usdr-gost/commit/8d047d7d2b3a4b81b869b99d60c51be43f6950af)