### PR TITLE
CPF-122 Add Passage login element

### DIFF
--- a/web/src/pages/LoginPage/LoginPage.tsx
+++ b/web/src/pages/LoginPage/LoginPage.tsx
@@ -1,3 +1,8 @@
+import { useEffect, useRef } from 'react'
+
+import '@passageidentity/passage-elements/passage-login'
+import { PassageElement } from '@passageidentity/passage-elements'
+
 import {
   Form,
   EmailField,
@@ -5,26 +10,35 @@ import {
   FieldError,
   Label,
   SelectField,
-  SubmitHandler,
 } from '@redwoodjs/forms'
 import { MetaTags } from '@redwoodjs/web'
 
 import { useAuth } from 'src/auth'
-import { LoginEventInterface } from 'src/auth/localAuth'
 import { users } from 'src/lib/seeds'
 
 const LoginPage = () => {
+  const ref = useRef<PassageElement>()
   const { logIn } = useAuth()
-  const onSuccess = (event: SubmitHandler<LoginEventInterface>) => {
-    if (
-      window.APP_CONFIG?.webConfigParams?.auth_provider === 'local' ||
-      process.env.AUTH_PROVIDER === 'local'
-    ) {
-      logIn(event)
-    } else {
-      logIn()
-    }
+
+  const onSuccess = (event) => {
+    logIn(event)
   }
+
+  useEffect(() => {
+    if (window.APP_CONFIG?.webConfigParams?.auth_provider === 'passage') {
+      const { current } = ref
+      current.onSuccess = onSuccess
+      return () => {}
+    }
+  })
+
+  const passageAuth = (
+    <passage-login
+      ref={ref}
+      app-id={window.APP_CONFIG?.webConfigParams?.passage_app_id}
+    />
+  )
+
   const localAuth = (
     <>
       <div className="rw-segment-main">
@@ -75,6 +89,9 @@ const LoginPage = () => {
         {window.APP_CONFIG?.webConfigParams?.auth_provider === 'local' ||
         process.env.AUTH_PROVIDER === 'local'
           ? localAuth
+          : ''}
+        {window.APP_CONFIG?.webConfigParams?.auth_provider === 'passage'
+          ? passageAuth
           : ''}
       </div>
     </>

--- a/web/types/passage.d.ts
+++ b/web/types/passage.d.ts
@@ -1,0 +1,12 @@
+import { PassageElement, PassageProfileElement } from '@passageidentity/passage-elements'
+
+declare global {
+ namespace JSX {
+    interface IntrinsicElements {
+      "passage-auth": PassageElement;
+      "passage-login": PassageElement;
+      "passage-register": PassageElement;
+      "passage-profile": PassageProfileElement;
+    }
+  }
+}


### PR DESCRIPTION
# Ticket #122 

## Overview
- Adds `<passage-login>` element that renders when auth_provider is set to passage
- Modifies JSX to include passage element types according to these docs: https://docs.passage.id/embedded-login/examples-by-framework/react#typescript-support