### PR TITLE
Reporting periods schema changes

### DIFF
--- a/api/db/migrations/20240521213042_reporting_period_changes/migration.sql
+++ b/api/db/migrations/20240521213042_reporting_period_changes/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `certifiedAt` on the `ReportingPeriod` table. All the data in the column will be lost.
+  - You are about to drop the column `certifiedById` on the `ReportingPeriod` table. All the data in the column will be lost.
+  - You are about to drop the column `isCurrentPeriod` on the `ReportingPeriod` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "ReportingPeriod" DROP CONSTRAINT "ReportingPeriod_certifiedById_fkey";
+
+-- AlterTable
+ALTER TABLE "ReportingPeriod" DROP COLUMN "certifiedAt",
+DROP COLUMN "certifiedById",
+DROP COLUMN "isCurrentPeriod",
+ADD COLUMN     "validationRulesId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "ReportingPeriod" ADD CONSTRAINT "ReportingPeriod_validationRulesId_fkey" FOREIGN KEY ("validationRulesId") REFERENCES "ValidationRules"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -42,7 +42,6 @@ model User {
   isActive       Boolean             @default(true)
   passageId      String?
   agency         Agency              @relation(fields: [agencyId], references: [id])
-  certified      ReportingPeriod[]
   uploaded       Upload[]
   initiated      UploadValidation[]
 
