### PR TITLE
fix: prisma openssl version with node 20 upgrade

### DIFF
--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = ["native", "rhel-openssl-1.0.x"]
+  binaryTargets = ["native", "rhel-openssl-3.0.x"]
   previewFeatures = ["metrics", "tracing"]
 }
 


### PR DESCRIPTION
#246 

The above PR ended up having breaking changes for prisma. This PR fixes the error.
```
2024-05-07T19:32:14.742Z	0685460a-3db4-461b-a814-ced562abc1dd	ERROR	[dd.trace_id=1407637206256682088 dd.span_id=8046729419864637656] Unhandled Promise Rejection 	{"errorType":"Runtime.UnhandledPromiseRejection","errorMessage":"PrismaClientInitializationError: Prisma Client could not locate the Query Engine for runtime \"rhel-openssl-3.0.x\".

This happened because Prisma Client was generated for \"debian-openssl-1.1.x\", but the actual deployment required \"rhel-openssl-3.0.x\".
Add \"rhel-openssl-3.0.x\" to `binaryTargets` in the \"schema.prisma\" file and run `prisma generate` after saving it:

generator client {
  provider      = \"prisma-client-js\"
  binaryTargets = [\"native\", \"rhel-openssl-1.0.x\", \"rhel-openssl-3.0.x\"]
}

The following locations have been searched:
  /var/task/node_modules/.prisma/client
  /var/task/node_modules/@prisma/client
  /home/runner/work/cpf-reporter/cpf-reporter/node_modules/@prisma/client
  /tmp/prisma-engines","reason":{"errorType":"PrismaClientInitializationError","errorMessage":"Prisma Client could not locate the Query Engine for runtime \"rhel-openssl-3.0.x\".

This happened because Prisma Client was generated for \"debian-openssl-1.1.x\", but the actual deployment required \"rhel-openssl-3.0.x\".
Add \"rhel-openssl-3.0.x\" to `binaryTargets` in the \"schema.prisma\" file and run `prisma generate` after saving it:

generator client {
  provider      = \"prisma-client-js\"
  binaryTargets = [\"native\", \"rhel-openssl-1.0.x\", \"rhel-openssl-3.0.x\"]
}

The following locations have been searched:
  /var/task/node_modules/.prisma/client
  /var/task/node_modules/@prisma/client
  /home/runner/work/cpf-reporter/cpf-reporter/node_modules/@prisma/client
  /tmp/prisma-engines","name":"PrismaClientInitializationError","clientVersion":"5.11.0","stack":["PrismaClientInitializationError: Prisma Client could not locate the Query Engine for runtime \"rhel-openssl-3.0.x\".","","This happened because Prisma Client was generated for \"debian-openssl-1.1.x\", but the actual deployment required \"rhel-openssl-3.0.x\".","Add \"rhel-openssl-3.0.x\" to `binaryTargets` in the \"schema.prisma\" file and run `prisma generate` after saving it:","","generator client {","  provider      = \"prisma-client-js\"","  binaryTargets = [\"native\", \"rhel-openssl-1.0.x\", \"rhel-openssl-3.0.x\"]","}","","The following locations have been searched:","  /var/task/node_modules/.prisma/client","  /var/task/node_modules/@prisma/client","  /home/runner/work/cpf-reporter/cpf-reporter/node_modules/@prisma/client","  /tmp/prisma-engines","    at ba (/var/task/node_modules/@prisma/client/runtime/library.js:64:805)","    at async Object.loadLibrary (/var/task/node_modules/@prisma/client/runtime/library.js:111:9992)","    at async xt.loadEngine (/var/task/node_modules/@prisma/client/runtime/library.js:112:448)","    at async xt.instantiateLibrary (/var/task/node_modules/@prisma/client/runtime/library.js:111:12602)"]},"promise":{},"stack":["Runtime.UnhandledPromiseRejection: PrismaClientInitializationError: Prisma Client could not locate the Query Engine for runtime \"rhel-openssl-3.0.x\".","","This happened because Prisma Client was generated for \"debian-openssl-1.1.x\", but the actual deployment required \"rhel-openssl-3.0.x\".","Add \"rhel-openssl-3.0.x\" to `binaryTargets` in the \"schema.prisma\" file and run `prisma generate` after saving it:","","generator client {","  provider      = \"prisma-client-js\"","  binaryTargets = [\"native\", \"rhel-openssl-1.0.x\", \"rhel-openssl-3.0.x\"]","}","","The following locations have been searched:","  /var/task/node_modules/.prisma/client","  /var/task/node_modules/@prisma/client","  /home/runner/work/cpf-reporter/cpf-reporter/node_modules/@prisma/client","  /tmp/prisma-engines","    at process.<anonymous> (file:///var/runtime/index.mjs:1276:17)","    at process.emit (node:events:518:28)","    at emit (node:internal/process/promises:150:20)","    at processPromiseRejections (node:internal/process/promises:284:27)","    at process.processTicksAndRejections (node:internal/process/task_queues:96:32)"]}
```