### PR TITLE
Create global setup for Jest tests so db is present

### DIFF
--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -8,6 +8,7 @@ const config = {
     'html',
     ['text', { file: 'coverage.txt', path: './' }],
   ],
+  setupFilesAfterEnv: ['<rootDir>/api/setup-jest.ts'],
 }
 
 module.exports = config

--- a/api/setup-jest.ts
+++ b/api/setup-jest.ts
@@ -1,0 +1,5 @@
+import initializeDb from './src/lib/db'
+
+beforeAll(async () => {
+  await initializeDb()
+})

--- a/api/src/lib/auth.test.ts
+++ b/api/src/lib/auth.test.ts
@@ -8,6 +8,7 @@ jest.mock('src/lib/db', () => ({
     user: {
       findFirst: jest.fn(),
     },
+    $disconnect: jest.fn(),
   },
 }))
 

--- a/api/src/lib/db.ts
+++ b/api/src/lib/db.ts
@@ -64,6 +64,8 @@ export async function getPrismaClient() {
   return client
 }
 
+export default getPrismaClient
+
 /*
  * Instance of the Prisma Client
  */


### PR DESCRIPTION
Since a lot of Redwood internals expect `api/src/lib/db` to always be an instantiated Prisma client (ref - https://github.com/redwoodjs/redwood/issues/3707), this creates Jest setup that runs before all tests to initialize it. 