### PR TITLE
fix: logging custom objects

### DIFF
--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -54,8 +54,8 @@ export const getCurrentUser = async (
       return user
     } else if (process.env.AUTH_PROVIDER === 'passage') {
       logger.info(
-        'Identifying passage authentication user from api-gateway event',
-        event
+        { custom: event },
+        'Identifying passage authentication user from api-gateway event'
       )
       const passageId = event.requestContext.authorizer?.jwt?.claims?.sub
 


### PR DESCRIPTION
#234 


Some test code I wrote to make sure what type of logging captures custom objects.
```
    const someObj1 = {
      one: 'one',
    }
    logger.info(
      'Identifying local authentication user from api-gateway event',
      someObj1
    )
    const someObj2 = {
      two: 'two',
    }
    logger.info(
      someObj2,
      'Identifying local authentication user from api-gateway event'
    )
    const someObj3 = {
      three: 'three',
    }
    logger.info(`Test someobje ${someObj3}`)

    const someObj4 = {
      four: 'four',
    }
    logger.info({ custom: someObj4 }, 'foo bar someObj')


api | 14:17:55 🐛 Processing GraphQL Parameters
api | 14:17:55 🌲 Identifying local authentication user from api-gateway event
api | 14:17:55 🌲 Identifying local authentication user from api-gateway event 
api | 🗒 Custom
api | {
api |   "two": "two"
api | }
api | 14:17:55 🌲 Test someobje [object Object]
api | 14:17:55 🌲 foo bar someObj 
api | 🗒 Custom
api | {
api |   "four": "four"
api | }
```