### PR TITLE
Enable docker for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ TODO
 
 TODO
 
+## Local development via Docker
+
+To use Docker for local development, run the following commands:
+- `docker compose -f ./docker-compose.dev.yml build` - to build the docker images
+- `docker compose -f ./docker-compose.dev.yml up` - to run the docker containers
+- `docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash` - to go into the console container and INSIDE the container, run the following:
+  - `yarn rw prisma migrate dev` - migrates the local DB
+  - `yarn rw prisma db seed` - seeds the local DB
+- Now you should be able to open your browser to `localhost:8910` and hit the web server in the redwood container.
+
+To use Docker to run the pytest suite, run the following commands (after starting the docker containers via `up`):
+- `docker compose -f ./docker-compose.dev.yml run --rm -it python-console /bin/bash` - to go into the python container
+  - `poetry run pytest` - to run the pytest suite
+
 ## Development
 
 We recommend checking out the [Getting Started with RedwoodJS](./docs/redwood-introduction.md) guide to get familiar with our development patterns.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -56,6 +56,24 @@ services:
       - TEST_DATABASE_URL=postgresql://redwood:redwood@db:5432/redwood_test
     depends_on:
       - db
+  
+  # docker compose -f ./docker-compose.dev.yml run --rm -it python-console /bin/bash
+  python-console:
+    user: root
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+      target: python-console
+    volumes:
+      - .:/home/node/app
+    tmpfs:
+      - /tmp
+    command: "true"
+    environment:
+      - DATABASE_URL=postgresql://redwood:redwood@db:5432/redwood
+      - TEST_DATABASE_URL=postgresql://redwood:redwood@db:5432/redwood_test
+    depends_on:
+      - db
 
 volumes:
   node_modules:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,6 +45,9 @@ services:
       context: .
       dockerfile: ./Dockerfile
       target: console
+    volumes:
+      - .:/home/node/app
+      - node_modules:/home/node/app/node_modules
     tmpfs:
       - /tmp
     command: "true"

--- a/redwood.toml
+++ b/redwood.toml
@@ -9,6 +9,7 @@
   bundler = "webpack"
   title = "Redwood App"
   port = 8910
+  host = "0.0.0.0"
   # You can customize graphql and dbauth urls individually too:
   # see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
   apiUrl = "${API_URL:/.redwood/functions}"
@@ -30,6 +31,7 @@
   ]
 
 [api]
+  host = '0.0.0.0'
   port = 8911
 
 [browser]

--- a/web/public/deploy-config.js
+++ b/web/public/deploy-config.js
@@ -9,8 +9,8 @@ window.APP_CONFIG.featureFlags = {}
 // For local development only. Register feature flags for Staging and Production by
 //  configuring the `website_config_params` input variable in Terraform (see `terraform/*.tfvars`).
 window.APP_CONFIG.webConfigParams = {
-  passage_app_id: 'TBD',
-  auth_provider: 'TBD',
+  passage_app_id: 'local',
+  auth_provider: 'local',
 }
 
 window.APP_CONFIG.overrideFeatureFlag = (flagName, overrideValue) => {


### PR DESCRIPTION
As I was getting my local development environment to work with Docker, these are the changes I needed to make to be able to access `localhost:8910` from the host browser and for the seed code to work.

I also added some documentation to the README to get everything up an running in Docker.