### PR TITLE
Fix `tar` command for building release artifact for web

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Upload release assets
         run: |
           WEB_TAR_FILE="web-dist.tar.gz"
-          tar -czf "$WEB_TAR_FILE" -C $(dirname "$WEB_DIST_PATH")
+          tar -czf "$WEB_TAR_FILE" -C "$WEB_DIST_PATH" .
           gh release upload --clobber "$RELEASE_TAG" \
             "$WEB_TAR_FILE#Client web bundle" \
             "$PROVENANCE_FILE_CONSOLE#Console Docker image provenance attestations" \

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Upload release assets
         run: |
           WEB_TAR_FILE="web-dist.tar.gz"
-          tar -czf "$WEB_TAR_FILE" -C "$WEB_DIST_PATH" .
+          tar -czf "$WEB_TAR_FILE" -C $(dirname "$WEB_DIST_PATH") ./dist
           gh release upload --clobber "$RELEASE_TAG" \
             "$WEB_TAR_FILE#Client web bundle" \
             "$PROVENANCE_FILE_CONSOLE#Console Docker image provenance attestations" \


### PR DESCRIPTION
This PR fixes a failing `tar` command that runs in the `deploy-production.yml` GHA workflow. The updated command ensures that the tarball is created with a single top-level directory, `./dist`, which contains the web-side build output.