### PR TITLE
chore: explicitly log error with user-auth

### DIFF
--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -77,6 +77,7 @@ export const getCurrentUser = async (
       throw new AuthenticationError('No auth provider found')
     }
   } catch (error) {
+    logger.error(error)
     logger.error({ custom: { event, error } }, 'Error getting current user.')
     return null
   }


### PR DESCRIPTION
#3052
https://github.com/usdigitalresponse/usdr-gost/issues/3052

## Current State
For some reason `error` object does not get logged into `custom` as seen in this datadog log: https://app.datadoghq.com/logs?query=service%3Acpf-reporter&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAY99B-lfrYO3hQAAAAAAAAAYAAAAAEFZOTlCLXJmQUFBMGhVeGN5NUpfSXdBRAAAACQAAAAAMDE4ZjdkMDctZWI1NC00NTVkLWIwMzktOTNiODZkMjgyYjM2&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1715788769367&to_ts=1715789669367&live=true

## State after PR is merged
the error stack is explicitly logged

### Before
```
api | 11:41:22 🚨 Error getting current user. 
api | 🗒 Custom
api | {
api |   "event": {
api |     "httpMethod": "POST",
...
...
api |     "body": "{\"operationName\":\"FindUploads\",\"variables\":{},\"query\":\"query FindUploads {\\n  uploads {\\n    id\\n    filename\\n    uploadedBy {\\n      id\\n      email\\n      __typename\\n    }\\n    agency {\\n      id\\n      code\\n      __typename\\n    }\\n    expenditureCategory {\\n      id\\n      code\\n      __typename\\n    }\\n    latestValidation {\\n      id\\n      createdAt\\n      passed\\n      results\\n      __typename\\n    }\\n    createdAt\\n    updatedAt\\n    __typename\\n  }\\n}\"}",
api |     "isBase64Encoded": false
api |   },
api |   "error": {}
api | }
```

### After
```
api | 11:41:22 🚨 foo 
api | 
api | 🚨 Error Info
api | 
api | {}
api |  
api | 🥞 Error Stack
api | 
api | Error: foo
api |     at getCurrentUser (/Users/adityasridhar/USDR/cpf-reporter/api/src/lib/auth.ts:48:13)
api |     at onContextBuilding (/Users/adityasridhar/USDR/cpf-reporter/node_modules/@redwoodjs/graphql-server/dist/plugins/useRedwoodAuthContext.js:43:54)
api |     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
api |     at async Object.contextFactory (/Users/adityasridhar/USDR/cpf-reporter/node_modules/@envelop/core/cjs/orchestrator.js:206:45)
api |     at async processRequest (/Users/adityasridhar/USDR/cpf-reporter/node_modules/graphql-yoga/cjs/process-request.js:46:26)
api |     at async YogaServer.getResultForParams (/Users/adityasridhar/USDR/cpf-reporter/node_modules/graphql-yoga/cjs/server.js:270:26)
api |     at async handle (/Users/adityasridhar/USDR/cpf-reporter/node_modules/graphql-yoga/cjs/server.js:336:25)
api |     at async graphQLYogaHandler (/Users/adityasridhar/USDR/cpf-reporter/node_modules/@redwoodjs/api-server/dist/plugins/graphql.js:73:24)
api | 
```
