### PR TITLE
Configure Terraform for Production environment

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -204,6 +204,7 @@ jobs:
           TF_CLI_ARGS_plan: "-var-file=${{ inputs.tf-var-file }}"
           TF_VAR_version_identifier: ${{ inputs.ref }}
           TF_VAR_git_commit_sha: ${{ inputs.ref }}
+          TF_VAR_git_repository_url: "${{github.server_url}}/${{ github.repository }}"
           TF_VAR_datadog_api_key: ${{ secrets.datadog-api-key }}
           TF_VAR_datadog_app_key: ${{ secrets.datadog-app-key }}
           TF_VAR_console_container_image: ${{ inputs.console-image }}

--- a/terraform/production.s3.tfbackend
+++ b/terraform/production.s3.tfbackend
@@ -1,0 +1,5 @@
+region         = "us-west-2"
+bucket         = "729134339726-us-west-2-terraform"
+key            = "usdr/cpfreporter/production/us-west-2/terraform.tfstate"
+dynamodb_table = "cpfreporter-terraform-lock"
+encrypt        = true

--- a/terraform/production.tfvars
+++ b/terraform/production.tfvars
@@ -1,0 +1,47 @@
+// Common
+namespace                             = "cpfreporter"
+environment                           = "production"
+ssm_service_parameters_path_prefix    = "/cpfreporter"
+ssm_deployment_parameters_path_prefix = "/cpfreporter/deploy-config"
+log_bucket_versioning                 = true
+log_retention_in_days                 = 30
+
+// Datadog
+datadog_enabled            = true
+datadog_draft              = false
+datadog_dashboards_enabled = true
+datadog_monitors_enabled   = true
+datadog_monitor_notification_handles = [
+  "thendrickson@usdigitalresponse.org",
+  "asridhar@usdigitalresponse.org",
+]
+datadog_lambda_extension_version      = "55"
+datadog_lambda_js_tracer_version      = "108"
+datadog_lambda_py_tracer_version      = "91"
+datadog_default_environment_variables = { DD_CAPTURE_LAMBDA_PAYLOAD = "true" }
+
+// RDS Postgres
+postgres_prevent_destroy           = true
+postgres_snapshot_before_destroy   = true
+postgres_apply_changes_immediately = false
+postgres_query_logging_enabled     = true
+
+// General Lambda options
+lambda_log_level  = "debug"
+lambda_js_runtime = "nodejs18.x"
+lambda_py_runtime = "python3.12"
+lambda_arch       = "x86_64"
+
+// Website
+website_domain_name   = "cpf.grants.usdigitalresponse.org"
+website_feature_flags = {}
+website_config_params = {
+  passage_app_id = "TBD"
+  auth_provider  = "passage"
+}
+
+// API Auth Provider
+auth_provider = "passage"
+
+// API
+api_domain_name = "api.cpf.grants.usdigitalresponse.org"


### PR DESCRIPTION
This PR configures Terraform state backend and input variables for targeting Production deployment environments. It also updates the `terraform-plan.yml` Github Actions workflow to provide the `github_repo_url` input variable to `terraform plan`.