### PR TITLE
Fix: validate-deployment.yml job can't find deployment ref

### DIFF
--- a/.github/workflows/validate-deployment.yml
+++ b/.github/workflows/validate-deployment.yml
@@ -40,6 +40,8 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           ref: ${{ env.PROTECTED_REF }}
+          fetch-depth: '0'
+          filter: 'tree:0'
           show-progress: 'false'
           persist-credentials: 'false'
       - name: Count commits in candidate ref that are not in protected ref

--- a/.github/workflows/validate-deployment.yml
+++ b/.github/workflows/validate-deployment.yml
@@ -71,7 +71,7 @@ jobs:
           INVALID_CHERRY_COUNT: ${{ steps.missing-cherries.outputs.count }}
           CHERRY_FILE: ${{ steps.all-cherries.outputs.file }}
       - name: Fail validation
-        if: fromJson(steps.missing-cherries.outputs.count) > 0
+        if: success() && fromJson(steps.missing-cherries.outputs.count) > 0
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |

--- a/.github/workflows/validate-deployment.yml
+++ b/.github/workflows/validate-deployment.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           disable-sudo: true
           egress-policy: audit
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           ref: ${{ env.PROTECTED_REF }}
           show-progress: 'false'


### PR DESCRIPTION
This PR fixes an issue affecting the `validate-deployment.yml` GHA workflow in Production deployments. Currently, the settings used to `git checkout` the repository are not configured to fetch tag refs, which is how we reference Production deployments (as `refs/tags/release/<version>`). This does happen in Staging deployments because we use a branch ref (`refs/heads/main`) for the deployment commit. In addition to causing the actual validation check to fail, the problem causes a side-effect in the `Fail validation` step because the step conditional is corrupted due to missing data. 

In addition to fixing the checkout issue, this PR also adds a conditional check to the `Fail validation` step so that the rest of the step conditional is skipped if the job is already failing (in which case, we don't need to explicitly set its status as "failed").