### PR TITLE
Fix authorizer config for APIGW integration routes & make Passage required

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -102,12 +102,14 @@ module "api_gateway" {
 
   integrations = {
     "POST /graphql" = {
-      lambda_arn     = module.lambda_function-graphql.lambda_function_arn
-      authorizer_key = "passage"
+      lambda_arn         = module.lambda_function-graphql.lambda_function_arn
+      authorizer_key     = "passage"
+      authorization_type = "JWT"
     }
     "GET /graphql" = {
-      lambda_arn     = module.lambda_function-graphql.lambda_function_arn
-      authorizer_key = "passage"
+      lambda_arn         = module.lambda_function-graphql.lambda_function_arn
+      authorizer_key     = "passage"
+      authorization_type = "JWT"
     }
   }
 

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -335,7 +335,7 @@ module "lambda_function-graphql" {
     DATABASE_SECRET_SSM_PARAMETER_PATH = aws_ssm_parameter.postgres_master_password.name
     DD_LAMBDA_HANDLER                  = "graphql.handler"
     PASSAGE_API_KEY_SECRET_ARN         = data.aws_ssm_parameter.passage_api_key_secret_arn.value
-    AUTH_PROVIDER                      = var.auth_provider
+    AUTH_PROVIDER                      = "passage"
   })
 
   // Triggers

--- a/terraform/production.tfvars
+++ b/terraform/production.tfvars
@@ -35,13 +35,10 @@ lambda_arch       = "x86_64"
 // Website
 website_domain_name   = "cpf.grants.usdigitalresponse.org"
 website_feature_flags = {}
-website_config_params = {
-  passage_app_id = "TBD"
-  auth_provider  = "passage"
-}
+website_config_params = {}
 
 // API Auth Provider
-auth_provider = "passage"
+passage_app_id = "TBD" # All auth will fail until this is replaced
 
 // API
 api_domain_name = "api.cpf.grants.usdigitalresponse.org"

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -34,13 +34,9 @@ lambda_arch       = "x86_64"
 // Website
 website_domain_name   = "staging.cpf.usdr.dev"
 website_feature_flags = {}
-website_config_params = {
-  passage_app_id = "OjNe5PvwdKm6rmcFc1WfPIBa"
-  auth_provider  = "passage"
-}
+website_config_params = {}
 
 // API Auth Provider
-auth_provider  = "passage"
 passage_app_id = "OjNe5PvwdKm6rmcFc1WfPIBa"
 
 // API

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -307,14 +307,7 @@ variable "website_config_params" {
   }
 }
 
-variable "auth_provider" {
-  description = "The authentication provider to use for the API."
-  type        = string
-  default     = ""
-}
-
 variable "passage_app_id" {
   description = "The Passage app ID to use for authentication."
   type        = string
-  default     = ""
 }

--- a/terraform/web.tf
+++ b/terraform/web.tf
@@ -135,8 +135,11 @@ locals {
   website_config_origin_path  = "config"
   website_config_object_key   = "${local.website_config_origin_path}/deploy-config.js"
   website_config_object_contents = templatefile("${path.module}/tpl/deploy-config.js", {
-    feature_flags     = jsonencode(var.website_feature_flags),
-    web_config_params = jsonencode(var.website_config_params),
+    feature_flags = jsonencode(var.website_feature_flags),
+    web_config_params = jsonencode(merge(
+      { auth_provider = "passage", passage_app_id = var.passage_app_id },
+      var.website_config_params,
+    )),
   })
   website_origin_artifacts_dist_path = coalesce(
     var.website_origin_artifacts_dist_path,


### PR DESCRIPTION
This PR makes two changes to Terraform configuration related to Passage:
1. Adds a missing `authorization_type = "JWT"` parameter to each GraphQL route entry in the API Gateway `integrations` map in Terraform. This is necessary because the [`terraform-aws-modules/apigateway-v2/aws` module](https://registry.terraform.io/modules/terraform-aws-modules/apigateway-v2/aws/2.2.2) will [default to `"NONE"`](https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/blob/dd6826c62909fe6aaf6761cb755b5124d876e80a/main.tf#L132) if this setting is not provided as explicit input (rather than, say, inferring the type from the related authorizer config). Currently, the API Gateway authorizer resource is created but never associated with any integration routes.
2. Makes Passage a requirement for Terraform deployments. In particular, it removes the optional `auth_provider` input variable for the project and makes `passage_app_id` required. This is already effectively the case, as deployments will fail if `passage_app_id` is left blank/default and GraphQL functions will not behave as expected if `auth_provider` is not set to `passage`, so we instead hard-code `passage` as the provider name and instruct Terraform to fail validation if no `passage_app_id` is provided. 
    - Note: The alternative would be to add conditional logic to make Passage integration toggle-able in Terraform deployments. However, since this would add code complexity with no immediate benefit (we do not intend to deploy to hosted environments without Passage integration), we're choosing to tighten this requirement.