### PR TITLE
Revert "chore: update payload version to 2.0"

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -102,16 +102,14 @@ module "api_gateway" {
 
   integrations = {
     "POST /graphql" = {
-      lambda_arn             = module.lambda_function-graphql.lambda_function_arn
-      payload_format_version = "2.0"
-      authorizer_key         = "passage"
-      authorization_type     = "JWT"
+      lambda_arn         = module.lambda_function-graphql.lambda_function_arn
+      authorizer_key     = "passage"
+      authorization_type = "JWT"
     }
     "GET /graphql" = {
-      lambda_arn             = module.lambda_function-graphql.lambda_function_arn
-      payload_format_version = "2.0"
-      authorizer_key         = "passage"
-      authorization_type     = "JWT"
+      lambda_arn         = module.lambda_function-graphql.lambda_function_arn
+      authorizer_key     = "passage"
+      authorization_type = "JWT"
     }
   }
 


### PR DESCRIPTION
Reverts usdigitalresponse/cpf-reporter#259

This didn't end up fixing the issue since Redwoodjs graphql initialization requires payload format 1.0.

https://app.datadoghq.com/logs?query=service%3Acpf-reporter&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAY9aZjK4xmymqwAAAAAAAAAYAAAAAEFZOWFaak03QUFBajFfeldtd1I0NVFBQwAAACQAAAAAMDE4ZjVhNjYtMzlkYy00MzFlLWIxY2UtNmM2MTFiNGNhYzE2&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1715205875587&to_ts=1715206775587&live=true