### PR TITLE
Fix #240 environment settings & add `tf-summarize`

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -120,7 +120,7 @@ jobs:
       tf-fmt-outcome: ${{ needs.tf-plan.outputs.fmt-outcome }}
       tf-init-outcome: ${{ needs.tf-plan.outputs.init-outcome }}
       tf-plan-outcome: ${{ needs.tf-plan.outputs.plan-outcome }}
-      tf-plan-output: ${{ needs.tf-plan.outputs.plan-output }}
+      tf-plan-summary: ${{ needs.tf-plan.outputs.plan-summary-markdown }}
       tf-validate-outcome: ${{ needs.tf-plan.outputs.validate-outcome }}
       tf-validate-output: ${{ needs.tf-plan.outputs.validate-output }}
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -156,9 +156,9 @@ jobs:
       web-artifacts-path: ${{ needs.build.outputs.web-artifacts-path }}
       tf-plan-artifacts-key: ${{ needs.tf-plan.outputs.artifacts-key }}
       aws-region: us-west-2
-      concurrency-group: run_terraform-staging
-      tf-backend-config-file: staging.s3.tfbackend
-      environment-name: staging
+      concurrency-group: run_terraform-production
+      tf-backend-config-file: production.s3.tfbackend
+      environment-name: production
     secrets:
       aws-access-key-id: ${{ needs.aws-auth-apply.outputs.aws-access-key-id }}
       aws-secret-access-key: ${{ needs.aws-auth-apply.outputs.aws-secret-access-key }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -117,7 +117,7 @@ jobs:
       tf-fmt-outcome: ${{ needs.tf-plan.outputs.fmt-outcome }}
       tf-init-outcome: ${{ needs.tf-plan.outputs.init-outcome }}
       tf-plan-outcome: ${{ needs.tf-plan.outputs.plan-outcome }}
-      tf-plan-output: ${{ needs.tf-plan.outputs.plan-output }}
+      tf-plan-summary: ${{ needs.tf-plan.outputs.plan-summary-markdown }}
       tf-validate-outcome: ${{ needs.tf-plan.outputs.validate-outcome }}
       tf-validate-output: ${{ needs.tf-plan.outputs.validate-output }}
 

--- a/.github/workflows/publish-terraform-plan.yml
+++ b/.github/workflows/publish-terraform-plan.yml
@@ -114,14 +114,14 @@ jobs:
       - name: Find previous report comment
         id: find-comment
         if: inputs.write-comment && inputs.pr-number != ''
-        uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1 # v2.4.0
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         with:
           issue-number: ${{ inputs.pr-number }}
           comment-author: 'github-actions[bot]'
           body-includes: Terraform Summary
       - name: Create or update comment
         if: inputs.write-comment && inputs.pr-number != ''
-        uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2 # v3.1.0
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/publish-terraform-plan.yml
+++ b/.github/workflows/publish-terraform-plan.yml
@@ -12,7 +12,7 @@ on:
       tf-plan-outcome:
         type: string
         required: true
-      tf-plan-output:
+      tf-plan-summary:
         type: string
         required: true
       tf-validate-outcome:
@@ -43,20 +43,12 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
+      - uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
         with:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
-      - name: Reformat Plan
-        run: |
-          PLAN=$(echo "$PLAN_RAW_OUTPUT" | sed -E 's/^([[:space:]]+)([-+])/\2\1/g')
-          echo "PLAN_REFORMATTED<<EOF" >> $GITHUB_ENV
-          echo "$PLAN" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-        env:
-          PLAN_RAW_OUTPUT: ${{ inputs.tf-plan-output }}
       - name: Write the report markdown file
         run: |
           REPORT_FILE=$(mktemp -t summary.md.XXXXX)
@@ -85,11 +77,9 @@ jobs:
           </details>
 
           <details>
-          <summary>Plan Output</summary>
+          <summary>Plan Summary</summary>
 
-          ```diff
-          ${{ env.TF_PLAN_OUTPUT }}
-          ```
+          ${{ env.TF_PLAN_SUMMARY }}
 
           </details>
 
@@ -101,7 +91,7 @@ jobs:
           TF_VALIDATE_OUTCOME: ${{ inputs.tf-validate-outcome }}
           TF_VALIDATE_OUTPUT: ${{ inputs.tf-validate-output }}
           TF_PLAN_OUTCOME: ${{ inputs.tf-plan-outcome }}
-          TF_PLAN_OUTPUT: ${{ env.PLAN_REFORMATTED }}
+          TF_PLAN_SUMMARY: ${{ inputs.tf-plan-summary }}
           GH_ACTOR: ${{ github.actor }}
           GH_ACTION: ${{ github.event_name }}
           GH_WORKFLOW: ${{ github.workflow }}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -117,11 +117,11 @@ jobs:
       group: ${{ inputs.concurrency-group }}
       cancel-in-progress: false
     steps:
-      - uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
+      - uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
         with:
           disable-sudo: true
           egress-policy: audit
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           ref: ${{ inputs.ref }}
           show-progress: 'false'
@@ -146,14 +146,14 @@ jobs:
           name: ${{ inputs.python-functions-artifacts-key }}
           path: ${{ inputs.python-functions-artifacts-path }}
       - name: Download website artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: ${{ inputs.web-artifacts-key }}
           path: ${{ inputs.web-artifacts-path }}
       - name: Get project TF version
         id: get_tf_version
         run: echo "TF_VERSION=$(cat .terraform-version | tr -d '[:space:]')" | tee -a $GITHUB_OUTPUT
-      - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
+      - uses: hashicorp/setup-terraform@97f030cf6dc0b4f5e0da352c7bca9cca34579800 # v3.1.0
         with:
           terraform_version: ${{ steps.get_tf_version.outputs.TF_VERSION }}
       - name: Terraform fmt
@@ -240,7 +240,7 @@ jobs:
           rm tfplan
       - name: Store terraform artifacts
         if: success() && inputs.upload-artifacts
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: ${{ env.ARTIFACTS_KEY }}
           path: |
@@ -248,3 +248,4 @@ jobs:
             !${{ github.workspace }}/terraform/.terraform
           if-no-files-found: error
           retention-days: ${{ inputs.artifacts-retention-days }}
+          overwrite: true

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -84,6 +84,8 @@ on:
         value: ${{ jobs.do.outputs.plan_outcome }}
       plan-output:
         value: ${{ jobs.do.outputs.plan_output }}
+      plan-summary-markdown:
+        value: ${{ jobs.do.outputs.plan_summary_md }}
 
 jobs:
   do:
@@ -103,6 +105,7 @@ jobs:
       plan_exitcode: ${{ steps.plan.outputs.exitcode }}
       plan_outcome: ${{ steps.plan.outcome }}
       plan_output: ${{ steps.show_plan.outputs.stdout || steps.show_plan.outputs.stderr }}
+      plan_summary_md: ${{ steps.plan_summary.outputs.markdown_table }}
     env:
       ARTIFACTS_KEY: terraform-${{ inputs.environment-key }}-${{ inputs.ref }}
       AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
@@ -123,6 +126,8 @@ jobs:
           ref: ${{ inputs.ref }}
           show-progress: 'false'
           persist-credentials: 'false'
+      - name: Set up tf-summarize
+        uses: kishaningithub/setup-tf-summarize@b752490b135f74e59d82e656a1dab7f11a937f84 # v2.0.0
       - name: Validate workflow configuration
         if: inputs.upload-artifacts && (env.GPG_PASSPHRASE == '')
         run: |
@@ -214,6 +219,17 @@ jobs:
       - name: Generate plaintext plan
         id: show_plan
         run: terraform show tfplan
+      - name: Generate JSON plan
+        run: terraform show -json tfplan > tfplan.json
+      - name: Generate plan summary
+        id: plan_summary
+        run: |
+          SUMMARIZED_PLAN_MD=$(tf-summarize -md tfplan.json)
+          echo "markdown_table<<ENDOFTFPLANSUMMARYMARKDOWN" >> $GITHUB_OUTPUT
+          echo "$SUMMARIZED_PLAN_MD" >> $GITHUB_OUTPUT
+          echo "ENDOFTFPLANSUMMARYMARKDOWN" >> $GITHUB_OUTPUT
+          rm tfplan.json
+          echo "$SUMMARIZED_PLAN_MD"
       - name: Encrypt terraform plan file
         id: encrypt_plan
         if: success() && inputs.upload-artifacts


### PR DESCRIPTION
This PR addresses two issues:
- Corrects the environment name config values in the `tf-apply` job of the `deploy-production.yml` workflow. These changes were mistakenly left out of #240.
- Implements `tf-summarize` instead of publishing the plaintext plan to GHA step summaries and PR comments. See https://github.com/usdigitalresponse/usdr-gost/pull/2966, which these changes are based on.