### PR TITLE
Add Passage app ID for Production

### DIFF
--- a/terraform/production.tfvars
+++ b/terraform/production.tfvars
@@ -38,7 +38,7 @@ website_feature_flags = {}
 website_config_params = {}
 
 // API Auth Provider
-passage_app_id = "TBD" # All auth will fail until this is replaced
+passage_app_id = "ysWup7gbVOMXhRCwzjXmDnQ8" # All auth will fail until this is replaced
 
 // API
 api_domain_name = "api.cpf.grants.usdigitalresponse.org"

--- a/terraform/production.tfvars
+++ b/terraform/production.tfvars
@@ -38,7 +38,7 @@ website_feature_flags = {}
 website_config_params = {}
 
 // API Auth Provider
-passage_app_id = "ysWup7gbVOMXhRCwzjXmDnQ8" # All auth will fail until this is replaced
+passage_app_id = "ysWup7gbVOMXhRCwzjXmDnQ8"
 
 // API
 api_domain_name = "api.cpf.grants.usdigitalresponse.org"


### PR DESCRIPTION
This PR simply updates Terraform variables for Production with the Passage app ID corresponding to that environment, removing the previous placeholder value.