@@ -78,24 +77,22 @@ model OutputTemplate {
 }
 
 model ReportingPeriod {
-  id               Int            @id @default(autoincrement())
-  name             String
-  startDate        DateTime       @db.Date
-  endDate          DateTime       @db.Date
-  organizationId   Int
-  organization     Organization   @relation(fields: [organizationId], references: [id])
-  certifiedAt      DateTime?      @db.Timestamptz(6)
-  certifiedById    Int?
-  certifiedBy      User?          @relation(fields: [certifiedById], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  inputTemplateId  Int
-  inputTemplate    InputTemplate  @relation(fields: [inputTemplateId], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  outputTemplateId Int
-  outputTemplate   OutputTemplate @relation(fields: [outputTemplateId], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  isCurrentPeriod  Boolean        @default(false)
-  createdAt        DateTime       @default(now()) @db.Timestamptz(6)
-  updatedAt        DateTime       @default(now()) @db.Timestamptz(6)
-  uploads          Upload[]
-  projects         Project[]
+  id                Int            @id @default(autoincrement())
+  name              String
+  startDate         DateTime       @db.Date
+  endDate           DateTime       @db.Date
+  organizationId    Int
+  organization      Organization   @relation(fields: [organizationId], references: [id])
+  inputTemplateId   Int
+  inputTemplate     InputTemplate  @relation(fields: [inputTemplateId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  outputTemplateId  Int
+  outputTemplate    OutputTemplate @relation(fields: [outputTemplateId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  validationRulesId Int?
+  validationRules   ValidationRules? @relation(fields: [validationRulesId], references: [id])
+  createdAt         DateTime       @default(now()) @db.Timestamptz(6)
+  updatedAt         DateTime       @default(now()) @db.Timestamptz(6)
+  uploads           Upload[]
+  projects          Project[]
 }
 
 model ExpenditureCategory {
@@ -177,4 +174,5 @@ model ValidationRules {
   createdAt           DateTime        @default(now()) @db.Timestamptz(6)
   updatedAt           DateTime        @default(now()) @db.Timestamptz(6)
   validations         UploadValidation[]
+  reportingPeriods    ReportingPeriod[]
 }

--- a/api/src/graphql/reportingPeriods.sdl.ts
+++ b/api/src/graphql/reportingPeriods.sdl.ts
@@ -6,18 +6,16 @@ export const schema = gql`
     endDate: DateTime!
     organizationId: Int!
     organization: Organization!
-    certifiedAt: DateTime
-    certifiedById: Int
-    certifiedBy: User
     inputTemplateId: Int!
     inputTemplate: InputTemplate!
     outputTemplateId: Int!
     outputTemplate: OutputTemplate!
-    isCurrentPeriod: Boolean!
     createdAt: DateTime!
     updatedAt: DateTime!
     uploads: [Upload]!
     projects: [Project]!
+    validationRulesId: Int
+    validationRules: ValidationRules
   }
 
   type Query {
@@ -30,11 +28,8 @@ export const schema = gql`
     startDate: DateTime!
     endDate: DateTime!
     organizationId: Int!
-    certifiedAt: DateTime
-    certifiedById: Int
     inputTemplateId: Int!
     outputTemplateId: Int!
-    isCurrentPeriod: Boolean!
   }
 
   input UpdateReportingPeriodInput {
@@ -42,11 +37,8 @@ export const schema = gql`
     startDate: DateTime
     endDate: DateTime
     organizationId: Int
-    certifiedAt: DateTime
-    certifiedById: Int
     inputTemplateId: Int
     outputTemplateId: Int
-    isCurrentPeriod: Boolean
   }
 
   type Mutation {

--- a/api/src/graphql/users.sdl.ts
+++ b/api/src/graphql/users.sdl.ts
@@ -14,7 +14,6 @@ export const schema = gql`
     updatedAt: DateTime!
     agency: Agency!
     role: RoleEnum!
-    certified: [ReportingPeriod]!
     uploaded: [Upload]!
   }
 

--- a/api/src/graphql/validationRuleses.sdl.ts
+++ b/api/src/graphql/validationRuleses.sdl.ts
@@ -5,6 +5,7 @@ export const schema = gql`
     createdAt: DateTime!
     updatedAt: DateTime!
     validations: [UploadValidation]!
+    reportingPeriods: [ReportingPeriod]!
   }
 
   enum Version {

--- a/api/src/services/reportingPeriods/reportingPeriods.test.ts
+++ b/api/src/services/reportingPeriods/reportingPeriods.test.ts
@@ -47,7 +47,6 @@ describe('reportingPeriods', () => {
         organizationId: scenario.reportingPeriod.two.organizationId,
         inputTemplateId: scenario.reportingPeriod.two.inputTemplateId,
         outputTemplateId: scenario.reportingPeriod.two.outputTemplateId,
-        isCurrentPeriod: true,
       },
     })
 

--- a/api/src/services/reportingPeriods/reportingPeriods.ts
+++ b/api/src/services/reportingPeriods/reportingPeriods.ts
@@ -44,11 +44,6 @@ export const ReportingPeriod: ReportingPeriodRelationResolvers = {
       .findUnique({ where: { id: root?.id } })
       .organization()
   },
-  certifiedBy: (_obj, { root }) => {
-    return db.reportingPeriod
-      .findUnique({ where: { id: root?.id } })
-      .certifiedBy()
-  },
   inputTemplate: (_obj, { root }) => {
     return db.reportingPeriod
       .findUnique({ where: { id: root?.id } })
@@ -64,5 +59,10 @@ export const ReportingPeriod: ReportingPeriodRelationResolvers = {
   },
   projects: (_obj, { root }) => {
     return db.reportingPeriod.findUnique({ where: { id: root?.id } }).projects()
+  },
+  validationRules: (_obj, { root }) => {
+    return db.reportingPeriod
+      .findUnique({ where: { id: root?.id } })
+      .outputTemplate()
   },
 }

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -233,9 +233,6 @@ export const User: UserRelationResolvers = {
   agency: (_obj, { root }) => {
     return db.user.findUnique({ where: { id: root?.id } }).agency()
   },
-  certified: (_obj, { root }) => {
-    return db.user.findUnique({ where: { id: root?.id } }).certified()
-  },
   uploaded: (_obj, { root }) => {
     return db.user.findUnique({ where: { id: root?.id } }).uploaded()
   },

--- a/api/src/services/validationRuleses/validationRuleses.ts
+++ b/api/src/services/validationRuleses/validationRuleses.ts
@@ -44,4 +44,9 @@ export const ValidationRules: ValidationRulesRelationResolvers = {
       .findUnique({ where: { id: root?.id } })
       .validations()
   },
+  reportingPeriods: (_obj, { root }) => {
+    return db.validationRules
+      .findUnique({ where: { id: root?.id } })
+      .reportingPeriods()
+  },
 }

--- a/api/types/graphql.d.ts
+++ b/api/types/graphql.d.ts
@@ -141,11 +141,8 @@ export type CreateProjectInput = {
 }
 
 export type CreateReportingPeriodInput = {
-  certifiedAt?: InputMaybe<Scalars['DateTime']>
-  certifiedById?: InputMaybe<Scalars['Int']>
   endDate: Scalars['DateTime']
   inputTemplateId: Scalars['Int']
-  isCurrentPeriod: Scalars['Boolean']
   name: Scalars['String']
   organizationId: Scalars['Int']
   outputTemplateId: Scalars['Int']
@@ -575,15 +572,11 @@ export type Redwood = {
 
 export type ReportingPeriod = {
   __typename?: 'ReportingPeriod'
-  certifiedAt?: Maybe<Scalars['DateTime']>
-  certifiedBy?: Maybe<User>
-  certifiedById?: Maybe<Scalars['Int']>
   createdAt: Scalars['DateTime']
   endDate: Scalars['DateTime']
   id: Scalars['Int']
   inputTemplate: InputTemplate
   inputTemplateId: Scalars['Int']
-  isCurrentPeriod: Scalars['Boolean']
   name: Scalars['String']
   organization: Organization
   organizationId: Scalars['Int']
@@ -593,6 +586,8 @@ export type ReportingPeriod = {
   startDate: Scalars['DateTime']
   updatedAt: Scalars['DateTime']
   uploads: Array<Maybe<Upload>>
+  validationRulesId: Maybe<Scalars['Int']>
+  validationRules: Maybe<ValidationRules>
 }
 
 export type RoleEnum =
@@ -656,11 +651,8 @@ export type UpdateProjectInput = {
 }
 
 export type UpdateReportingPeriodInput = {
-  certifiedAt?: InputMaybe<Scalars['DateTime']>
-  certifiedById?: InputMaybe<Scalars['Int']>
   endDate?: InputMaybe<Scalars['DateTime']>
   inputTemplateId?: InputMaybe<Scalars['Int']>
-  isCurrentPeriod?: InputMaybe<Scalars['Boolean']>
   name?: InputMaybe<Scalars['String']>
   organizationId?: InputMaybe<Scalars['Int']>
   outputTemplateId?: InputMaybe<Scalars['Int']>
@@ -741,7 +733,6 @@ export type User = {
   __typename?: 'User'
   agency: Agency
   agencyId: Scalars['Int']
-  certified: Array<Maybe<ReportingPeriod>>
   createdAt: Scalars['DateTime']
   email: Scalars['String']
   id: Scalars['Int']
@@ -2468,21 +2459,6 @@ export type ReportingPeriodResolvers<
   ContextType = RedwoodGraphQLContext,
   ParentType extends ResolversParentTypes['ReportingPeriod'] = ResolversParentTypes['ReportingPeriod']
 > = {
-  certifiedAt: OptArgsResolverFn<
-    Maybe<ResolversTypes['DateTime']>,
-    ParentType,
-    ContextType
-  >
-  certifiedBy: OptArgsResolverFn<
-    Maybe<ResolversTypes['User']>,
-    ParentType,
-    ContextType
-  >
-  certifiedById: OptArgsResolverFn<
-    Maybe<ResolversTypes['Int']>,
-    ParentType,
-    ContextType
-  >
   createdAt: OptArgsResolverFn<
     ResolversTypes['DateTime'],
     ParentType,
@@ -2501,11 +2477,6 @@ export type ReportingPeriodResolvers<
   >
   inputTemplateId: OptArgsResolverFn<
     ResolversTypes['Int'],
-    ParentType,
-    ContextType
-  >
-  isCurrentPeriod: OptArgsResolverFn<
-    ResolversTypes['Boolean'],
     ParentType,
     ContextType
   >
@@ -2550,6 +2521,16 @@ export type ReportingPeriodResolvers<
     ParentType,
     ContextType
   >
+  validationRules: OptArgsResolverFn<
+  Maybe<ResolversTypes['ValidationRules']>,
+  ParentType,
+  ContextType
+>
+validationRulesId: OptArgsResolverFn<
+  Maybe<ResolversTypes['Int']>,
+  ParentType,
+  ContextType
+>
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -2557,21 +2538,6 @@ export type ReportingPeriodRelationResolvers<
   ContextType = RedwoodGraphQLContext,
   ParentType extends ResolversParentTypes['ReportingPeriod'] = ResolversParentTypes['ReportingPeriod']
 > = {
-  certifiedAt?: RequiredResolverFn<
-    Maybe<ResolversTypes['DateTime']>,
-    ParentType,
-    ContextType
-  >
-  certifiedBy?: RequiredResolverFn<
-    Maybe<ResolversTypes['User']>,
-    ParentType,
-    ContextType
-  >
-  certifiedById?: RequiredResolverFn<
-    Maybe<ResolversTypes['Int']>,
-    ParentType,
-    ContextType
-  >
   createdAt?: RequiredResolverFn<
     ResolversTypes['DateTime'],
     ParentType,
@@ -2590,11 +2556,6 @@ export type ReportingPeriodRelationResolvers<
   >
   inputTemplateId?: RequiredResolverFn<
     ResolversTypes['Int'],
-    ParentType,
-    ContextType
-  >
-  isCurrentPeriod?: RequiredResolverFn<
-    ResolversTypes['Boolean'],
     ParentType,
     ContextType
   >
@@ -2636,6 +2597,16 @@ export type ReportingPeriodRelationResolvers<
   >
   uploads?: RequiredResolverFn<
     Array<Maybe<ResolversTypes['Upload']>>,
+    ParentType,
+    ContextType
+  >
+  validationRules?: RequiredResolverFn<
+    Maybe<ResolversTypes['ValidationRules']>,
+    ParentType,
+    ContextType
+  >
+  validationRulesId?: RequiredResolverFn<
+    Maybe<ResolversTypes['Int']>,
     ParentType,
     ContextType
   >
@@ -2989,11 +2960,6 @@ export type UserResolvers<
 > = {
   agency: OptArgsResolverFn<ResolversTypes['Agency'], ParentType, ContextType>
   agencyId: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>
-  certified: OptArgsResolverFn<
-    Array<Maybe<ResolversTypes['ReportingPeriod']>>,
-    ParentType,
-    ContextType
-  >
   createdAt: OptArgsResolverFn<
     ResolversTypes['DateTime'],
     ParentType,
@@ -3022,11 +2988,6 @@ export type UserRelationResolvers<
 > = {
   agency?: RequiredResolverFn<ResolversTypes['Agency'], ParentType, ContextType>
   agencyId?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>
-  certified?: RequiredResolverFn<
-    Array<Maybe<ResolversTypes['ReportingPeriod']>>,
-    ParentType,
-    ContextType
-  >
   createdAt?: RequiredResolverFn<
     ResolversTypes['DateTime'],
     ParentType,
@@ -3069,6 +3030,11 @@ export type ValidationRulesResolvers<
     ParentType,
     ContextType
   >
+  reportingPeriods: OptArgsResolverFn<
+    Array<Maybe<ResolversTypes['ReportingPeriod']>>,
+    ParentType,
+    ContextType
+  >
   versionId: OptArgsResolverFn<
     ResolversTypes['Version'],
     ParentType,
@@ -3097,6 +3063,11 @@ export type ValidationRulesRelationResolvers<
     ParentType,
     ContextType
   >
+  reportingPeriods?: RequiredResolverFn<
+    Array<Maybe<ResolversTypes['ReportingPeriod']>>,
+    ParentType,
+    ContextType
+  > 
   versionId?: RequiredResolverFn<
     ResolversTypes['Version'],
     ParentType,

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,8 +1,9 @@
 import type { Prisma } from '@prisma/client'
-import { db } from 'api/src/lib/db'
+import { db, getPrismaClient } from 'api/src/lib/db'
 
 export default async () => {
   try {
+    await getPrismaClient()
     //
     // Manually seed via `yarn rw prisma db seed`
     // Seeds automatically with `yarn rw prisma migrate dev` and `yarn rw prisma migrate reset`

--- a/web/src/components/ReportingPeriod/EditReportingPeriodCell/EditReportingPeriodCell.tsx
+++ b/web/src/components/ReportingPeriod/EditReportingPeriodCell/EditReportingPeriodCell.tsx
@@ -18,11 +18,8 @@ export const QUERY = gql`
       startDate
       endDate
       organizationId
-      certifiedAt
-      certifiedById
       inputTemplateId
       outputTemplateId
-      isCurrentPeriod
       createdAt
       updatedAt
     }
@@ -39,11 +36,8 @@ const UPDATE_REPORTING_PERIOD_MUTATION = gql`
       startDate
       endDate
       organizationId
-      certifiedAt
-      certifiedById
       inputTemplateId
       outputTemplateId
-      isCurrentPeriod
       createdAt
       updatedAt
     }

--- a/web/src/components/ReportingPeriod/ReportingPeriod/ReportingPeriod.tsx
+++ b/web/src/components/ReportingPeriod/ReportingPeriod/ReportingPeriod.tsx
@@ -7,7 +7,7 @@ import { Link, routes, navigate } from '@redwoodjs/router'
 import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 
-import { checkboxInputTag, timeTag } from 'src/lib/formatters'
+import { timeTag } from 'src/lib/formatters'
 
 const DELETE_REPORTING_PERIOD_MUTATION = gql`
   mutation DeleteReportingPeriodMutation($id: Int!) {
@@ -74,24 +74,12 @@ const ReportingPeriod = ({ reportingPeriod }: Props) => {
               <td>{reportingPeriod.organizationId}</td>
             </tr>
             <tr>
-              <th>Certified at</th>
-              <td>{timeTag(reportingPeriod.certifiedAt)}</td>
-            </tr>
-            <tr>
-              <th>Certified by id</th>
-              <td>{reportingPeriod.certifiedById}</td>
-            </tr>
-            <tr>
               <th>Input template id</th>
               <td>{reportingPeriod.inputTemplateId}</td>
             </tr>
             <tr>
               <th>Output template id</th>
               <td>{reportingPeriod.outputTemplateId}</td>
-            </tr>
-            <tr>
-              <th>Is current period</th>
-              <td>{checkboxInputTag(reportingPeriod.isCurrentPeriod)}</td>
             </tr>
             <tr>
               <th>Created at</th>

--- a/web/src/components/ReportingPeriod/ReportingPeriodCell/ReportingPeriodCell.tsx
+++ b/web/src/components/ReportingPeriod/ReportingPeriodCell/ReportingPeriodCell.tsx
@@ -12,11 +12,8 @@ export const QUERY = gql`
       startDate
       endDate
       organizationId
-      certifiedAt
-      certifiedById
       inputTemplateId
       outputTemplateId
-      isCurrentPeriod
       createdAt
       updatedAt
     }

--- a/web/src/components/ReportingPeriod/ReportingPeriodForm/ReportingPeriodForm.tsx
+++ b/web/src/components/ReportingPeriod/ReportingPeriodForm/ReportingPeriodForm.tsx
@@ -11,7 +11,6 @@ import {
   TextField,
   DatetimeLocalField,
   NumberField,
-  CheckboxField,
   Submit,
 } from '@redwoodjs/forms'
 import type { RWGqlError } from '@redwoodjs/forms'
@@ -124,41 +123,6 @@ const ReportingPeriodForm = (props: ReportingPeriodFormProps) => {
         <FieldError name="organizationId" className="rw-field-error" />
 
         <Label
-          name="certifiedAt"
-          className="rw-label"
-          errorClassName="rw-label rw-label-error"
-        >
-          Certified at
-        </Label>
-
-        <DatetimeLocalField
-          name="certifiedAt"
-          defaultValue={formatDatetime(props.reportingPeriod?.certifiedAt)}
-          className="rw-input"
-          errorClassName="rw-input rw-input-error"
-        />
-
-        <FieldError name="certifiedAt" className="rw-field-error" />
-
-        <Label
-          name="certifiedById"
-          className="rw-label"
-          errorClassName="rw-label rw-label-error"
-        >
-          Certified by id
-        </Label>
-
-        <NumberField
-          name="certifiedById"
-          defaultValue={props.reportingPeriod?.certifiedById}
-          className="rw-input"
-          errorClassName="rw-input rw-input-error"
-          emptyAs={'undefined'}
-        />
-
-        <FieldError name="certifiedById" className="rw-field-error" />
-
-        <Label
           name="inputTemplateId"
           className="rw-label"
           errorClassName="rw-label rw-label-error"
@@ -193,23 +157,6 @@ const ReportingPeriodForm = (props: ReportingPeriodFormProps) => {
         />
 
         <FieldError name="outputTemplateId" className="rw-field-error" />
-
-        <Label
-          name="isCurrentPeriod"
-          className="rw-label"
-          errorClassName="rw-label rw-label-error"
-        >
-          Is current period
-        </Label>
-
-        <CheckboxField
-          name="isCurrentPeriod"
-          defaultChecked={props.reportingPeriod?.isCurrentPeriod}
-          className="rw-input"
-          errorClassName="rw-input rw-input-error"
-        />
-
-        <FieldError name="isCurrentPeriod" className="rw-field-error" />
 
         <div className="rw-button-group">
           <Submit disabled={props.loading} className="rw-button rw-button-blue">

--- a/web/src/components/ReportingPeriod/ReportingPeriods/ReportingPeriods.tsx
+++ b/web/src/components/ReportingPeriod/ReportingPeriods/ReportingPeriods.tsx
@@ -8,7 +8,7 @@ import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 
 import { QUERY } from 'src/components/ReportingPeriod/ReportingPeriodsCell'
-import { checkboxInputTag, timeTag, truncate } from 'src/lib/formatters'
+import { timeTag, truncate } from 'src/lib/formatters'
 
 const DELETE_REPORTING_PERIOD_MUTATION = gql`
   mutation DeleteReportingPeriodMutation($id: Int!) {
@@ -54,11 +54,8 @@ const ReportingPeriodsList = ({ reportingPeriods }: FindReportingPeriods) => {
             <th>Start date</th>
             <th>End date</th>
             <th>Organization id</th>
-            <th>Certified at</th>
-            <th>Certified by id</th>
             <th>Input template id</th>
             <th>Output template id</th>
-            <th>Is current period</th>
             <th>Created at</th>
             <th>Updated at</th>
             <th>&nbsp;</th>
@@ -72,11 +69,8 @@ const ReportingPeriodsList = ({ reportingPeriods }: FindReportingPeriods) => {
               <td>{timeTag(reportingPeriod.startDate)}</td>
               <td>{timeTag(reportingPeriod.endDate)}</td>
               <td>{truncate(reportingPeriod.organizationId)}</td>
-              <td>{timeTag(reportingPeriod.certifiedAt)}</td>
-              <td>{truncate(reportingPeriod.certifiedById)}</td>
               <td>{truncate(reportingPeriod.inputTemplateId)}</td>
               <td>{truncate(reportingPeriod.outputTemplateId)}</td>
-              <td>{checkboxInputTag(reportingPeriod.isCurrentPeriod)}</td>
               <td>{timeTag(reportingPeriod.createdAt)}</td>
               <td>{timeTag(reportingPeriod.updatedAt)}</td>
               <td>

--- a/web/src/components/ReportingPeriod/ReportingPeriodsCell/ReportingPeriodsCell.tsx
+++ b/web/src/components/ReportingPeriod/ReportingPeriodsCell/ReportingPeriodsCell.tsx
@@ -13,11 +13,8 @@ export const QUERY = gql`
       startDate
       endDate
       organizationId
-      certifiedAt
-      certifiedById
       inputTemplateId
       outputTemplateId
-      isCurrentPeriod
       createdAt
       updatedAt
     }

--- a/web/src/components/ReportingPeriodsCell/ReportingPeriodsCell.tsx
+++ b/web/src/components/ReportingPeriodsCell/ReportingPeriodsCell.tsx
@@ -11,11 +11,6 @@ export const QUERY = gql`
       id
       startDate
       endDate
-      isCurrentPeriod
-      certifiedAt
-      certifiedBy {
-        email
-      }
       inputTemplate {
         name
       }
@@ -41,7 +36,6 @@ export const Success = ({
           <th>Start Date</th>
           <th>End Date</th>
           <th>Template</th>
-          <th>Certified At</th>
           <th>Actions</th>
         </tr>
       </thead>
@@ -53,25 +47,6 @@ export const Success = ({
               <td>{item.endDate}</td>
               <td>
                 {item.inputTemplate?.name}
-                {!item.certifiedAt && (
-                  <span>
-                    {' '}
-                    <Link to={routes.uploadTemplate({ id: item.id })}>
-                      Upload Template
-                    </Link>
-                  </span>
-                )}
-              </td>
-              <td>
-                {item.isCurrentPeriod ? (
-                  <Button size="sm">Certify Reporting Period</Button>
-                ) : (
-                  item.certifiedAt && (
-                    <span>
-                      {item.certifiedAt} by {item.certifiedBy?.email}
-                    </span>
-                  )
-                )}
               </td>
               <td>
                 <nav>

--- a/web/types/graphql.d.ts
+++ b/web/types/graphql.d.ts
@@ -92,11 +92,8 @@ export type CreateProjectInput = {
 }
 
 export type CreateReportingPeriodInput = {
-  certifiedAt?: InputMaybe<Scalars['DateTime']>
-  certifiedById?: InputMaybe<Scalars['Int']>
   endDate: Scalars['DateTime']
   inputTemplateId: Scalars['Int']
-  isCurrentPeriod: Scalars['Boolean']
   name: Scalars['String']
   organizationId: Scalars['Int']
   outputTemplateId: Scalars['Int']
@@ -526,15 +523,11 @@ export type Redwood = {
 
 export type ReportingPeriod = {
   __typename?: 'ReportingPeriod'
-  certifiedAt?: Maybe<Scalars['DateTime']>
-  certifiedBy?: Maybe<User>
-  certifiedById?: Maybe<Scalars['Int']>
   createdAt: Scalars['DateTime']
   endDate: Scalars['DateTime']
   id: Scalars['Int']
   inputTemplate: InputTemplate
   inputTemplateId: Scalars['Int']
-  isCurrentPeriod: Scalars['Boolean']
   name: Scalars['String']
   organization: Organization
   organizationId: Scalars['Int']
@@ -544,6 +537,8 @@ export type ReportingPeriod = {
   startDate: Scalars['DateTime']
   updatedAt: Scalars['DateTime']
   uploads: Array<Maybe<Upload>>
+  validationRules: Maybe<ValidationRules>
+  validationRulesId: Maybe<['Int']>
 }
 
 export type RoleEnum =
@@ -607,11 +602,8 @@ export type UpdateProjectInput = {
 }
 
 export type UpdateReportingPeriodInput = {
-  certifiedAt?: InputMaybe<Scalars['DateTime']>
-  certifiedById?: InputMaybe<Scalars['Int']>
   endDate?: InputMaybe<Scalars['DateTime']>
   inputTemplateId?: InputMaybe<Scalars['Int']>
-  isCurrentPeriod?: InputMaybe<Scalars['Boolean']>
   name?: InputMaybe<Scalars['String']>
   organizationId?: InputMaybe<Scalars['Int']>
   outputTemplateId?: InputMaybe<Scalars['Int']>
@@ -691,7 +683,6 @@ export type User = {
   __typename?: 'User'
   agency: Agency
   agencyId: Scalars['Int']
-  certified: Array<Maybe<ReportingPeriod>>
   createdAt: Scalars['DateTime']
   email: Scalars['String']
   id: Scalars['Int']
@@ -708,6 +699,7 @@ export type ValidationRules = {
   updatedAt: Scalars['DateTime']
   validations: Array<Maybe<UploadValidation>>
   versionId: Version
+  reportingPeriods: Array<Maybe<ReportingPeriod>>
 }
 
 export type Version = 'V2023_12_12' | 'V2024_01_07' | 'V2024_04_01'
@@ -891,11 +883,8 @@ export type EditReportingPeriodById = {
     startDate: string
     endDate: string
     organizationId: number
-    certifiedAt?: string | null
-    certifiedById?: number | null
     inputTemplateId: number
     outputTemplateId: number
-    isCurrentPeriod: boolean
     createdAt: string
     updatedAt: string
   } | null
@@ -956,11 +945,8 @@ export type FindReportingPeriodById = {
     startDate: string
     endDate: string
     organizationId: number
-    certifiedAt?: string | null
-    certifiedById?: number | null
     inputTemplateId: number
     outputTemplateId: number
-    isCurrentPeriod: boolean
     createdAt: string
     updatedAt: string
   } | null
@@ -977,11 +963,8 @@ export type FindReportingPeriods = {
     startDate: string
     endDate: string
     organizationId: number
-    certifiedAt?: string | null
-    certifiedById?: number | null
     inputTemplateId: number
     outputTemplateId: number
-    isCurrentPeriod: boolean
     createdAt: string
     updatedAt: string
   }>
@@ -996,9 +979,6 @@ export type ReportingPeriodsQuery = {
     id: number
     startDate: string
     endDate: string
-    isCurrentPeriod: boolean
-    certifiedAt?: string | null
-    certifiedBy?: { __typename?: 'User'; email: string } | null
     inputTemplate: { __typename?: 'InputTemplate'; name: string }
   }>
 }


### PR DESCRIPTION
This essentially is the same as the changes in [274](https://github.com/usdigitalresponse/cpf-reporter/pull/274), but after conversation with @as1729 we are not yet severing the link between reporting periods and organizations. We need to add the UI to collect organization preferences JSON, which will include a reporting period ID, and use that to link uploads to reporting periods. I will file a follow on ticket to remove the link between `organization` and `reporting period` when that is done.