### PR TITLE
Fix python variable bug

### DIFF
--- a/python/src/functions/validate_workbook.py
+++ b/python/src/functions/validate_workbook.py
@@ -80,7 +80,7 @@ def validate_workbook(file: IO[bytes]) -> ValidationResults:
     logger.debug("validating workbook")
 
     try:
-        errors, expenditure_category_group = validate(file)
+        errors, project_use_code = validate(file)
     except:
         logger.exception("unhandled exception validating workbook")
         raise


### PR DESCRIPTION
- When I added in the new schema versioning, I experimented with changing our references to `project_use_code` to `expenditure_category_group`, since that's now what we're calling that field. I ultimately decided to put it back because I felt the diff was large enough as it was, but I missed one spot which is causing issues in staging
- This should fix staging by setting back the variable init to what it was before