### PR TITLE
fix: update passage code to use api gateway payload format v1.0

### DIFF
--- a/api/src/lib/auth.test.ts
+++ b/api/src/lib/auth.test.ts
@@ -42,7 +42,7 @@ describe('getCurrentUser', () => {
     })
   })
 
-  it('should return the user when AUTH_PROVIDER is "passage"', async () => {
+  it('should return the user when AUTH_PROVIDER is "passage" and using api gateway v1.0', async () => {
     process.env.AUTH_PROVIDER = 'passage'
     const mockUser = {
       id: 1,
@@ -55,10 +55,8 @@ describe('getCurrentUser', () => {
     const event = {
       requestContext: {
         authorizer: {
-          jwt: {
-            claims: {
-              sub: 'passage-user-id',
-            },
+          claims: {
+            sub: 'passage-user-id',
           },
         },
       },
@@ -82,9 +80,30 @@ describe('getCurrentUser', () => {
     const event = {
       requestContext: {
         authorizer: {
+          claims: {},
+        },
+      },
+    } as unknown as APIGatewayEvent
+
+    const result = await getCurrentUser(null, { token: '' }, { event })
+
+    expect(db.user.findFirst).not.toHaveBeenCalled()
+    expect(result).toBeNull()
+  })
+
+
+  it('should throw an error when using api gateway payload v2.0', async () => {
+    process.env.AUTH_PROVIDER = 'passage'
+
+    // version 2.0 structure of the API gateway should fail even if the passageId is present
+    const event = {
+      requestContext: {
+        authorizer: {
           jwt: {
-            claims: {},
-          },
+            claims: {
+              sub: 'passage-user-id',
+            },
+          }
         },
       },
     } as unknown as APIGatewayEvent

--- a/api/src/lib/auth.test.ts
+++ b/api/src/lib/auth.test.ts
@@ -91,7 +91,6 @@ describe('getCurrentUser', () => {
     expect(result).toBeNull()
   })
 
-
   it('should throw an error when using api gateway payload v2.0', async () => {
     process.env.AUTH_PROVIDER = 'passage'
 
@@ -103,7 +102,7 @@ describe('getCurrentUser', () => {
             claims: {
               sub: 'passage-user-id',
             },
-          }
+          },
         },
       },
     } as unknown as APIGatewayEvent

--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -53,11 +53,7 @@ export const getCurrentUser = async (
       user.roles = [`${user.role}`]
       return user
     } else if (process.env.AUTH_PROVIDER === 'passage') {
-      logger.info(
-        { custom: event },
-        'Identifying passage authentication user from api-gateway event'
-      )
-      const passageId = event.requestContext.authorizer?.jwt?.claims?.sub
+      const passageId = event.requestContext.authorizer?.claims?.sub
 
       if (!passageId) {
         throw new AuthenticationError('Passage ID not included.')


### PR DESCRIPTION
#244 

This PR was needed because we were able to ensure through datadog logs ([here](https://app.datadoghq.com/logs?query=service%3Acpf-reporter&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAY9aS6HPZeptIAAAAAAAAAAYAAAAAEFZOWFTOFRCQUFEM2ZnY2VTU25kWmdBRQAAACQAAAAAMDE4ZjVhYTYtMzI2OS00YjUyLWE2OWUtM2FjZWE4MzlmZDI2&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1715145264800&to_ts=1715231664800&live=true)) that API Gateway is configured to use payload format version 1.0 while the passage code was expecting version 2.0 to retrieve the authorizer claim.

Initial attempt (#259) to upgrade the payload-format-version to 2.0 had failed due to other issues ([captured in datadog here](https://app.datadoghq.com/logs?query=service%3Acpf-reporter&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAY9aafdyfSPlWgAAAAAAAAAYAAAAAEFZOWFhZmxrQUFBTldUUFVpa2ttdGdBQgAAACQAAAAAMDE4ZjVhYTYtMzI2OS00YjUyLWE2OWUtM2FjZWE4MzlmZDI2&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1715145264800&to_ts=1715231664800&live=true)) within the graphql lambda handler hence the decision was made to update the passage code instead.