### PR TITLE
chore: add logging around login failures

### DIFF
--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -5,6 +5,7 @@ import { Decoded } from '@redwoodjs/api'
 import { AuthenticationError, ForbiddenError } from '@redwoodjs/graphql-server'
 
 import { db } from 'src/lib/db'
+import { logger } from 'src/lib/logger'
 
 /**
  * Represents the user attributes returned by the decoding the
@@ -64,6 +65,7 @@ export const getCurrentUser = async (
       })
 
       if (!user) {
+        logger.error(`User not found for passageId: ${passageId}`, event)
         return null
       }
 


### PR DESCRIPTION
#244 

- Issue is `getCurrentUser` returns `null` for all passage users

This PR adds logging to figure out why that might be the case.

