### PR TITLE
Adds a script to create new expenditure-categories, templates, reporting periods, organizations, agencies, and users

### DIFF
--- a/api/db/migrations/20240522032556_make_org_id_optional/migration.sql
+++ b/api/db/migrations/20240522032556_make_org_id_optional/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "ReportingPeriod" DROP CONSTRAINT "ReportingPeriod_organizationId_fkey";
+
+-- AlterTable
+ALTER TABLE "ReportingPeriod" ALTER COLUMN "organizationId" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "ReportingPeriod" ADD CONSTRAINT "ReportingPeriod_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -81,8 +81,8 @@ model ReportingPeriod {
   name              String
   startDate         DateTime       @db.Date
   endDate           DateTime       @db.Date
-  organizationId    Int
-  organization      Organization   @relation(fields: [organizationId], references: [id])
+  organizationId    Int?
+  organization      Organization?   @relation(fields: [organizationId], references: [id])
   inputTemplateId   Int
   inputTemplate     InputTemplate  @relation(fields: [inputTemplateId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   outputTemplateId  Int

--- a/api/src/lib/constants.ts
+++ b/api/src/lib/constants.ts
@@ -3,3 +3,9 @@ export const ROLES = {
   ORGANIZATION_STAFF: 'ORGANIZATION_STAFF',
   USDR_ADMIN: 'USDR_ADMIN',
 }
+
+export const EXPENDITURE_CATEGORIES = {
+  '1A': 'Broadband Infrastructure',
+  '1B': 'Digital Connectivity Technology',
+  '1C': 'Multi-Purpose Community Facility',
+}

--- a/api/src/services/agencies/agencies.scenarios.ts
+++ b/api/src/services/agencies/agencies.scenarios.ts
@@ -1,10 +1,10 @@
-import type { Prisma, agency } from '@prisma/client'
+import type { Prisma } from '@prisma/client'
 
 import type { ScenarioData } from '@redwoodjs/testing/api'
 
 export const standard = defineScenario<
-| Prisma.OrganizationCreateArgs
-| Prisma.AgencyCreateArgs>({
+  Prisma.OrganizationCreateArgs | Prisma.AgencyCreateArgs
+>({
   organization: {
     one: {
       data: {
@@ -17,7 +17,7 @@ export const standard = defineScenario<
       },
     },
   },
-  agency:{
+  agency: {
     one: (scenario) => ({
       data: {
         name: 'Agency1',

--- a/api/src/services/agencies/agencies.scenarios.ts
+++ b/api/src/services/agencies/agencies.scenarios.ts
@@ -2,11 +2,43 @@ import type { Prisma, agency } from '@prisma/client'
 
 import type { ScenarioData } from '@redwoodjs/testing/api'
 
-export const standard = defineScenario<Prisma.agencyCreateArgs>({
-  agency: {
-    one: { data: { name: 'String', code: 'String' } },
-    two: { data: { name: 'String', code: 'String' } },
+export const standard = defineScenario<
+| Prisma.OrganizationCreateArgs
+| Prisma.AgencyCreateArgs>({
+  organization: {
+    one: {
+      data: {
+        name: 'USDR',
+      },
+    },
+    two: {
+      data: {
+        name: 'Example Organization',
+      },
+    },
+  },
+  agency:{
+    one: (scenario) => ({
+      data: {
+        name: 'Agency1',
+        organizationId: scenario.organization.one.id,
+        code: 'A1',
+      },
+      include: {
+        organization: true,
+      },
+    }),
+    two: (scenario) => ({
+      data: {
+        name: 'Agency2',
+        organizationId: scenario.organization.two.id,
+        code: 'A2',
+      },
+      include: {
+        organization: true,
+      },
+    }),
   },
 })
-
-export type StandardScenario = ScenarioData<agency, 'agency'>
+export type StandardScenario = ScenarioData<Organization, 'organization'> &
+  ScenarioData<Agency, 'agency'>

--- a/api/src/services/agencies/agencies.test.ts
+++ b/api/src/services/agencies/agencies.test.ts
@@ -18,7 +18,7 @@ import type { StandardScenario } from './agencies.scenarios'
 
 describe('agencies', () => {
   scenario('get or creates new agencies', async (scenario: StandardScenario) => {
-    const result = await getOrCreateAgencies(scenario.organization.one, [
+    const result = await getOrCreateAgencies(scenario.organization.one.name, [
       { name: 'Agency1', code: 'A1', abbreviation: 'A1'},
       { name: 'Agency3', code: 'A3', abbreviation: 'A3'}
     ])

--- a/api/src/services/agencies/agencies.test.ts
+++ b/api/src/services/agencies/agencies.test.ts
@@ -17,17 +17,20 @@ import type { StandardScenario } from './agencies.scenarios'
 // https://redwoodjs.com/docs/testing#jest-expect-type-considerations
 
 describe('agencies', () => {
-  scenario('get or creates new agencies', async (scenario: StandardScenario) => {
-    const result = await getOrCreateAgencies(scenario.organization.one.name, [
-      { name: 'Agency1', code: 'A1', abbreviation: 'A1'},
-      { name: 'Agency3', code: 'A3', abbreviation: 'A3'}
-    ])
+  scenario(
+    'get or creates new agencies',
+    async (scenario: StandardScenario) => {
+      const result = await getOrCreateAgencies(scenario.organization.one.name, [
+        { name: 'Agency1', code: 'A1', abbreviation: 'A1' },
+        { name: 'Agency3', code: 'A3', abbreviation: 'A3' },
+      ])
 
-    expect(result.length).toEqual(2)
-    expect(result[0].name).toEqual('Agency1')
-    expect(result[0].id).toEqual(scenario.agency.one.id)
-    expect(result[1].name).toEqual('Agency3')
-  })
+      expect(result.length).toEqual(2)
+      expect(result[0].name).toEqual('Agency1')
+      expect(result[0].id).toEqual(scenario.agency.one.id)
+      expect(result[1].name).toEqual('Agency3')
+    }
+  )
   scenario('returns all agencies', async (scenario: StandardScenario) => {
     const result = await agencies()
 

--- a/api/src/services/agencies/agencies.test.ts
+++ b/api/src/services/agencies/agencies.test.ts
@@ -6,6 +6,7 @@ import {
   createAgency,
   updateAgency,
   deleteAgency,
+  getOrCreateAgencies,
 } from './agencies'
 import type { StandardScenario } from './agencies.scenarios'
 
@@ -16,6 +17,17 @@ import type { StandardScenario } from './agencies.scenarios'
 // https://redwoodjs.com/docs/testing#jest-expect-type-considerations
 
 describe('agencies', () => {
+  scenario('get or creates new agencies', async (scenario: StandardScenario) => {
+    const result = await getOrCreateAgencies(scenario.organization.one, [
+      { name: 'Agency1', code: 'A1', abbreviation: 'A1'},
+      { name: 'Agency3', code: 'A3', abbreviation: 'A3'}
+    ])
+
+    expect(result.length).toEqual(2)
+    expect(result[0].name).toEqual('Agency1')
+    expect(result[0].id).toEqual(scenario.agency.one.id)
+    expect(result[1].name).toEqual('Agency3')
+  })
   scenario('returns all agencies', async (scenario: StandardScenario) => {
     const result = await agencies()
 
@@ -25,7 +37,7 @@ describe('agencies', () => {
   scenario('returns a single agency', async (scenario: StandardScenario) => {
     const result = await agency({ id: scenario.agency.one.id })
 
-    expect(result).toEqual(scenario.agency.one)
+    expect(result.id).toEqual(scenario.agency.one.id)
   })
 
   scenario('creates a agency', async () => {

--- a/api/src/services/agencies/agencies.ts
+++ b/api/src/services/agencies/agencies.ts
@@ -51,10 +51,12 @@ export const getOrCreateAgencies = async (orgName, agencyData) => {
     try {
       logger.info(`Processing agency ${agency.name}`)
       const existingAgency = await db.agency.findFirst({
-        where: { name: agency.name, organizationId: organization.id }
+        where: { name: agency.name, organizationId: organization.id },
       })
       if (existingAgency) {
-        logger.info(`${agency.name} exists for organization ${organization.name}`)
+        logger.info(
+          `${agency.name} exists for organization ${organization.name}`
+        )
         agencies.push(existingAgency)
       } else {
         logger.info(`Creating ${agency.name}`)

--- a/api/src/services/agencies/agencies.ts
+++ b/api/src/services/agencies/agencies.ts
@@ -40,7 +40,8 @@ export const getOrCreateAgencies = async (orgName, agencyData) => {
   // It is intended to only be called via the `onboardOrganization` script
   // Hence, we hard-return if we detect a non-empty context
   if (context && Object.keys(context).length > 0) {
-    logger.error({ custom: context },
+    logger.error(
+      { custom: context },
       `This function is intended to be called via the onboardOrganization script and not via GraphQL API. Skipping...`
     )
     return
@@ -83,7 +84,10 @@ export const getOrCreateAgencies = async (orgName, agencyData) => {
     logger.info(`Agencies processed: ${agencies.length}`)
     return agencies
   } catch (error) {
-    logger.error(error, `Error getting or creating agencies for organization ${orgName}`)
+    logger.error(
+      error,
+      `Error getting or creating agencies for organization ${orgName}`
+    )
   }
 }
 

--- a/api/src/services/agencies/agencies.ts
+++ b/api/src/services/agencies/agencies.ts
@@ -36,42 +36,55 @@ export const deleteAgency: MutationResolvers['deleteAgency'] = ({ id }) => {
 }
 
 export const getOrCreateAgencies = async (orgName, agencyData) => {
-  const agencies = []
-  /*
-  {
-    name: 'Sample Name',
-    abbreviation: SAMPLEABBR,
-    code: SAMPLECODE,
+  // This function is used to create initial expenditure categories
+  // It is intended to only be called via the `onboardOrganization` script
+  // Hence, we hard-return if we detect a non-empty context
+  if (context && Object.keys(context).length > 0) {
+    logger.error({ custom: context },
+      `This function is intended to be called via the onboardOrganization script and not via GraphQL API. Skipping...`
+    )
+    return
   }
-  */
-  const organization = await db.organization.findFirst({
-    where: { name: orgName },
-  })
-  for (const agency of agencyData) {
-    try {
-      logger.info(`Processing agency ${agency.name}`)
-      const existingAgency = await db.agency.findFirst({
-        where: { name: agency.name, organizationId: organization.id },
-      })
-      if (existingAgency) {
-        logger.info(
-          `${agency.name} exists for organization ${organization.name}`
-        )
-        agencies.push(existingAgency)
-      } else {
-        logger.info(`Creating ${agency.name}`)
-        agency.organizationId = organization.id
-        const newAgency = await db.agency.create({ data: agency })
-        agencies.push(newAgency)
-      }
-    } catch (error) {
-      logger.error(`Error processing agency ${agency.name}`)
-      logger.error(error)
-      continue
+
+  try {
+    const agencies = []
+    /*
+    {
+      name: 'Sample Name',
+      abbreviation: SAMPLEABBR,
+      code: SAMPLECODE,
     }
+    */
+    const organization = await db.organization.findFirst({
+      where: { name: orgName },
+    })
+    for (const agency of agencyData) {
+      try {
+        logger.info(`Processing agency ${agency.name}`)
+        const existingAgency = await db.agency.findFirst({
+          where: { name: agency.name, organizationId: organization.id },
+        })
+        if (existingAgency) {
+          logger.info(
+            `${agency.name} exists for organization ${organization.name}`
+          )
+          agencies.push(existingAgency)
+        } else {
+          logger.info(`Creating ${agency.name}`)
+          agency.organizationId = organization.id
+          const newAgency = await db.agency.create({ data: agency })
+          agencies.push(newAgency)
+        }
+      } catch (error) {
+        logger.error(error, `Error processing agency ${agency.name}`)
+        continue
+      }
+    }
+    logger.info(`Agencies processed: ${agencies.length}`)
+    return agencies
+  } catch (error) {
+    logger.error(error, `Error getting or creating agencies for organization ${orgName}`)
   }
-  logger.info(`Agencies processed: ${agencies.length}`)
-  return agencies
 }
 
 export const agenciesByOrganization: QueryResolvers['agenciesByOrganization'] =

--- a/api/src/services/agencies/agencies.ts
+++ b/api/src/services/agencies/agencies.ts
@@ -35,7 +35,7 @@ export const deleteAgency: MutationResolvers['deleteAgency'] = ({ id }) => {
   })
 }
 
-export const getOrCreateAgencies = async (organization, agencyData) => {
+export const getOrCreateAgencies = async (orgName, agencyData) => {
   const agencies = []
   /*
   {
@@ -44,6 +44,9 @@ export const getOrCreateAgencies = async (organization, agencyData) => {
     code: SAMPLECODE,
   }
   */
+  const organization = await db.organization.findFirst({
+    where: { name: orgName },
+  })
   for (const agency of agencyData) {
     try {
       logger.info(`Processing agency ${agency.name}`)

--- a/api/src/services/expenditureCategories/expenditureCategories.test.ts
+++ b/api/src/services/expenditureCategories/expenditureCategories.test.ts
@@ -6,6 +6,7 @@ import {
   createExpenditureCategory,
   updateExpenditureCategory,
   deleteExpenditureCategory,
+  createOrSkipInitialExpenditureCategories,
 } from './expenditureCategories'
 import type { StandardScenario } from './expenditureCategories.scenarios'
 
@@ -16,6 +17,16 @@ import type { StandardScenario } from './expenditureCategories.scenarios'
 // https://redwoodjs.com/docs/testing#jest-expect-type-considerations
 
 describe('expenditureCategories', () => {
+  scenario('creates initial expenditure categories', async () => {
+    const categoriesBefore = await expenditureCategories()
+    const result = await createOrSkipInitialExpenditureCategories()
+    const categoriesAfter = await expenditureCategories()
+
+    expect(result).toEqual(undefined)
+    expect(categoriesBefore.length).toEqual(2)
+    expect(categoriesAfter.length).toEqual(5)
+  })
+
   scenario(
     'returns all expenditureCategories',
     async (scenario: StandardScenario) => {

--- a/api/src/services/expenditureCategories/expenditureCategories.ts
+++ b/api/src/services/expenditureCategories/expenditureCategories.ts
@@ -1,9 +1,9 @@
+import type { Prisma } from '@prisma/client'
 import type {
   QueryResolvers,
   MutationResolvers,
   ExpenditureCategoryRelationResolvers,
 } from 'types/graphql'
-import type { Prisma } from '@prisma/client'
 
 import { db } from 'src/lib/db'
 import { logger } from 'src/lib/logger'
@@ -39,9 +39,8 @@ export const createOrSkipInitialExpenditureCategories = async () => {
   await Promise.all(
     expendtitureCategoriesData.map(
       async (data: Prisma.ExpenditureCategoryCreateArgs['data']) => {
-        const existingExpenditureCategory = await db.expenditureCategory.findFirst(
-          { where: { name: data.name } }
-        )
+        const existingExpenditureCategory =
+          await db.expenditureCategory.findFirst({ where: { name: data.name } })
         if (existingExpenditureCategory) {
           logger.info(
             `Expenditure category ${data.name} already exists. Skipping...`

--- a/api/src/services/expenditureCategories/expenditureCategories.ts
+++ b/api/src/services/expenditureCategories/expenditureCategories.ts
@@ -5,9 +5,9 @@ import type {
   ExpenditureCategoryRelationResolvers,
 } from 'types/graphql'
 
+import { EXPENDITURE_CATEGORIES } from 'src/lib/constants'
 import { db } from 'src/lib/db'
 import { logger } from 'src/lib/logger'
-import { EXPENDITURE_CATEGORIES } from 'src/lib/constants'
 
 export const expenditureCategories: QueryResolvers['expenditureCategories'] =
   () => {
@@ -27,21 +27,24 @@ export const createOrSkipInitialExpenditureCategories = async () => {
   // It is intended to only be called via the `onboardOrganization` script
   // Hence, we hard-return if we detect a non-empty context
   if (context && Object.keys(context).length > 0) {
-    logger.error({ custom: context },
+    logger.error(
+      { custom: context },
       `This function is intended to be called via the onboardOrganization script and not via GraphQL API. Skipping...`
     )
     return
   }
 
   try {
-    const expenditureCategoriesData = Object.entries(EXPENDITURE_CATEGORIES).map(
-      ([code, name]) => ({ code, name })
-    )
+    const expenditureCategoriesData = Object.entries(
+      EXPENDITURE_CATEGORIES
+    ).map(([code, name]) => ({ code, name }))
     await Promise.all(
       expenditureCategoriesData.map(
         async (data: Prisma.ExpenditureCategoryCreateArgs['data']) => {
           const existingExpenditureCategory =
-            await db.expenditureCategory.findFirst({ where: { name: data.name } })
+            await db.expenditureCategory.findFirst({
+              where: { name: data.name },
+            })
           if (existingExpenditureCategory) {
             logger.info(
               `Expenditure category ${data.name} already exists. Skipping...`
@@ -54,7 +57,10 @@ export const createOrSkipInitialExpenditureCategories = async () => {
       )
     )
   } catch (error) {
-    logger.error(error, 'Error creating or skipping initial expenditure categories')
+    logger.error(
+      error,
+      'Error creating or skipping initial expenditure categories'
+    )
   }
 }
 

--- a/api/src/services/expenditureCategories/expenditureCategories.ts
+++ b/api/src/services/expenditureCategories/expenditureCategories.ts
@@ -3,8 +3,10 @@ import type {
   MutationResolvers,
   ExpenditureCategoryRelationResolvers,
 } from 'types/graphql'
+import type { Prisma } from '@prisma/client'
 
 import { db } from 'src/lib/db'
+import { logger } from 'src/lib/logger'
 
 export const expenditureCategories: QueryResolvers['expenditureCategories'] =
   () => {
@@ -17,6 +19,40 @@ export const expenditureCategory: QueryResolvers['expenditureCategory'] = ({
   return db.expenditureCategory.findUnique({
     where: { id },
   })
+}
+
+export const createOrSkipInitialExpenditureCategories = async () => {
+  const expendtitureCategoriesData = [
+    {
+      name: '1A - Broadband Infrastructure',
+      code: '1A',
+    },
+    {
+      name: '1B - Digital Connectivity Technology',
+      code: '1B',
+    },
+    {
+      name: '1C - Multi-Purpose Community Facility',
+      code: '1C',
+    },
+  ]
+  await Promise.all(
+    expendtitureCategoriesData.map(
+      async (data: Prisma.ExpenditureCategoryCreateArgs['data']) => {
+        const existingExpenditureCategory = await db.expenditureCategory.findFirst(
+          { where: { name: data.name } }
+        )
+        if (existingExpenditureCategory) {
+          logger.info(
+            `Expenditure category ${data.name} already exists. Skipping...`
+          )
+          return
+        }
+        const record = await db.expenditureCategory.create({ data })
+        logger.info(`Created expenditure category ${record.name}`)
+      }
+    )
+  )
 }
 
 export const createExpenditureCategory: MutationResolvers['createExpenditureCategory'] =

--- a/api/src/services/inputTemplates/inputTemplates.test.ts
+++ b/api/src/services/inputTemplates/inputTemplates.test.ts
@@ -6,6 +6,7 @@ import {
   createInputTemplate,
   updateInputTemplate,
   deleteInputTemplate,
+  getOrCreateInputTemplate,
 } from './inputTemplates'
 import type { StandardScenario } from './inputTemplates.scenarios'
 
@@ -16,6 +17,19 @@ import type { StandardScenario } from './inputTemplates.scenarios'
 // https://redwoodjs.com/docs/testing#jest-expect-type-considerations
 
 describe('inputTemplates', () => {
+  scenario('gets or creates input template', async () => {
+    const result = await getOrCreateInputTemplate({
+      name: 'NEW TEMPLATE',
+      version: '1.0.0',
+      effectiveDate: '2023-12-07T18:17:24.374Z',
+    })
+
+    expect(result.name).toEqual('NEW TEMPLATE')
+    expect(result.version).toEqual('1.0.0')
+    expect(result.effectiveDate).toEqual(new Date('2023-12-07T00:00:00.000Z'))
+    expect(result.updatedAt).toBeDefined()
+  })
+
   scenario('returns all inputTemplates', async (scenario: StandardScenario) => {
     const result = await inputTemplates()
 

--- a/api/src/services/inputTemplates/inputTemplates.ts
+++ b/api/src/services/inputTemplates/inputTemplates.ts
@@ -25,8 +25,10 @@ export const getOrCreateInputTemplate = async (inputTemplateInfo) => {
       where: { name: inputTemplateInfo.name },
     })
     if (existingInputTemplate) {
+      logger.info(`Input template ${inputTemplateInfo.name} already exists`)
       inputTemplateRecord = existingInputTemplate
     } else {
+      logger.info(`Creating ${inputTemplateInfo.name}`)
       const data = inputTemplateInfo
       inputTemplateRecord = await db.inputTemplate.create({
         data,

--- a/api/src/services/inputTemplates/inputTemplates.ts
+++ b/api/src/services/inputTemplates/inputTemplates.ts
@@ -18,6 +18,16 @@ export const inputTemplate: QueryResolvers['inputTemplate'] = ({ id }) => {
 }
 
 export const getOrCreateInputTemplate = async (inputTemplateInfo) => {
+  // This function is used to create initial expenditure categories
+  // It is intended to only be called via the `onboardOrganization` script
+  // Hence, we hard-return if we detect a non-empty context
+  if (context && Object.keys(context).length > 0) {
+    logger.error({ custom: context },
+      `This function is intended to be called via the onboardOrganization script and not via GraphQL API. Skipping...`
+    )
+    return
+  }
+
   try {
     let inputTemplateRecord
 
@@ -36,8 +46,7 @@ export const getOrCreateInputTemplate = async (inputTemplateInfo) => {
     }
     return inputTemplateRecord
   } catch (error) {
-    logger.error(`Error creating input template ${inputTemplateInfo.name}`)
-    logger.error(error)
+    logger.error(error, `Error getting or creating input template ${inputTemplateInfo.name}`)
   }
 }
 

--- a/api/src/services/inputTemplates/inputTemplates.ts
+++ b/api/src/services/inputTemplates/inputTemplates.ts
@@ -22,7 +22,8 @@ export const getOrCreateInputTemplate = async (inputTemplateInfo) => {
   // It is intended to only be called via the `onboardOrganization` script
   // Hence, we hard-return if we detect a non-empty context
   if (context && Object.keys(context).length > 0) {
-    logger.error({ custom: context },
+    logger.error(
+      { custom: context },
       `This function is intended to be called via the onboardOrganization script and not via GraphQL API. Skipping...`
     )
     return
@@ -46,7 +47,10 @@ export const getOrCreateInputTemplate = async (inputTemplateInfo) => {
     }
     return inputTemplateRecord
   } catch (error) {
-    logger.error(error, `Error getting or creating input template ${inputTemplateInfo.name}`)
+    logger.error(
+      error,
+      `Error getting or creating input template ${inputTemplateInfo.name}`
+    )
   }
 }
 

--- a/api/src/services/inputTemplates/inputTemplates.ts
+++ b/api/src/services/inputTemplates/inputTemplates.ts
@@ -5,6 +5,7 @@ import type {
 } from 'types/graphql'
 
 import { db } from 'src/lib/db'
+import { logger } from 'src/lib/logger'
 
 export const inputTemplates: QueryResolvers['inputTemplates'] = () => {
   return db.inputTemplate.findMany()
@@ -14,6 +15,28 @@ export const inputTemplate: QueryResolvers['inputTemplate'] = ({ id }) => {
   return db.inputTemplate.findUnique({
     where: { id },
   })
+}
+
+export const getOrCreateInputTemplate = async (inputTemplateInfo) => {
+  try {
+    let inputTemplateRecord
+
+    const existingInputTemplate = await db.inputTemplate.findFirst({
+      where: { name: inputTemplateInfo.name },
+    })
+    if (existingInputTemplate) {
+      inputTemplateRecord = existingInputTemplate
+    } else {
+      const data = inputTemplateInfo
+      inputTemplateRecord = await db.inputTemplate.create({
+        data,
+      })
+    }
+    return inputTemplateRecord
+  } catch (error) {
+    logger.error(`Error creating input template ${inputTemplateInfo.name}`)
+    logger.error(error)
+  }
 }
 
 export const createInputTemplate: MutationResolvers['createInputTemplate'] = ({

--- a/api/src/services/organizations/organizations.scenarios.ts
+++ b/api/src/services/organizations/organizations.scenarios.ts
@@ -2,10 +2,34 @@ import type { Prisma, Organization } from '@prisma/client'
 
 import type { ScenarioData } from '@redwoodjs/testing/api'
 
-export const standard = defineScenario<Prisma.OrganizationCreateArgs>({
+export const standard = defineScenario<Prisma.OrganizationCreateArgs | Prisma.ReportingPeriodCreateArgs>({
+  reportingPeriod: {
+    one: {
+      data: {
+        name: 'Reporting Period 1',
+        startDate: '2024-01-12T15:48:11.499Z',
+        endDate: '2024-01-12T15:48:11.499Z',
+        organization: { create: { name: 'String' } },
+        inputTemplate: {
+          create: {
+            name: 'String',
+            version: 'String',
+            effectiveDate: '2024-01-12T15:48:11.499Z',
+          },
+        },
+        outputTemplate: {
+          create: {
+            name: 'String',
+            version: 'String',
+            effectiveDate: '2024-01-12T15:48:11.499Z',
+          },
+        },
+      },
+    },
+  },
   organization: {
-    one: { data: { name: 'USDR1' } },
-    two: { data: { name: 'USDR2' } },
+    one: (scenario) => ({ data: { name: 'USDR1', preferences: { current_reporting_period_id: scenario.reportingPeriod.one.id } } }),
+    two: (scenario) => ({ data: { name: 'USDR2', preferences: { current_reporting_period_id: scenario.reportingPeriod.one.id } } }),
   },
 })
 

--- a/api/src/services/organizations/organizations.scenarios.ts
+++ b/api/src/services/organizations/organizations.scenarios.ts
@@ -4,8 +4,8 @@ import type { ScenarioData } from '@redwoodjs/testing/api'
 
 export const standard = defineScenario<Prisma.OrganizationCreateArgs>({
   organization: {
-    one: { data: { name: 'String' } },
-    two: { data: { name: 'String' } },
+    one: { data: { name: 'USDR1' } },
+    two: { data: { name: 'USDR2' } },
   },
 })
 

--- a/api/src/services/organizations/organizations.scenarios.ts
+++ b/api/src/services/organizations/organizations.scenarios.ts
@@ -2,7 +2,9 @@ import type { Prisma, Organization } from '@prisma/client'
 
 import type { ScenarioData } from '@redwoodjs/testing/api'
 
-export const standard = defineScenario<Prisma.OrganizationCreateArgs | Prisma.ReportingPeriodCreateArgs>({
+export const standard = defineScenario<
+  Prisma.OrganizationCreateArgs | Prisma.ReportingPeriodCreateArgs
+>({
   reportingPeriod: {
     one: {
       data: {
@@ -28,8 +30,22 @@ export const standard = defineScenario<Prisma.OrganizationCreateArgs | Prisma.Re
     },
   },
   organization: {
-    one: (scenario) => ({ data: { name: 'USDR1', preferences: { current_reporting_period_id: scenario.reportingPeriod.one.id } } }),
-    two: (scenario) => ({ data: { name: 'USDR2', preferences: { current_reporting_period_id: scenario.reportingPeriod.one.id } } }),
+    one: (scenario) => ({
+      data: {
+        name: 'USDR1',
+        preferences: {
+          current_reporting_period_id: scenario.reportingPeriod.one.id,
+        },
+      },
+    }),
+    two: (scenario) => ({
+      data: {
+        name: 'USDR2',
+        preferences: {
+          current_reporting_period_id: scenario.reportingPeriod.one.id,
+        },
+      },
+    }),
   },
 })
 

--- a/api/src/services/organizations/organizations.test.ts
+++ b/api/src/services/organizations/organizations.test.ts
@@ -17,17 +17,30 @@ import type { StandardScenario } from './organizations.scenarios'
 // https://redwoodjs.com/docs/testing#jest-expect-type-considerations
 
 describe('organizations', () => {
-  scenario('creates or gets an organization', async (scenario: StandardScenario) => {
-    const resultGet = await getOrCreateOrganization('USDR1', 'Reporting Period 1')
-    const resultCreate = await getOrCreateOrganization('USDR3', 'Reporting Period 1')
-    const resultError = await getOrCreateOrganization('USDR5', 'NO PERIOD')
+  scenario(
+    'creates or gets an organization',
+    async (scenario: StandardScenario) => {
+      const resultGet = await getOrCreateOrganization(
+        'USDR1',
+        'Reporting Period 1'
+      )
+      const resultCreate = await getOrCreateOrganization(
+        'USDR3',
+        'Reporting Period 1'
+      )
+      const resultError = await getOrCreateOrganization('USDR5', 'NO PERIOD')
 
-    expect(resultGet.id).toEqual(scenario.organization.one.id)
-    expect(resultCreate.name).toEqual('USDR3')
-    expect([scenario.organization.one.id, scenario.organization.two.id].includes(resultCreate.id)).toBe(false)
-    expect(resultError).toBe(undefined)
-  })
-  scenario('returns all organizations', async (scenario: StandardScenario) => {
+      expect(resultGet.id).toEqual(scenario.organization.one.id)
+      expect(resultCreate.name).toEqual('USDR3')
+      expect(
+        [scenario.organization.one.id, scenario.organization.two.id].includes(
+          resultCreate.id
+        )
+      ).toBe(false)
+      expect(resultError).toBe(undefined)
+    }
+  )
+  scenario('returns all organizations', async () => {
     const result = await organizations()
 
     expect(result.length).toEqual(3)

--- a/api/src/services/organizations/organizations.test.ts
+++ b/api/src/services/organizations/organizations.test.ts
@@ -18,17 +18,19 @@ import type { StandardScenario } from './organizations.scenarios'
 
 describe('organizations', () => {
   scenario('creates or gets an organization', async (scenario: StandardScenario) => {
-    const resultGet = await getOrCreateOrganization('USDR1')
-    const resultCreate = await getOrCreateOrganization('USDR3')
+    const resultGet = await getOrCreateOrganization('USDR1', 'Reporting Period 1')
+    const resultCreate = await getOrCreateOrganization('USDR3', 'Reporting Period 1')
+    const resultError = await getOrCreateOrganization('USDR5', 'NO PERIOD')
 
     expect(resultGet.id).toEqual(scenario.organization.one.id)
     expect(resultCreate.name).toEqual('USDR3')
     expect([scenario.organization.one.id, scenario.organization.two.id].includes(resultCreate.id)).toBe(false)
+    expect(resultError).toBe(undefined)
   })
   scenario('returns all organizations', async (scenario: StandardScenario) => {
     const result = await organizations()
 
-    expect(result.length).toEqual(Object.keys(scenario.organization).length)
+    expect(result.length).toEqual(3)
   })
 
   scenario(

--- a/api/src/services/organizations/organizations.test.ts
+++ b/api/src/services/organizations/organizations.test.ts
@@ -6,6 +6,7 @@ import {
   createOrganization,
   updateOrganization,
   deleteOrganization,
+  getOrCreateOrganization,
 } from './organizations'
 import type { StandardScenario } from './organizations.scenarios'
 
@@ -16,6 +17,14 @@ import type { StandardScenario } from './organizations.scenarios'
 // https://redwoodjs.com/docs/testing#jest-expect-type-considerations
 
 describe('organizations', () => {
+  scenario('creates or gets an organization', async (scenario: StandardScenario) => {
+    const resultGet = await getOrCreateOrganization('USDR1')
+    const resultCreate = await getOrCreateOrganization('USDR3')
+
+    expect(resultGet.id).toEqual(scenario.organization.one.id)
+    expect(resultCreate.name).toEqual('USDR3')
+    expect([scenario.organization.one.id, scenario.organization.two.id].includes(resultCreate.id)).toBe(false)
+  })
   scenario('returns all organizations', async (scenario: StandardScenario) => {
     const result = await organizations()
 

--- a/api/src/services/organizations/organizations.ts
+++ b/api/src/services/organizations/organizations.ts
@@ -3,6 +3,7 @@ import type {
   MutationResolvers,
   OrganizationRelationResolvers,
 } from 'types/graphql'
+import type { Prisma } from '@prisma/client'
 
 import { db } from 'src/lib/db'
 import { logger } from 'src/lib/logger'
@@ -26,6 +27,16 @@ export const createOrganization: MutationResolvers['createOrganization'] = ({
 }
 
 export const getOrCreateOrganization = async (orgName, reportingPeriodName) => {
+  // This function is used to create initial expenditure categories
+  // It is intended to only be called via the `onboardOrganization` script
+  // Hence, we hard-return if we detect a non-empty context
+  if (context && Object.keys(context).length > 0) {
+    logger.error({ custom: context },
+      `This function is intended to be called via the onboardOrganization script and not via GraphQL API. Skipping...`
+    )
+    return
+  }
+
   try {
     let orgRecord
 
@@ -58,8 +69,7 @@ export const getOrCreateOrganization = async (orgName, reportingPeriodName) => {
     }
     return orgRecord
   } catch (error) {
-    logger.error(`Error creating organization: ${orgName}`)
-    logger.error(error)
+    logger.error(error, `Error getting or creating organization: ${orgName}`)
   }
 }
 

--- a/api/src/services/organizations/organizations.ts
+++ b/api/src/services/organizations/organizations.ts
@@ -1,9 +1,9 @@
+import type { Prisma } from '@prisma/client'
 import type {
   QueryResolvers,
   MutationResolvers,
   OrganizationRelationResolvers,
 } from 'types/graphql'
-import type { Prisma } from '@prisma/client'
 
 import { db } from 'src/lib/db'
 import { logger } from 'src/lib/logger'
@@ -31,7 +31,8 @@ export const getOrCreateOrganization = async (orgName, reportingPeriodName) => {
   // It is intended to only be called via the `onboardOrganization` script
   // Hence, we hard-return if we detect a non-empty context
   if (context && Object.keys(context).length > 0) {
-    logger.error({ custom: context },
+    logger.error(
+      { custom: context },
       `This function is intended to be called via the onboardOrganization script and not via GraphQL API. Skipping...`
     )
     return

--- a/api/src/services/organizations/organizations.ts
+++ b/api/src/services/organizations/organizations.ts
@@ -5,6 +5,7 @@ import type {
 } from 'types/graphql'
 
 import { db } from 'src/lib/db'
+import { logger } from 'src/lib/logger'
 
 export const organizations: QueryResolvers['organizations'] = () => {
   return db.organization.findMany()
@@ -22,6 +23,26 @@ export const createOrganization: MutationResolvers['createOrganization'] = ({
   return db.organization.create({
     data: input,
   })
+}
+
+export const getOrCreateOrganization = async (orgName) => {
+  let orgRecord
+  const existingOrganization = await db.organization.findFirst({
+    where: { name: orgName },
+  })
+  if (existingOrganization) {
+    logger.info(`Organization ${orgName} already exists`)
+    orgRecord = existingOrganization
+  } else {
+    logger.info(`Creating ${orgName}`)
+    const data: Prisma.OrganizationCreateArgs['data'] = {
+      name: orgName,
+    }
+    orgRecord = await db.organization.create({
+      data,
+    })
+  }
+  return orgRecord
 }
 
 export const createOrganizationAgencyAdmin: MutationResolvers['createOrganizationAgencyAdmin'] =

--- a/api/src/services/outputTemplates/outputTemplates.test.ts
+++ b/api/src/services/outputTemplates/outputTemplates.test.ts
@@ -6,6 +6,7 @@ import {
   createOutputTemplate,
   updateOutputTemplate,
   deleteOutputTemplate,
+  getOrCreateOutputTemplate,
 } from './outputTemplates'
 import type { StandardScenario } from './outputTemplates.scenarios'
 
@@ -16,6 +17,19 @@ import type { StandardScenario } from './outputTemplates.scenarios'
 // https://redwoodjs.com/docs/testing#jest-expect-type-considerations
 
 describe('outputTemplates', () => {
+  scenario('gets or creates output template', async () => {
+    const result = await getOrCreateOutputTemplate({
+      name: 'NEW TEMPLATE',
+      version: '1.0.0',
+      effectiveDate: '2023-12-07T18:17:34.958Z',
+    })
+
+    expect(result.name).toEqual('NEW TEMPLATE')
+    expect(result.version).toEqual('1.0.0')
+    expect(result.effectiveDate).toEqual(new Date('2023-12-07T00:00:00.000Z'))
+    expect(result.updatedAt).toBeDefined()
+  })
+
   scenario(
     'returns all outputTemplates',
     async (scenario: StandardScenario) => {

--- a/api/src/services/outputTemplates/outputTemplates.ts
+++ b/api/src/services/outputTemplates/outputTemplates.ts
@@ -5,6 +5,7 @@ import type {
 } from 'types/graphql'
 
 import { db } from 'src/lib/db'
+import { logger } from 'src/lib/logger'
 
 export const outputTemplates: QueryResolvers['outputTemplates'] = () => {
   return db.outputTemplate.findMany()
@@ -14,6 +15,28 @@ export const outputTemplate: QueryResolvers['outputTemplate'] = ({ id }) => {
   return db.outputTemplate.findUnique({
     where: { id },
   })
+}
+
+export const getOrCreateOutputTemplate = async (outputTemplateInfo) => {
+  try {
+    let outputTemplateRecord
+
+    const existingOutputTemplate = await db.outputTemplate.findFirst({
+      where: { name: outputTemplateInfo.name },
+    })
+    if (existingOutputTemplate) {
+      outputTemplateRecord = existingOutputTemplate
+    } else {
+      const data = outputTemplateInfo
+      outputTemplateRecord = await db.outputTemplate.create({
+        data,
+      })
+    }
+    return outputTemplateRecord
+  } catch (error) {
+    logger.error(`Error creating output template ${outputTemplateInfo.name}`)
+    logger.error(error)
+  }
 }
 
 export const createOutputTemplate: MutationResolvers['createOutputTemplate'] =

--- a/api/src/services/outputTemplates/outputTemplates.ts
+++ b/api/src/services/outputTemplates/outputTemplates.ts
@@ -22,7 +22,8 @@ export const getOrCreateOutputTemplate = async (outputTemplateInfo) => {
   // It is intended to only be called via the `onboardOrganization` script
   // Hence, we hard-return if we detect a non-empty context
   if (context && Object.keys(context).length > 0) {
-    logger.error({ custom: context },
+    logger.error(
+      { custom: context },
       `This function is intended to be called via the onboardOrganization script and not via GraphQL API. Skipping...`
     )
     return
@@ -46,7 +47,10 @@ export const getOrCreateOutputTemplate = async (outputTemplateInfo) => {
     }
     return outputTemplateRecord
   } catch (error) {
-    logger.error(error, `Error getting or creating output template ${outputTemplateInfo.name}`)
+    logger.error(
+      error,
+      `Error getting or creating output template ${outputTemplateInfo.name}`
+    )
   }
 }
 

--- a/api/src/services/outputTemplates/outputTemplates.ts
+++ b/api/src/services/outputTemplates/outputTemplates.ts
@@ -18,6 +18,16 @@ export const outputTemplate: QueryResolvers['outputTemplate'] = ({ id }) => {
 }
 
 export const getOrCreateOutputTemplate = async (outputTemplateInfo) => {
+  // This function is used to create initial expenditure categories
+  // It is intended to only be called via the `onboardOrganization` script
+  // Hence, we hard-return if we detect a non-empty context
+  if (context && Object.keys(context).length > 0) {
+    logger.error({ custom: context },
+      `This function is intended to be called via the onboardOrganization script and not via GraphQL API. Skipping...`
+    )
+    return
+  }
+
   try {
     let outputTemplateRecord
 
@@ -36,8 +46,7 @@ export const getOrCreateOutputTemplate = async (outputTemplateInfo) => {
     }
     return outputTemplateRecord
   } catch (error) {
-    logger.error(`Error creating output template ${outputTemplateInfo.name}`)
-    logger.error(error)
+    logger.error(error, `Error getting or creating output template ${outputTemplateInfo.name}`)
   }
 }
 

--- a/api/src/services/outputTemplates/outputTemplates.ts
+++ b/api/src/services/outputTemplates/outputTemplates.ts
@@ -25,8 +25,10 @@ export const getOrCreateOutputTemplate = async (outputTemplateInfo) => {
       where: { name: outputTemplateInfo.name },
     })
     if (existingOutputTemplate) {
+      logger.info(`Output template ${outputTemplateInfo.name} already exists`)
       outputTemplateRecord = existingOutputTemplate
     } else {
+      logger.info(`Creating ${outputTemplateInfo.name}`)
       const data = outputTemplateInfo
       outputTemplateRecord = await db.outputTemplate.create({
         data,

--- a/api/src/services/passage/passage.test.ts
+++ b/api/src/services/passage/passage.test.ts
@@ -59,8 +59,8 @@ describe('Passage User Management', () => {
       )
 
       expect(mockedLogger.error).toHaveBeenCalledWith(
-        'Failed to create Passage user',
-        error
+        error,
+        'Failed to create Passage user'
       )
     })
   })
@@ -88,8 +88,8 @@ describe('Passage User Management', () => {
       )
 
       expect(mockedLogger.error).toHaveBeenCalledWith(
-        'Failed to delete Passage user',
-        error
+        error,
+        'Failed to delete Passage user'
       )
     })
   })

--- a/api/src/services/passage/passage.ts
+++ b/api/src/services/passage/passage.ts
@@ -15,7 +15,7 @@ const getPassageClient = async () => {
 
     return new Passage(passageConfig)
   } catch (error) {
-    logger.error('Error getting Passage client:', error)
+    logger.error(error, 'Error getting Passage client')
     throw new Error('Error getting Passage client')
   }
 }
@@ -27,7 +27,7 @@ export const createPassageUser = async (email: string) => {
     const activatedUser = await passage.user.activate(newUser.id)
     return activatedUser
   } catch (error) {
-    logger.error('Failed to create Passage user', error)
+    logger.error(error, 'Failed to create Passage user')
     throw new Error('Failed to create Passage user', error)
   }
 }
@@ -37,7 +37,7 @@ export const deletePassageUser = async (userId: string) => {
     const passage = await getPassageClient()
     return await passage.user.delete(userId)
   } catch (error) {
-    logger.error('Failed to delete Passage user', error)
+    logger.error(error, 'Failed to delete Passage user')
     throw new Error('Failed to delete Passage user')
   }
 }

--- a/api/src/services/reportingPeriods/reportingPeriods.scenarios.ts
+++ b/api/src/services/reportingPeriods/reportingPeriods.scenarios.ts
@@ -12,14 +12,14 @@ export const standard = defineScenario<Prisma.ReportingPeriodCreateArgs>({
         organization: { create: { name: 'String' } },
         inputTemplate: {
           create: {
-            name: 'String',
+            name: 'INPUT TEMPLATE ONE',
             version: 'String',
             effectiveDate: '2024-01-12T15:48:11.499Z',
           },
         },
         outputTemplate: {
           create: {
-            name: 'String',
+            name: 'OUTPUT TEMPLATE ONE',
             version: 'String',
             effectiveDate: '2024-01-12T15:48:11.499Z',
           },
@@ -34,14 +34,14 @@ export const standard = defineScenario<Prisma.ReportingPeriodCreateArgs>({
         organization: { create: { name: 'String' } },
         inputTemplate: {
           create: {
-            name: 'String',
+            name: 'INPUT TEMPLATE TWO',
             version: 'String',
             effectiveDate: '2024-01-12T15:48:11.499Z',
           },
         },
         outputTemplate: {
           create: {
-            name: 'String',
+            name: 'OUTPUT TEMPLATE TWO',
             version: 'String',
             effectiveDate: '2024-01-12T15:48:11.499Z',
           },

--- a/api/src/services/reportingPeriods/reportingPeriods.test.ts
+++ b/api/src/services/reportingPeriods/reportingPeriods.test.ts
@@ -6,6 +6,7 @@ import {
   createReportingPeriod,
   updateReportingPeriod,
   deleteReportingPeriod,
+  getOrCreateReportingPeriod,
 } from './reportingPeriods'
 import type { StandardScenario } from './reportingPeriods.scenarios'
 
@@ -16,6 +17,37 @@ import type { StandardScenario } from './reportingPeriods.scenarios'
 // https://redwoodjs.com/docs/testing#jest-expect-type-considerations
 
 describe('reportingPeriods', () => {
+  scenario('gets or creates reporting period', async () => {
+    const result = await getOrCreateReportingPeriod({
+      name: 'NEW PERIOD',
+      startDate: '2023-12-07T18:38:12.341Z',
+      endDate: '2023-12-07T18:38:12.341Z',
+
+      // previously existing input and output templates
+      inputTemplateName: 'INPUT TEMPLATE ONE',
+      outputTemplateName: 'OUTPUT TEMPLATE ONE',
+    })
+
+    expect(result.name).toEqual('NEW PERIOD')
+    expect(result.startDate).toEqual(new Date('2023-12-07T00:00:00.000Z'))
+    expect(result.endDate).toEqual(new Date('2023-12-07T00:00:00.000Z'))
+    expect(result.updatedAt).toBeDefined()
+  })
+
+  scenario('get or create returns null', async () => {
+    const result = await getOrCreateReportingPeriod({
+      name: 'NEW PERIOD',
+      startDate: '2023-12-07T18:38:12.341Z',
+      endDate: '2023-12-07T18:38:12.341Z',
+
+      // previously non existing input and output templates
+      inputTemplateName: 'NONEXISTENT INPUT TEMPLATE',
+      outputTemplateName: 'NONEXISTENT OUTPUT TEMPLATE',
+    })
+
+    expect(result).toEqual(undefined)
+  })
+
   scenario(
     'returns all reportingPeriods',
     async (scenario: StandardScenario) => {

--- a/api/src/services/reportingPeriods/reportingPeriods.ts
+++ b/api/src/services/reportingPeriods/reportingPeriods.ts
@@ -5,6 +5,7 @@ import type {
 } from 'types/graphql'
 
 import { db } from 'src/lib/db'
+import { logger } from 'src/lib/logger'
 
 export const reportingPeriods: QueryResolvers['reportingPeriods'] = () => {
   return db.reportingPeriod.findMany()
@@ -14,6 +15,28 @@ export const reportingPeriod: QueryResolvers['reportingPeriod'] = ({ id }) => {
   return db.reportingPeriod.findUnique({
     where: { id },
   })
+}
+
+export const getOrCreateReportingPeriod = async (periodInfo) => {
+  try {
+    let reportingPeriodRecord
+
+    const existingReportingPeriod = await db.reportingPeriod.findFirst({
+      where: { name: periodInfo.name },
+    })
+    if (existingReportingPeriod) {
+      reportingPeriodRecord = existingReportingPeriod
+    } else {
+      const data = periodInfo
+      reportingPeriodRecord = await db.reportingPeriod.create({
+        data,
+      })
+    }
+    return reportingPeriodRecord
+  } catch (error) {
+    logger.error(`Error creating reporting period ${periodInfo.name}`)
+    logger.error(error)
+  }
 }
 
 export const createReportingPeriod: MutationResolvers['createReportingPeriod'] =

--- a/api/src/services/reportingPeriods/reportingPeriods.ts
+++ b/api/src/services/reportingPeriods/reportingPeriods.ts
@@ -22,7 +22,8 @@ export const getOrCreateReportingPeriod = async (periodInfo) => {
   // It is intended to only be called via the `onboardOrganization` script
   // Hence, we hard-return if we detect a non-empty context
   if (context && Object.keys(context).length > 0) {
-    logger.error({ custom: context },
+    logger.error(
+      { custom: context },
       `This function is intended to be called via the onboardOrganization script and not via GraphQL API. Skipping...`
     )
     return
@@ -70,7 +71,10 @@ export const getOrCreateReportingPeriod = async (periodInfo) => {
     }
     return reportingPeriodRecord
   } catch (error) {
-    logger.error(error, `Error getting or creating reporting period ${periodInfo.name}`)
+    logger.error(
+      error,
+      `Error getting or creating reporting period ${periodInfo.name}`
+    )
   }
 }
 

--- a/api/src/services/reportingPeriods/reportingPeriods.ts
+++ b/api/src/services/reportingPeriods/reportingPeriods.ts
@@ -6,7 +6,6 @@ import type {
 
 import { db } from 'src/lib/db'
 import { logger } from 'src/lib/logger'
-import { getOrCreateOutputTemplate } from '../outputTemplates/outputTemplates'
 
 export const reportingPeriods: QueryResolvers['reportingPeriods'] = () => {
   return db.reportingPeriod.findMany()

--- a/api/src/services/reportingPeriods/reportingPeriods.ts
+++ b/api/src/services/reportingPeriods/reportingPeriods.ts
@@ -25,6 +25,7 @@ export const getOrCreateReportingPeriod = async (periodInfo) => {
       where: { name: periodInfo.name },
     })
     if (existingReportingPeriod) {
+      logger.info(`Reporting period ${periodInfo.name} already exists`)
       reportingPeriodRecord = existingReportingPeriod
     } else {
       const outputTemplate = await db.outputTemplate.findFirst({
@@ -45,6 +46,7 @@ export const getOrCreateReportingPeriod = async (periodInfo) => {
         )
         return
       }
+      logger.info(`Creating ${periodInfo.name}`)
       const data = {
         name: periodInfo.name,
         startDate: periodInfo.startDate,

--- a/api/src/services/reportingPeriods/reportingPeriods.ts
+++ b/api/src/services/reportingPeriods/reportingPeriods.ts
@@ -18,6 +18,16 @@ export const reportingPeriod: QueryResolvers['reportingPeriod'] = ({ id }) => {
 }
 
 export const getOrCreateReportingPeriod = async (periodInfo) => {
+  // This function is used to create initial expenditure categories
+  // It is intended to only be called via the `onboardOrganization` script
+  // Hence, we hard-return if we detect a non-empty context
+  if (context && Object.keys(context).length > 0) {
+    logger.error({ custom: context },
+      `This function is intended to be called via the onboardOrganization script and not via GraphQL API. Skipping...`
+    )
+    return
+  }
+
   try {
     let reportingPeriodRecord
 
@@ -60,8 +70,7 @@ export const getOrCreateReportingPeriod = async (periodInfo) => {
     }
     return reportingPeriodRecord
   } catch (error) {
-    logger.error(`Error creating reporting period ${periodInfo.name}`)
-    logger.error(error)
+    logger.error(error, `Error getting or creating reporting period ${periodInfo.name}`)
   }
 }
 

--- a/api/src/services/users/users.test.ts
+++ b/api/src/services/users/users.test.ts
@@ -40,7 +40,7 @@ describe('user queries', () => {
         role: 'ORGANIZATION_STAFF',
         agencyName: scenario.agency.two.name,
       }
-    ], scenario.organization.one)
+    ], scenario.organization.one.name)
     expect(result.length).toEqual(2)
     expect(result[0].id).toEqual(scenario.user.one.id)
     expect(result[1].email).toEqual('newuser99@example.com')

--- a/api/src/services/users/users.test.ts
+++ b/api/src/services/users/users.test.ts
@@ -27,20 +27,23 @@ import type { StandardScenario } from './users.scenarios'
 
 describe('user queries', () => {
   scenario('gets or creates a user', async (scenario: StandardScenario) => {
-    const result = await getOrCreateUsers([
-      {
-        email: 'uniqueemail1@test.com',
-        name: 'String',
-        role: 'ORGANIZATION_ADMIN',
-        agencyName: scenario.agency.one.name,
-      },
-      {
-        email: 'newuser99@example.com',
-        name: 'String',
-        role: 'ORGANIZATION_STAFF',
-        agencyName: scenario.agency.two.name,
-      }
-    ], scenario.organization.one.name)
+    const result = await getOrCreateUsers(
+      [
+        {
+          email: 'uniqueemail1@test.com',
+          name: 'String',
+          role: 'ORGANIZATION_ADMIN',
+          agencyName: scenario.agency.one.name,
+        },
+        {
+          email: 'newuser99@example.com',
+          name: 'String',
+          role: 'ORGANIZATION_STAFF',
+          agencyName: scenario.agency.two.name,
+        },
+      ],
+      scenario.organization.one.name
+    )
     expect(result.length).toEqual(2)
     expect(result[0].id).toEqual(scenario.user.one.id)
     expect(result[1].email).toEqual('newuser99@example.com')

--- a/api/src/services/users/users.test.ts
+++ b/api/src/services/users/users.test.ts
@@ -15,6 +15,7 @@ import {
   runGeneralCreateOrUpdateValidations,
   runPermissionsCreateOrUpdateValidations,
   runUpdateSpecificValidations,
+  getOrCreateUsers,
 } from './users'
 import type { StandardScenario } from './users.scenarios'
 
@@ -25,6 +26,25 @@ import type { StandardScenario } from './users.scenarios'
 // https://redwoodjs.com/docs/testing#jest-expect-type-considerations
 
 describe('user queries', () => {
+  scenario('gets or creates a user', async (scenario: StandardScenario) => {
+    const result = await getOrCreateUsers([
+      {
+        email: 'uniqueemail1@test.com',
+        name: 'String',
+        role: 'ORGANIZATION_ADMIN',
+        agencyName: scenario.agency.one.name,
+      },
+      {
+        email: 'newuser99@example.com',
+        name: 'String',
+        role: 'ORGANIZATION_STAFF',
+        agencyName: scenario.agency.two.name,
+      }
+    ], scenario.organization.one)
+    expect(result.length).toEqual(2)
+    expect(result[0].id).toEqual(scenario.user.one.id)
+    expect(result[1].email).toEqual('newuser99@example.com')
+  })
   scenario(
     'users query returns all users for USDR admin',
     async (scenario: StandardScenario) => {

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -249,7 +249,7 @@ export const getOrCreateUsers = async (users, orgName) => {
     return
   }
   const orgAgencies = await db.agency.findMany({
-    where: { organizationId: organization.id }
+    where: { organizationId: organization.id },
   })
   const agenciesByName = {}
   for (const agency of orgAgencies) {
@@ -260,7 +260,9 @@ export const getOrCreateUsers = async (users, orgName) => {
     try {
       logger.info(`Processing user ${user.email}`)
       if (!agenciesByName[user.agencyName]) {
-        logger.error(`Agency ${user.agencyName} not found for organization ${organization.name}`)
+        logger.error(
+          `Agency ${user.agencyName} not found for organization ${organization.name}`
+        )
         continue
       }
       const userData: Prisma.UserCreateArgs['data'] = {
@@ -271,14 +273,13 @@ export const getOrCreateUsers = async (users, orgName) => {
         isActive: true,
       }
       const existingUser = await db.user.findFirst({
-        where: { email: userData.email }
+        where: { email: userData.email },
       })
       if (existingUser) {
         logger.info(`User ${userData.email} already exists`)
         userRecords.push(existingUser)
         continue
-      }
-      else {
+      } else {
         if (process.env.AUTH_PROVIDER === 'passage' && !userData.passageId) {
           logger.info(`Creating Passage user for ${userData.email}`)
           const passageUser = await createPassageUser(userData.email)

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -235,7 +235,8 @@ export const getOrCreateUsers = async (users, orgName) => {
   // It is intended to only be called via the `onboardOrganization` script
   // Hence, we hard-return if we detect a non-empty context
   if (context && Object.keys(context).length > 0) {
-    logger.error({ custom: context },
+    logger.error(
+      { custom: context },
       `This function is intended to be called via the onboardOrganization script and not via GraphQL API. Skipping...`
     )
     return
@@ -308,7 +309,10 @@ export const getOrCreateUsers = async (users, orgName) => {
     }
     return userRecords
   } catch (error) {
-    logger.error(error, `Error getting or creating users for organization ${orgName}`)
+    logger.error(
+      error,
+      `Error getting or creating users for organization ${orgName}`
+    )
   }
 }
 

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -246,6 +246,7 @@ export const getOrCreateUsers = async (users, organization) => {
   })
   const agenciesByName = {}
   for (const agency of orgAgencies) {
+    logger.info(`Agency ${agency.name} found for organization ${organization.name}`)
     agenciesByName[agency.name] = agency
   }
   const userRecords = []

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -231,72 +231,85 @@ export const usersByOrganization: QueryResolvers['usersByOrganization'] =
   }
 
 export const getOrCreateUsers = async (users, orgName) => {
-  /*
-  Users are sent in the following Array format
-  {
-    name: 'Sample Name',
-    email: 'sample@example.com',
-    role: 'ORGANIZATION_STAFF',
-    agencyName: 'Sample Name',
-    passageId: '1234', // Optional
-  }
-  */
-  const organization = await db.organization.findFirst({
-    where: { name: orgName },
-  })
-  if (!organization) {
-    logger.error(`Organization ${orgName} not found`)
+  // This function is used to create initial expenditure categories
+  // It is intended to only be called via the `onboardOrganization` script
+  // Hence, we hard-return if we detect a non-empty context
+  if (context && Object.keys(context).length > 0) {
+    logger.error({ custom: context },
+      `This function is intended to be called via the onboardOrganization script and not via GraphQL API. Skipping...`
+    )
     return
   }
-  const orgAgencies = await db.agency.findMany({
-    where: { organizationId: organization.id },
-  })
-  const agenciesByName = {}
-  for (const agency of orgAgencies) {
-    agenciesByName[agency.name] = agency
-  }
-  const userRecords = []
-  for (const user of users) {
-    try {
-      logger.info(`Processing user ${user.email}`)
-      if (!agenciesByName[user.agencyName]) {
-        logger.error(
-          `Agency ${user.agencyName} not found for organization ${organization.name}`
-        )
-        continue
-      }
-      const userData: Prisma.UserCreateArgs['data'] = {
-        email: user.email,
-        name: user.name,
-        agencyId: agenciesByName[user.agencyName].id,
-        role: user.role,
-        isActive: true,
-      }
-      const existingUser = await db.user.findFirst({
-        where: { email: userData.email },
-      })
-      if (existingUser) {
-        logger.info(`User ${userData.email} already exists`)
-        userRecords.push(existingUser)
-        continue
-      } else {
-        if (process.env.AUTH_PROVIDER === 'passage' && !userData.passageId) {
-          logger.info(`Creating Passage user for ${userData.email}`)
-          const passageUser = await createPassageUser(userData.email)
-          userData.passageId = passageUser.id
-        }
-        const record = await db.user.create({ data: userData })
-        logger.info(`User ${userData.email} created`)
-        logger.info(record)
-        userRecords.push(record)
-      }
-    } catch (error) {
-      logger.error(`Error processing user ${user.email}`)
-      logger.error(error)
-      continue
+
+  try {
+    /*
+    Users are sent in the following Array format
+    {
+      name: 'Sample Name',
+      email: 'sample@example.com',
+      role: 'ORGANIZATION_STAFF',
+      agencyName: 'Sample Name',
+      passageId: '1234', // Optional
     }
+    */
+    const organization = await db.organization.findFirst({
+      where: { name: orgName },
+    })
+    if (!organization) {
+      logger.error(`Organization ${orgName} not found`)
+      return
+    }
+    const orgAgencies = await db.agency.findMany({
+      where: { organizationId: organization.id },
+    })
+    const agenciesByName = {}
+    for (const agency of orgAgencies) {
+      agenciesByName[agency.name] = agency
+    }
+    const userRecords = []
+    for (const user of users) {
+      try {
+        logger.info(`Processing user ${user.email}`)
+        if (!agenciesByName[user.agencyName]) {
+          logger.error(
+            `Agency ${user.agencyName} not found for organization ${organization.name}`
+          )
+          continue
+        }
+        const userData: Prisma.UserCreateArgs['data'] = {
+          email: user.email,
+          name: user.name,
+          agencyId: agenciesByName[user.agencyName].id,
+          role: user.role,
+          isActive: true,
+        }
+        const existingUser = await db.user.findFirst({
+          where: { email: userData.email },
+        })
+        if (existingUser) {
+          logger.info(`User ${userData.email} already exists`)
+          userRecords.push(existingUser)
+          continue
+        } else {
+          if (process.env.AUTH_PROVIDER === 'passage' && !userData.passageId) {
+            logger.info(`Creating Passage user for ${userData.email}`)
+            const passageUser = await createPassageUser(userData.email)
+            userData.passageId = passageUser.id
+          }
+          const record = await db.user.create({ data: userData })
+          logger.info(`User ${userData.email} created`)
+          logger.info(record)
+          userRecords.push(record)
+        }
+      } catch (error) {
+        logger.error(error, `Error processing user ${user.email}`)
+        continue
+      }
+    }
+    return userRecords
+  } catch (error) {
+    logger.error(error, `Error getting or creating users for organization ${orgName}`)
   }
-  return userRecords
 }
 
 export const User: UserRelationResolvers = {

--- a/scripts/onboardOrganization.ts
+++ b/scripts/onboardOrganization.ts
@@ -19,6 +19,7 @@ export default async ({ args }) => {
 
   Example:
     yarn redwood exec onboardOrganization \
+      --orgName 'Sample Org' \
       --inputTemplateInfo '{
         "name": "Input Template 1",
         "version": "1.0.0",
@@ -35,9 +36,8 @@ export default async ({ args }) => {
         "startDate": "2024-04-01T00:00:00.000Z",
         "endDate": "2024-06-30T23:59:59.999Z",
         "inputTemplateName": "Input Template 1",
-        "outputTemplateName": "Output Template 1",
+        "outputTemplateName": "Output Template 1"
       }' \
-      --orgName 'Sample Org' \
       --agencyInfo '[
         {"name": "Sample Agency", "abbreviation": "SA", "code": "SA"},
         {"name": "Sample Agency 2", "abbreviation": "SA2", "code": "SA2"}
@@ -49,44 +49,52 @@ export default async ({ args }) => {
   */
   await getPrismaClient()
   console.log(':: Executing script with args ::')
-  console.log(args)
-  console.log(JSON.parse(args.inputTemplateInfo))
-  console.log(JSON.parse(args.outputTemplateInfo))
-  console.log(args.currentPeriodName)
-  console.log(args.orgName)
-  console.log(JSON.parse(args.agencyInfo))
-  console.log(JSON.parse(args.userInfo))
-  console.log(':: Script executed ::')
+  console.log(`Received following arguments: ${Object.keys(args)}`)
+
   if (!args.orgName) {
     throw new Error('Organization name is required')
   }
 
   if (args.inputTemplateInfo) {
+    console.log('get or create input template')
+    console.log(JSON.parse(args.inputTemplateInfo))
     const parsedInputTemplateInfo = JSON.parse(args.inputTemplateInfo)
     await getOrCreateInputTemplate(parsedInputTemplateInfo)
   }
 
   if (args.outputTemplateInfo) {
+    console.log('get or create output template')
+    console.log(JSON.parse(args.outputTemplateInfo))
     const parsedOutputTemplateInfo = JSON.parse(args.outputTemplateInfo)
     await getOrCreateOutputTemplate(parsedOutputTemplateInfo)
   }
 
   if (args.periodInfo) {
+    console.log('get or create reporting period')
+    console.log(JSON.parse(args.periodInfo))
     const parsedPeriodInfo = JSON.parse(args.periodInfo)
     await getOrCreateReportingPeriod(parsedPeriodInfo)
   }
 
   if (args.orgName && args.currentPeriodName) {
+    console.log('Get or create Organization')
+    console.log(args.orgName)
+    console.log(args.currentPeriodName)
     await getOrCreateOrganization(args.orgName, args.currentPeriodName)
   }
 
   if (args.agencyInfo) {
+    console.log('Get or create Agencies')
+    console.log(JSON.parse(args.agencyInfo))
     const parsedAgencyInfo = JSON.parse(args.agencyInfo)
     await getOrCreateAgencies(args.orgName, parsedAgencyInfo)
   }
 
   if (args.userInfo) {
+    console.log('Get or create Users')
+    console.log(JSON.parse(args.userInfo))
     const parsedUserInfo = JSON.parse(args.userInfo)
-    getOrCreateUsers(parsedUserInfo, args.orgName)
+    await getOrCreateUsers(parsedUserInfo, args.orgName)
   }
+  console.log(':: Script executed ::')
 }

--- a/scripts/onboardOrganization.ts
+++ b/scripts/onboardOrganization.ts
@@ -10,13 +10,8 @@ import {
 } from 'api/src/services/agencies/agencies'
 import { getOrCreateUsers } from 'api/src/services/users/users'
 import { getOrCreateReportingPeriod } from 'api/src/services/reportingPeriods/reportingPeriods'
-
-async function addOrgAgencyUsers(currentPeriodName, orgName, agencyInfo, userInfo) {
-  const reportingPeriod = await getOrCreateReportingPeriod(currentPeriodName)
-  const organizationRecord = await getOrCreateOrganization(orgName, currentPeriodName)
-  await getOrCreateAgencies(orgName, agencyInfo)
-  getOrCreateUsers(userInfo, orgName)
-}
+import { getOrCreateInputTemplate } from 'api/src/services/inputTemplates/inputTemplates'
+import { getOrCreateOutputTemplate } from 'api/src/services/outputTemplates/outputTemplates'
 
 export default async ({ args }) => {
   /*
@@ -61,6 +56,37 @@ export default async ({ args }) => {
   console.log(args.orgName)
   console.log(JSON.parse(args.agencyInfo))
   console.log(JSON.parse(args.userInfo))
-  await addOrgAgencyUsers(args.currentPeriodName, args.orgName, JSON.parse(args.agencyInfo), JSON.parse(args.userInfo))
   console.log(':: Script executed ::')
+  if (!args.orgName) {
+    throw new Error('Organization name is required')
+  }
+
+  if (args.inputTemplateInfo) {
+    const parsedInputTemplateInfo = JSON.parse(args.inputTemplateInfo)
+    await getOrCreateInputTemplate(parsedInputTemplateInfo)
+  }
+
+  if (args.outputTemplateInfo) {
+    const parsedOutputTemplateInfo = JSON.parse(args.outputTemplateInfo)
+    await getOrCreateOutputTemplate(parsedOutputTemplateInfo)
+  }
+
+  if (args.periodInfo) {
+    const parsedPeriodInfo = JSON.parse(args.periodInfo)
+    await getOrCreateReportingPeriod(parsedPeriodInfo)
+  }
+
+  if (args.orgName && args.currentPeriodName) {
+    await getOrCreateOrganization(args.orgName, args.currentPeriodName)
+  }
+
+  if (args.agencyInfo) {
+    const parsedAgencyInfo = JSON.parse(args.agencyInfo)
+    await getOrCreateAgencies(args.orgName, parsedAgencyInfo)
+  }
+
+  if (args.userInfo) {
+    const parsedUserInfo = JSON.parse(args.userInfo)
+    getOrCreateUsers(parsedUserInfo, args.orgName)
+  }
 }

--- a/scripts/onboardOrganization.ts
+++ b/scripts/onboardOrganization.ts
@@ -1,9 +1,6 @@
 // To access your database
 // Append api/* to import from api and web/* to import from web
-import { db, getPrismaClient } from 'api/src/lib/db'
-import {
-  createPassageUser,
-} from 'api/src/services/passage/passage'
+import { getPrismaClient } from 'api/src/lib/db'
 import type { Prisma } from '@prisma/client'
 import {
   getOrCreateOrganization
@@ -12,11 +9,13 @@ import {
   getOrCreateAgencies
 } from 'api/src/services/agencies/agencies'
 import { getOrCreateUsers } from 'api/src/services/users/users'
+import { getOrCreateReportingPeriod } from 'api/src/services/reportingPeriods/reportingPeriods'
 
-async function addOrgAgencyUsers(orgName, agencyInfo, userInfo) {
-  const organizationRecord = await getOrCreateOrganization(orgName)
-  await getOrCreateAgencies(organizationRecord, agencyInfo)
-  getOrCreateUsers(userInfo, organizationRecord)
+async function addOrgAgencyUsers(currentPeriodName, orgName, agencyInfo, userInfo) {
+  const reportingPeriod = await getOrCreateReportingPeriod(currentPeriodName)
+  const organizationRecord = await getOrCreateOrganization(orgName, currentPeriodName)
+  await getOrCreateAgencies(orgName, agencyInfo)
+  getOrCreateUsers(userInfo, orgName)
 }
 
 export default async ({ args }) => {
@@ -25,6 +24,24 @@ export default async ({ args }) => {
 
   Example:
     yarn redwood exec onboardOrganization \
+      --inputTemplateInfo '{
+        "name": "Input Template 1",
+        "version": "1.0.0",
+        "effectiveDate": "2024-04-01T00:00:00.000Z"
+      }' \
+      --outputTemplateInfo '{
+        "name": "Output Template 1",
+        "version": "1.0.0",
+        "effectiveDate": "2024-04-01T00:00:00.000Z"
+      }' \
+      --currentPeriodName '[April 1st - June 30th] Q2 2024' \
+      --periodInfo '{
+        "name": "[April 1st - June 30th] Q2 2024",
+        "startDate": "2024-04-01T00:00:00.000Z",
+        "endDate": "2024-06-30T23:59:59.999Z",
+        "inputTemplateName": "Input Template 1",
+        "outputTemplateName": "Output Template 1",
+      }' \
       --orgName 'Sample Org' \
       --agencyInfo '[
         {"name": "Sample Agency", "abbreviation": "SA", "code": "SA"},
@@ -38,8 +55,12 @@ export default async ({ args }) => {
   await getPrismaClient()
   console.log(':: Executing script with args ::')
   console.log(args)
+  console.log(JSON.parse(args.inputTemplateInfo))
+  console.log(JSON.parse(args.outputTemplateInfo))
+  console.log(args.currentPeriodName)
+  console.log(args.orgName)
   console.log(JSON.parse(args.agencyInfo))
   console.log(JSON.parse(args.userInfo))
-  await addOrgAgencyUsers(args.orgName, JSON.parse(args.agencyInfo), JSON.parse(args.userInfo))
+  await addOrgAgencyUsers(args.currentPeriodName, args.orgName, JSON.parse(args.agencyInfo), JSON.parse(args.userInfo))
   console.log(':: Script executed ::')
 }

--- a/scripts/onboardOrganization.ts
+++ b/scripts/onboardOrganization.ts
@@ -1,0 +1,42 @@
+// To access your database
+// Append api/* to import from api and web/* to import from web
+import { db, getPrismaClient } from 'api/src/lib/db'
+import {
+  createPassageUser,
+} from 'api/src/services/passage/passage'
+import type { Prisma } from '@prisma/client'
+import {
+  getOrCreateOrganization
+} from 'api/src/services/organizations/organizations'
+import {
+  getOrCreateAgencies
+} from 'api/src/services/agencies/agencies'
+import { getOrCreateUsers } from 'api/src/services/users/users'
+
+async function addOrgAgencyUsers(orgName, agencyInfo, userInfo) {
+  const organizationRecord = await getOrCreateOrganization(orgName)
+  await getOrCreateAgencies(organizationRecord, agencyInfo)
+  getOrCreateUsers(userInfo, organizationRecord)
+}
+
+export default async ({ args }) => {
+  /*
+  yarn redwood exec onboardOrganization \
+    --orgName 'Sample Org' \
+    --agencyInfo '[
+      {"name": "Sample Agency", "abbreviation": "SA", "code": "SA"},
+      {"name": "Sample Agency 2", "abbreviation": "SA2", "code": "SA2"}
+    ]' \
+    --userInfo '[
+      {"name": "Sample User", "email": "sample@example.com", "role": "ORGANIZATION_STAFF", "agencyName": "Sample Agency"},
+      {"name": "Sample User 2", "email": "sample2@example.com", "role": "ORGANIZATION_ADMIN", "agencyName": "Sample Agency 2"}
+    ]'
+  */
+  await getPrismaClient()
+  console.log(':: Executing script with args ::')
+  console.log(args)
+  console.log(JSON.parse(args.agencyInfo))
+  console.log(JSON.parse(args.userInfo))
+  await addOrgAgencyUsers(args.orgName, JSON.parse(args.agencyInfo), JSON.parse(args.userInfo))
+  console.log(':: Script executed ::')
+}

--- a/scripts/onboardOrganization.ts
+++ b/scripts/onboardOrganization.ts
@@ -21,16 +21,19 @@ async function addOrgAgencyUsers(orgName, agencyInfo, userInfo) {
 
 export default async ({ args }) => {
   /*
-  yarn redwood exec onboardOrganization \
-    --orgName 'Sample Org' \
-    --agencyInfo '[
-      {"name": "Sample Agency", "abbreviation": "SA", "code": "SA"},
-      {"name": "Sample Agency 2", "abbreviation": "SA2", "code": "SA2"}
-    ]' \
-    --userInfo '[
-      {"name": "Sample User", "email": "sample@example.com", "role": "ORGANIZATION_STAFF", "agencyName": "Sample Agency"},
-      {"name": "Sample User 2", "email": "sample2@example.com", "role": "ORGANIZATION_ADMIN", "agencyName": "Sample Agency 2"}
-    ]'
+  Useful to create a new organization, agencies, and users.
+
+  Example:
+    yarn redwood exec onboardOrganization \
+      --orgName 'Sample Org' \
+      --agencyInfo '[
+        {"name": "Sample Agency", "abbreviation": "SA", "code": "SA"},
+        {"name": "Sample Agency 2", "abbreviation": "SA2", "code": "SA2"}
+      ]' \
+      --userInfo '[
+        {"name": "Sample User", "email": "sample@example.com", "role": "ORGANIZATION_STAFF", "agencyName": "Sample Agency"},
+        {"name": "Sample User 2", "email": "sample2@example.com", "role": "ORGANIZATION_ADMIN", "agencyName": "Sample Agency 2"}
+      ]'
   */
   await getPrismaClient()
   console.log(':: Executing script with args ::')

--- a/scripts/onboardOrganization.ts
+++ b/scripts/onboardOrganization.ts
@@ -12,6 +12,7 @@ import { getOrCreateUsers } from 'api/src/services/users/users'
 import { getOrCreateReportingPeriod } from 'api/src/services/reportingPeriods/reportingPeriods'
 import { getOrCreateInputTemplate } from 'api/src/services/inputTemplates/inputTemplates'
 import { getOrCreateOutputTemplate } from 'api/src/services/outputTemplates/outputTemplates'
+import { createOrSkipInitialExpenditureCategories } from 'api/src/services/expenditureCategories/expenditureCategories'
 
 export default async ({ args }) => {
   /*
@@ -20,6 +21,7 @@ export default async ({ args }) => {
   Example:
     yarn redwood exec onboardOrganization \
       --orgName 'Sample Org' \
+      --initializeExpenditureCategories true \
       --inputTemplateInfo '{
         "name": "Input Template 1",
         "version": "1.0.0",
@@ -53,6 +55,11 @@ export default async ({ args }) => {
 
   if (!args.orgName) {
     throw new Error('Organization name is required')
+  }
+
+  if (args.initializeExpenditureCategories) {
+    console.log('Initializing expenditure categories')
+    await createOrSkipInitialExpenditureCategories()
   }
 
   if (args.inputTemplateInfo) {

--- a/scripts/onboardOrganization.ts
+++ b/scripts/onboardOrganization.ts
@@ -1,7 +1,6 @@
 // To access your database
 // Append api/* to import from api and web/* to import from web
 import { getPrismaClient } from 'api/src/lib/db'
-import type { Prisma } from '@prisma/client'
 import {
   getOrCreateOrganization
 } from 'api/src/services/organizations/organizations'

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -8,7 +8,6 @@ export default async () => {
     // Manually seed via `yarn rw prisma db seed`
     // Seeds automatically with `yarn rw prisma migrate dev` and `yarn rw prisma migrate reset`
     //
-    await getPrismaClient()
 
     const organization: Prisma.OrganizationCreateArgs['data'] = {
       name: 'US Digital Response',

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,5 +1,5 @@
 import type { Prisma } from '@prisma/client'
-import { db } from 'api/src/lib/db'
+import { getPrismaClient, db } from 'api/src/lib/db'
 
 export default async () => {
   try {
@@ -7,6 +7,7 @@ export default async () => {
     // Manually seed via `yarn rw prisma db seed`
     // Seeds automatically with `yarn rw prisma migrate dev` and `yarn rw prisma migrate reset`
     //
+    await getPrismaClient()
 
     const organization: Prisma.OrganizationCreateArgs['data'] = {
       name: 'US Digital Response',

--- a/web/src/components/Organization/OrganizationPickListsCell/OrganizationPickListsCell.tsx
+++ b/web/src/components/Organization/OrganizationPickListsCell/OrganizationPickListsCell.tsx
@@ -42,7 +42,10 @@ export const Success = ({
       <Label name="reportingPeriodId" className="rw-label">
         Reporting Period - April 1st to June 30th - Q2 2024
       </Label>
-      <HiddenField name="reportingPeriodId" value={organization.preferences.current_reporting_period_id} />
+      <HiddenField
+        name="reportingPeriodId"
+        value={organization.preferences.current_reporting_period_id}
+      />
       <Label
         name="agencyId"
         className="rw-label"

--- a/web/src/components/Organization/OrganizationPickListsCell/OrganizationPickListsCell.tsx
+++ b/web/src/components/Organization/OrganizationPickListsCell/OrganizationPickListsCell.tsx
@@ -38,6 +38,10 @@ export const Success = ({
 }: CellSuccessProps<FindOrganizationQuery, FindOrganizationQueryVariables>) => {
   return (
     <div>
+      {/* Hard-coding the reporting period name temporarily. Will be resolved by issue #79 */}
+      <Label name="reportingPeriodId" className="rw-label">
+        Reporting Period - April 1st to June 30th - Q2 2024
+      </Label>
       <HiddenField name="reportingPeriodId" value={organization.preferences.current_reporting_period_id} />
       <Label
         name="agencyId"

--- a/web/src/components/Organization/OrganizationPickListsCell/OrganizationPickListsCell.tsx
+++ b/web/src/components/Organization/OrganizationPickListsCell/OrganizationPickListsCell.tsx
@@ -3,13 +3,14 @@ import type {
   FindOrganizationQueryVariables,
 } from 'types/graphql'
 
-import { Label, SelectField } from '@redwoodjs/forms'
+import { Label, SelectField, HiddenField } from '@redwoodjs/forms'
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
 export const QUERY = gql`
   query FindOrganizationQuery($id: Int!) {
     organization: organization(id: $id) {
       id
+      preferences
       reportingPeriods {
         id
         name
@@ -37,20 +38,7 @@ export const Success = ({
 }: CellSuccessProps<FindOrganizationQuery, FindOrganizationQueryVariables>) => {
   return (
     <div>
-      <Label
-        name="reportingPeriodId"
-        className="rw-label"
-        errorClassName="rw-label rw-label-error"
-      >
-        Reporting Period
-      </Label>
-      <SelectField name="reportingPeriodId">
-        {organization.reportingPeriods.map((reportingPeriod) => (
-          <option key={reportingPeriod.id} value={reportingPeriod.id}>
-            {reportingPeriod.name}
-          </option>
-        ))}
-      </SelectField>
+      <HiddenField name="reportingPeriodId" value={organization.preferences.current_reporting_period_id} />
       <Label
         name="agencyId"
         className="rw-label"

--- a/web/src/components/ReportingPeriodsCell/ReportingPeriodsCell.tsx
+++ b/web/src/components/ReportingPeriodsCell/ReportingPeriodsCell.tsx
@@ -45,9 +45,7 @@ export const Success = ({
             <tr key={item.id}>
               <td>{item.startDate}</td>
               <td>{item.endDate}</td>
-              <td>
-                {item.inputTemplate?.name}
-              </td>
+              <td>{item.inputTemplate?.name}</td>
               <td>
                 <nav>
                   <Link


### PR DESCRIPTION
#57 
#249 

The script replaces the existing `seed.ts` file with a more comprehensive onboarding script that is a bit more flexible and ensures that only net-new entities are created in the database. The script supports creation of:
- expenditure categories ( one time for all organizations)
- input templates (one time for all orgs)
- output templates (one time for all orgs)
- reporting periods ( one time for all organizations)
  - Note: previously these were one-per-organization however, I have made the relationship `nullable` to be able to support the new standard.
- organizations
- agencies
- users
  - passage user-creation and activation if not already setup

## Screenshot
<img width="858" alt="image" src="https://github.com/usdigitalresponse/cpf-reporter/assets/6497366/260bd8a5-dd0a-4b49-b49f-cbcfcd47cc31">


## Testing
- All functions have unit tests. The script merely parses the arguments and passes directly to these functions.
- I also tested the script locally with the following results to ensure it is able to flow through all conditionals.
```
Adityas-PillarBook-Pro:cpf-reporter adityasridhar$ yarn redwood exec onboardOrganization \
      --orgName 'Sample Org' \ategories true \
      --initializeExpenditureCategories true \
      --inputTemplateInfo '{ate 1",
        "name": "Input Template 1",
        "version": "1.0.0",024-04-01T00:00:00.000Z"
        "effectiveDate": "2024-04-01T00:00:00.000Z"
      }' \tputTemplateInfo '{
      --outputTemplateInfo '{ate 1",
        "name": "Output Template 1",
        "version": "1.0.0",024-04-01T00:00:00.000Z"
        "effectiveDate": "2024-04-01T00:00:00.000Z"
      }' \rrentPeriodName '[April 1st - June 30th] Q2 2024' \
      --currentPeriodName '[April 1st - June 30th] Q2 2024' \
      --periodInfo '{il 1st - June 30th] Q2 2024",
        "name": "[April 1st - June 30th] Q2 2024",
        "startDate": "2024-04-01T00:00:00.000Z",
        "endDate": "2024-06-30T23:59:59.999Z",",
        "inputTemplateName": "Input Template 1","
        "outputTemplateName": "Output Template 1"
      }' \encyInfo '[
      --agencyInfo '[ple Agency", "abbreviation": "SA", "code": "SA"},
        {"name": "Sample Agency", "abbreviation": "SA", "code": "SA"},2"}
        {"name": "Sample Agency 2", "abbreviation": "SA2", "code": "SA2"}
      ]' \erInfo '[
      --userInfo '[ample User", "email": "sample@example.com", "role": "ORGANIZATION_STAFF", "agencyName": "Sample Agency"},
        {"name": "Sample User", "email": "sample@example.com", "role": "ORGANIZATION_STAFF", "agencyName": "Sample Agency"}, 2"}
        {"name": "Sample User 2", "email": "sample2@example.com", "role": "ORGANIZATION_ADMIN", "agencyName": "Sample Agency 2"}
      ]'
[STARTED] Generating Prisma client
[COMPLETED] Generating Prisma client
[STARTED] Running script
{"level":30,"time":1716353335255,"pid":44113,"hostname":"adityasrbookpro.lan","msg":"Initializing Prisma Client"}
:: Executing script with args ::
Received following arguments: _,orgName,initializeExpenditureCategories,inputTemplateInfo,outputTemplateInfo,currentPeriodName,periodInfo,agencyInfo,userInfo,l,$0
Initializing expenditure categories
{"level":30,"time":1716353335746,"pid":44113,"hostname":"adityasrbookpro.lan","prisma":{"clientVersion":"5.11.0"},"timestamp":"2024-05-22T04:48:55.746Z","message":"Starting a postgresql pool with 1 connections.","target":"quaint::pooled","msg":"Starting a postgresql pool with 1 connections."}
{"level":30,"time":1716353335760,"pid":44113,"hostname":"adityasrbookpro.lan","msg":"Expenditure category 1A - Broadband Infrastructure already exists. Skipping..."}
{"level":30,"time":1716353335761,"pid":44113,"hostname":"adityasrbookpro.lan","msg":"Expenditure category 1C - Multi-Purpose Community Facility already exists. Skipping..."}
{"level":30,"time":1716353335761,"pid":44113,"hostname":"adityasrbookpro.lan","msg":"Expenditure category 1B - Digital Connectivity Technology already exists. Skipping..."}
get or create input template
{
  name: 'Input Template 1',
  version: '1.0.0',
  effectiveDate: '2024-04-01T00:00:00.000Z'
}
{"level":30,"time":1716353335765,"pid":44113,"hostname":"adityasrbookpro.lan","msg":"Input template Input Template 1 already exists"}
get or create output template
{
  name: 'Output Template 1',
  version: '1.0.0',
  effectiveDate: '2024-04-01T00:00:00.000Z'
}
{"level":30,"time":1716353335767,"pid":44113,"hostname":"adityasrbookpro.lan","msg":"Output template Output Template 1 already exists"}
get or create reporting period
{
  name: '[April 1st - June 30th] Q2 2024',
  startDate: '2024-04-01T00:00:00.000Z',
  endDate: '2024-06-30T23:59:59.999Z',
  inputTemplateName: 'Input Template 1',
  outputTemplateName: 'Output Template 1'
}
{"level":30,"time":1716353335771,"pid":44113,"hostname":"adityasrbookpro.lan","msg":"Reporting period [April 1st - June 30th] Q2 2024 already exists"}
Get or create Organization
Sample Org
[April 1st - June 30th] Q2 2024
{"level":30,"time":1716353335773,"pid":44113,"hostname":"adityasrbookpro.lan","msg":"Organization Sample Org already exists"}
Get or create Agencies
[
  { name: 'Sample Agency', abbreviation: 'SA', code: 'SA' },
  { name: 'Sample Agency 2', abbreviation: 'SA2', code: 'SA2' }
]
{"level":30,"time":1716353335776,"pid":44113,"hostname":"adityasrbookpro.lan","msg":"Processing agency Sample Agency"}
{"level":30,"time":1716353335778,"pid":44113,"hostname":"adityasrbookpro.lan","msg":"Sample Agency exists for organization Sample Org"}
{"level":30,"time":1716353335778,"pid":44113,"hostname":"adityasrbookpro.lan","msg":"Processing agency Sample Agency 2"}
{"level":30,"time":1716353335779,"pid":44113,"hostname":"adityasrbookpro.lan","msg":"Sample Agency 2 exists for organization Sample Org"}
Get or create Users
[
  {
    name: 'Sample User',
    email: 'sample@example.com',
    role: 'ORGANIZATION_STAFF',
    agencyName: 'Sample Agency'
  },
  {
    name: 'Sample User 2',
    email: 'sample2@example.com',
    role: 'ORGANIZATION_ADMIN',
    agencyName: 'Sample Agency 2'
  }
]
{"level":30,"time":1716353335779,"pid":44113,"hostname":"adityasrbookpro.lan","msg":"Agencies processed: 2"}
{"level":30,"time":1716353335782,"pid":44113,"hostname":"adityasrbookpro.lan","msg":"Processing user sample@example.com"}
{"level":30,"time":1716353335785,"pid":44113,"hostname":"adityasrbookpro.lan","msg":"User sample@example.com already exists"}
{"level":30,"time":1716353335785,"pid":44113,"hostname":"adityasrbookpro.lan","msg":"Processing user sample2@example.com"}
{"level":30,"time":1716353335786,"pid":44113,"hostname":"adityasrbookpro.lan","msg":"User sample2@example.com already exists"}
:: Script executed ::
[COMPLETED] Running script
Adityas-PillarBook-Pro:cpf-reporter adityasridhar$ 
```