### PR TITLE
Adjust error messages

### DIFF
--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -325,7 +325,7 @@ def validate_project_sheet(project_sheet: Worksheet, project_schema: Type[Union[
     if not sheet_has_data:
         errors += [WorkbookError(
             message="Upload doesn’t include any project records.",
-            row=INITIAL_STARTING_ROW,
+            row=INITIAL_STARTING_ROW + 1,
             col=0,
             tab=PROJECT_SHEET,
             field_name="",

--- a/python/src/schemas/schema_V2024_04_01.py
+++ b/python/src/schemas/schema_V2024_04_01.py
@@ -733,10 +733,6 @@ class CoverSheetRow(BaseModel):
             raise ValueError(
                 f"EC code must be set"
             )
-        elif v not in ProjectType:
-            raise ValueError(
-                f"EC code '{v}' is not recognized."
-            )
         return v
 
     @field_validator("project_use_name")

--- a/python/src/schemas/schema_V2024_05_24.py
+++ b/python/src/schemas/schema_V2024_05_24.py
@@ -812,10 +812,6 @@ class CoverSheetRow(BaseModel):
             raise ValueError(
                 f"EC code must be set"
             )
-        elif v not in ProjectType:
-            raise ValueError(
-                f"EC code '{v}' is not recognized."
-            )
         return v
 
     @field_validator("detailed_expenditure_category")

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -58,6 +58,12 @@ def invalid_cover_sheet_empty_code(valid_coversheet):
 
 
 @pytest.fixture
+def invalid_cover_sheet_empty_desc(valid_coversheet):
+    valid_coversheet["B2"] = "  "
+    return valid_coversheet
+
+
+@pytest.fixture
 def invalid_project_sheet(valid_project_sheet):
     valid_project_sheet["D13"] = "X" * 21
     return valid_project_sheet

--- a/python/tests/src/lib/test_workbook_validator.py
+++ b/python/tests/src/lib/test_workbook_validator.py
@@ -92,19 +92,6 @@ class TestValidateCoverSheet:
         assert errors == []
         assert project_use_code == SAMPLE_EXPENDITURE_CATEGORY_GROUP
         assert schema == getSchemaByProject(V2024_05_24_VERSION_STRING, SAMPLE_EXPENDITURE_CATEGORY_GROUP)
-
-    def test_invalid_cover_sheet(self, invalid_cover_sheet: Worksheet):
-        errors, schema, project_use_code = validate_cover_sheet(invalid_cover_sheet, V2024_05_24_VERSION_STRING)
-        assert errors != []
-        error = errors[0]
-        assert "EC code 'INVALID' is not recognized." in error.message
-        assert error.col == "A"
-        assert error.row == "2"
-        assert error.tab == "Cover"
-        assert error.severity == ErrorLevel.ERR.name
-        assert schema is None
-        assert project_use_code is None
-    
     
     def test_invalid_cover_sheet_missing_code(self, invalid_cover_sheet_missing_code: Worksheet):
         errors, schema, project_use_code = validate_cover_sheet(invalid_cover_sheet_missing_code, V2024_05_24_VERSION_STRING)
@@ -125,6 +112,18 @@ class TestValidateCoverSheet:
         error = errors[0]
         assert "EC code must be set" in error.message
         assert error.col == "A"
+        assert error.row == "2"
+        assert error.tab == "Cover"
+        assert error.severity == ErrorLevel.ERR.name
+        assert schema is None
+        assert project_use_code is None
+
+    def test_invalid_cover_sheet_empty_desc(self, invalid_cover_sheet_empty_desc: Worksheet):
+        errors, schema, project_use_code = validate_cover_sheet(invalid_cover_sheet_empty_desc, V2024_05_24_VERSION_STRING)
+        assert errors != []
+        error = errors[0]
+        assert "Value is required for detailed_expenditure_category" in error.message
+        assert error.col == "B"
         assert error.row == "2"
         assert error.tab == "Cover"
         assert error.severity == ErrorLevel.ERR.name


### PR DESCRIPTION
Due to a macro in the worksheet, the A2 field stays in sync with B2 so we don't need to show the invalid error. We could actually remove all validation on A2 if we want too but I left it in for now to be safe.

https://github.com/usdigitalresponse/cpf-reporter/issues/305