### PR TITLE
Enforce linter checks in CI

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -209,6 +209,9 @@ jobs:
       - name: Run linter for web side
         if: ${{ !cancelled() }}
         run: yarn eslint web/src
+      - name: Run linter for scripts
+        if: ${{ !cancelled() }}
+        run: yarn eslint scripts
 
   ruff:
     name: Lint python

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -224,7 +224,6 @@ jobs:
           show-progress: 'false'
           persist-credentials: 'false'
       - uses: chartboost/ruff-action@e18ae971ccee1b2d7bbef113930f00c670b78da4 # v1
-        continue-on-error: true
         with:
           src: python
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,6 +9,7 @@
 		"hashicorp.terraform",
 		"ms-azuretools.vscode-docker",
 		"ms-python.python",
+		"njpwerner.autodocstring",
 		"tamasfe.even-better-toml",
 	],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,4 +19,5 @@
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": false,
+    "autoDocstring.docstringFormat": "google-notypes"
 }

--- a/python/src/functions/validate_workbook.py
+++ b/python/src/functions/validate_workbook.py
@@ -12,7 +12,8 @@ from mypy_boto3_s3.client import S3Client
 from src.lib.logging import get_logger, reset_contextvars
 from src.lib.workbook_validator import validate
 
-type ValidationResults = Dict[str, Union[List[Dict[str,str]], str, None]]
+type ValidationResults = Dict[str, Union[List[Dict[str, str]], str, None]]
+
 
 @reset_contextvars
 def handle(event: S3Event, context: Context):
@@ -85,9 +86,7 @@ def validate_workbook(file: IO[bytes]) -> ValidationResults:
         logger.exception("unhandled exception validating workbook")
         raise
 
-    logger.debug(
-        "successfully validated workbook", count_validation_errors=len(errors)
-    )
+    logger.debug("successfully validated workbook", count_validation_errors=len(errors))
     results: ValidationResults = {
         "errors": list(map(lambda x: x.__dict__, errors)),
         "projectUseCode": project_use_code,
@@ -95,7 +94,9 @@ def validate_workbook(file: IO[bytes]) -> ValidationResults:
     return results
 
 
-def save_validation_results(client: S3Client, bucket, key: str, results: ValidationResults):
+def save_validation_results(
+    client: S3Client, bucket, key: str, results: ValidationResults
+):
     """Persists workbook validation results to S3.
 
     Args:

--- a/python/src/lib/output_template_comparator.py
+++ b/python/src/lib/output_template_comparator.py
@@ -204,9 +204,9 @@ def compare(
                 previous_sheet, latest_sheet, header_map
             )
             if cell_value_differences:
-                differences.cell_value_changed[
-                    f"{file}: {sheet}"
-                ] += cell_value_differences
+                differences.cell_value_changed[f"{file}: {sheet}"] += (
+                    cell_value_differences
+                )
 
     return differences
 

--- a/python/src/lib/output_template_comparator.py
+++ b/python/src/lib/output_template_comparator.py
@@ -54,9 +54,7 @@ class CPFDiffReport:
 
 
 class CPFFileArchive:
-    """
-    Class for working with a CPF file archive
-    """
+    """Class for working with a CPF file archive"""
 
     _zip_file: zipfile.ZipFile
     _file_name_map: dict
@@ -66,21 +64,15 @@ class CPFFileArchive:
         self._normalize_names()
 
     def normalized_file_names(self) -> Set[str]:
-        """
-        Returns a dictionary of normalized file names
-        """
+        """Returns a dictionary of normalized file names"""
         return set(self._file_name_map.keys())
 
     def file_by_name(self, name) -> zipfile.ZipExtFile:
-        """
-        Returns a file object by name
-        """
+        """Returns a file object by name"""
         return self._zip_file.open(self._file_name_map[name])
 
     def _normalize_names(self):
-        """
-        Normalizes file names
-        """
+        """Normalizes file names"""
         suffix_regex = r"\s\(\d+\)"
         normalized_files = {}
         for file in self._zip_file.namelist():
@@ -212,10 +204,11 @@ def compare(
 
 
 def load_files(zip_path) -> zipfile.ZipFile:
-    """
-    Load XLSX files from a zip file
+    """Loads XLSX files from a zip file.
+
     Args:
         zip_path (str): Path to the zip file
+
     Returns:
         list: List of files in the zip file
     """
@@ -224,13 +217,14 @@ def load_files(zip_path) -> zipfile.ZipFile:
 
 
 if __name__ == "__main__":
-    """
-    Main function to test comparator function
-    Accepts two arguments. First argument is the "latest" template. Second argument is the previous template.
-    Returns a list of changes that are in the latest template that are different from the previous template.
+    """Main function to test comparator function.
+
+    Accepts two arguments:
+        1. Argument is the "latest" template. Second argument is the previous template.
+        2. Returns a list of changes that are in the latest template that are different
+        from the previous template.
 
     Run with `poetry run python -m src.lib.output_template_comparator 2024_05_16.zip 2024_04_26.zip`
-
     """
     import sys
 

--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -259,7 +259,9 @@ def validate_workbook(workbook: Workbook) -> Tuple[Errors, Optional[str]]:
     3. Ensure all project rows are validated with the schema
     """
     if project_schema:
-        project_errors, projects = validate_project_sheet(workbook[PROJECT_SHEET], project_schema, version_string)
+        project_errors, projects = validate_project_sheet(
+            workbook[PROJECT_SHEET], project_schema, version_string
+        )
         errors += project_errors
     else:
         projects = None
@@ -267,7 +269,9 @@ def validate_workbook(workbook: Workbook) -> Tuple[Errors, Optional[str]]:
     """
     4. Ensure all subrecipient rows are validated with the schema
     """
-    subrecipient_errors, subrecipients = validate_subrecipient_sheet(workbook[SUBRECIPIENTS_SHEET], version_string)
+    subrecipient_errors, subrecipients = validate_subrecipient_sheet(
+        workbook[SUBRECIPIENTS_SHEET], version_string
+    )
     errors += subrecipient_errors
 
     """
@@ -360,8 +364,9 @@ def validate_cover_sheet(
 
 
 def validate_project_sheet(
-        project_sheet: Worksheet, project_schema: Type[Union[Project1ARow, Project1BRow, Project1CRow]], \
-        version_string: str
+    project_sheet: Worksheet,
+    project_schema: Type[Union[Project1ARow, Project1BRow, Project1CRow]],
+    version_string: str,
 ) -> Tuple[Errors, List[Union[Project1ARow, Project1BRow, Project1CRow]]]:
     errors = []
     metadata = getSchemaMetadata(version_string)
@@ -403,13 +408,14 @@ def validate_project_sheet(
 
 
 def validate_subrecipient_sheet(
-        subrecipient_sheet: Worksheet,
-        version_string: str
+    subrecipient_sheet: Worksheet, version_string: str
 ) -> Tuple[Errors, List[SubrecipientRow]]:
     errors = []
     metadata = getSchemaMetadata(version_string)
     subrecipients = []
-    subrecipient_headers = get_headers(subrecipient_sheet, metadata["Subrecipients"]["header_range"])
+    subrecipient_headers = get_headers(
+        subrecipient_sheet, metadata["Subrecipients"]["header_range"]
+    )
     current_row = INITIAL_STARTING_ROW
     SubrecipientRowClass = getSubrecipientRowClass(version_string)
     for subrecipient_row in subrecipient_sheet.iter_rows(
@@ -429,18 +435,29 @@ def validate_subrecipient_sheet(
 
 
 def validate_projects_subrecipients(
-        projects: List[Union[Project1ARow, Project1BRow, Project1CRow]],
-        subrecipients: List[SubrecipientRow]
+    projects: List[Union[Project1ARow, Project1BRow, Project1CRow]],
+    subrecipients: List[SubrecipientRow],
 ) -> Errors:
     errors = []
     subrecipients_by_uei_tin = {}
     for subrecipient in subrecipients:
-        subrecipients_by_uei_tin[(subrecipient.EIN__c, subrecipient.Unique_Entity_Identifier__c)] = subrecipient
+        subrecipients_by_uei_tin[
+            (subrecipient.EIN__c, subrecipient.Unique_Entity_Identifier__c)
+        ] = subrecipient
 
     for project in projects:
-        if subrecipients_by_uei_tin.get((project.Subrecipient_TIN__c, project.Subrecipient_UEI__c)) is None:
-            col_name_tin = project.__class__.model_fields["Subrecipient_TIN__c"].json_schema_extra['column']
-            col_name_uei = project.__class__.model_fields["Subrecipient_UEI__c"].json_schema_extra['column']
+        if (
+            subrecipients_by_uei_tin.get(
+                (project.Subrecipient_TIN__c, project.Subrecipient_UEI__c)
+            )
+            is None
+        ):
+            col_name_tin = project.__class__.model_fields[
+                "Subrecipient_TIN__c"
+            ].json_schema_extra["column"]
+            col_name_uei = project.__class__.model_fields[
+                "Subrecipient_UEI__c"
+            ].json_schema_extra["column"]
             errors.append(
                 WorkbookError(
                     message="You must submit a subrecipient record with the same UEI & TIN numbers entered for this project",

--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -376,14 +376,16 @@ def validate_project_sheet(
             )
 
     if not sheet_has_data:
-        errors += [WorkbookError(
-            message="Upload doesn’t include any project records.",
-            row=INITIAL_STARTING_ROW + 1,
-            col=0,
-            tab=PROJECT_SHEET,
-            field_name="",
-            severity=ErrorLevel.ERR.name,
-        )]
+        errors += [
+            WorkbookError(
+                message="Upload doesn’t include any project records.",
+                row=INITIAL_STARTING_ROW + 1,
+                col=0,
+                tab=PROJECT_SHEET,
+                field_name="",
+                severity=ErrorLevel.ERR.name,
+            )
+        ]
 
     return errors
 

--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -127,7 +127,7 @@ def generate_error_text(
             field_name == "project_use_code"
             or field_name == "expenditure_category_group"
         ):
-            return f"EC code must be set"
+            return "EC code must be set"
         else:
             return f"Value is required for {field_name}"
     elif error_type == "string_too_long" or error_type == "string_too_short":

--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -80,17 +80,16 @@ def get_headers(sheet: Worksheet, cell_range: str) -> tuple:
     return tuple(header_cell.value for header_cell in sheet[cell_range][0])
 
 
-"""
-This function gets the Project Use Code / Expenditure Category Group (depending on version) from the cover sheet or uses the row provided.
-If the project use code is not found or if it does not match any of the ProjectType values, it raises an error.
-"""
-
-
 def get_project_use_code(
     cover_sheet: Worksheet,
     version_string: str,
     row_dict: Optional[Dict[str, str]] = None,
 ) -> ProjectType:
+    """This function gets the Project Use Code / Expenditure Category Group
+    (depending on version) from the cover sheet or uses the row provided.
+    If the project use code is not found or if it does not match any of the ProjectType
+    values, it raises an error.
+    """
     metadata = getSchemaMetadata(version_string)
     if not row_dict:
         cover_header = get_headers(cover_sheet, metadata["Cover"]["header_range"])
@@ -104,21 +103,23 @@ def get_project_use_code(
     return ProjectType.from_project_name(code)
 
 
-"""
-This function converts a list of ValidationError records for a single row into a list of WorkbookError records.
-Since each row has many different fields-- there can be multiple errors in a single row.
-It maps the thrown error to the impacted column in the spreadsheet.
-It does so by first getting the error's location (the loc property), which is the field name,
-and then grabbing that field off of the relevant model class passed in.
-On the model class, the field definition has a property of json_schema_extra,
-defined in schema.py on a per-field basis, that contains the column for that particular field.
-"""
-
-
 def generate_error_text(
     field_name: str,
     error: ErrorDetails,
 ) -> str:
+    """This function converts a list of ValidationError records for a single row
+    into a list of WorkbookError records.
+
+    Since each row has many different fields and there can be multiple errors in
+    a single row, it maps the thrown error to the impacted column in the spreadsheet.
+    It does so by first getting the error's location (the loc property), which is
+    the field name, and then grabbing that field off of the relevant model class
+    passed in.
+
+    On the model class, the field definition has a property of `json_schema_extra`,
+    defined in the schema on a per-field basis, which contains the column for that
+    particular field.
+    """
     error_type = error["type"]
     input = error["input"]
     if isinstance(input, str):
@@ -158,14 +159,14 @@ def get_workbook_errors_for_row(
     workbook_errors: List[WorkbookError] = []
     for error in e.errors():
         """
-            Sample structure of the variable `e` here-
+            Sample structure of the variable `e` here:
             https://docs.pydantic.dev/latest/api/pydantic_core/#pydantic_core.ErrorDetails
             {
-            'type': 'string_type',
-            'loc': ('Identification_Number__c',),
-            'msg': 'Input should be a valid string',
-            'input': None,
-            'url': 'https://errors.pydantic.dev/2.6/v/string_type'
+                'type': 'string_type',
+                'loc': ('Identification_Number__c',),
+                'msg': 'Input should be a valid string',
+                'input': None,
+                'url': 'https://errors.pydantic.dev/2.6/v/string_type'
             }
         """
         erroring_field_name: str = f'{error["loc"][0]}'
@@ -417,9 +418,9 @@ def validate_subrecipient_sheet(
 
 
 if __name__ == "__main__":
-    """
-        Main function to test validate function
-        Run with `poetry run python -m src.lib.workbook_validator upload.xlsm`
+    """Main block to test validate function
+
+    Run with `poetry run python -m src.lib.workbook_validator upload.xlsm`
     """
     import sys
 

--- a/python/src/schemas/project_types.py
+++ b/python/src/schemas/project_types.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+
 class ProjectType(str, Enum):
     _1A = "1A"
     _1B = "1B"
@@ -10,8 +11,11 @@ class ProjectType(str, Enum):
         for project_type in cls:
             if project_type.value == project_name:
                 return project_type
-        raise ValueError(f"Project name '{project_name}' is not a recognized project type.")
-    
+        raise ValueError(
+            f"Project name '{project_name}' is not a recognized project type."
+        )
+
+
 NAME_BY_PROJECT = {
     ProjectType._1A: "1A-Broadband Infrastructure",
     ProjectType._1B: "1B-Digital Connectivity Technology",

--- a/python/src/schemas/schema_V2024_04_01.py
+++ b/python/src/schemas/schema_V2024_04_01.py
@@ -990,7 +990,7 @@ class CoverSheetRow(BaseModel):
     @classmethod
     def validate_code(cls, v: Any, info: ValidationInfo, **kwargs):
         if v is None or v.strip() == "":
-            raise ValueError(f"EC code must be set")
+            raise ValueError("EC code must be set")
         elif v not in ProjectType:
             raise ValueError(f"EC code '{v}' is not recognized.")
         return v

--- a/python/src/schemas/schema_V2024_04_01.py
+++ b/python/src/schemas/schema_V2024_04_01.py
@@ -2,8 +2,16 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Optional
 
-from pydantic import (BaseModel, ConfigDict, Field, condecimal, conint, constr,
-                      ValidationInfo, field_validator)
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    condecimal,
+    conint,
+    constr,
+    ValidationInfo,
+    field_validator,
+)
 from src.schemas.project_types import ProjectType, NAME_BY_PROJECT
 
 
@@ -97,139 +105,226 @@ class ProjectInvestmentType(str, Enum):
 class BaseProjectRow(BaseModel):
     model_config = ConfigDict(coerce_numbers_to_str=True, loc_by_alias=False)
 
-    Project_Name__c: constr(strip_whitespace=True, min_length=1, max_length=100) = Field(
-        ..., serialization_alias="Project Name", json_schema_extra={"column":"C"}
+    Project_Name__c: constr(strip_whitespace=True, min_length=1, max_length=100) = (
+        Field(
+            ..., serialization_alias="Project Name", json_schema_extra={"column": "C"}
+        )
     )
-    Identification_Number__c: constr(strip_whitespace=True, min_length=1, max_length=20) = Field(
-        ..., serialization_alias="Identification Number", json_schema_extra={"column":"D"}
+    Identification_Number__c: constr(
+        strip_whitespace=True, min_length=1, max_length=20
+    ) = Field(
+        ...,
+        serialization_alias="Identification Number",
+        json_schema_extra={"column": "D"},
     )
-    
-    Project_Description__c: constr(strip_whitespace=True, min_length=1, max_length=3000) = Field(
-        ..., serialization_alias="Project Description", json_schema_extra={"column":"E"}
+
+    Project_Description__c: constr(
+        strip_whitespace=True, min_length=1, max_length=3000
+    ) = Field(
+        ...,
+        serialization_alias="Project Description",
+        json_schema_extra={"column": "E"},
     )
     Capital_Asset_Ownership_Type__c: CapitalAssetOwnershipType = Field(
-        ..., serialization_alias="Capital Asset Owenership Type", json_schema_extra={"column":"F"}
+        ...,
+        serialization_alias="Capital Asset Owenership Type",
+        json_schema_extra={"column": "F"},
     )
     Total_CPF_Funding_for_Project__c: condecimal(max_digits=13, decimal_places=2) = (
-        Field(..., serialization_alias="Total CPF Funding for Project", json_schema_extra={"column":"G"})
+        Field(
+            ...,
+            serialization_alias="Total CPF Funding for Project",
+            json_schema_extra={"column": "G"},
+        )
     )
     Total_from_all_funding_sources__c: condecimal(max_digits=13, decimal_places=2) = (
-        Field(..., serialization_alias="Total From all Funding Sources", json_schema_extra={"column":"H"})
+        Field(
+            ...,
+            serialization_alias="Total From all Funding Sources",
+            json_schema_extra={"column": "H"},
+        )
     )
     Narrative_Description__c: Optional[str] = Field(
-        default=None, serialization_alias="Narrative Description", max_length=3000, json_schema_extra={"column":"I"}
+        default=None,
+        serialization_alias="Narrative Description",
+        max_length=3000,
+        json_schema_extra={"column": "I"},
     )
     Current_Period_Obligation__c: condecimal(max_digits=12, decimal_places=2) = Field(
-        ..., serialization_alias="Current Period Obligation", json_schema_extra={"column":"J"}
+        ...,
+        serialization_alias="Current Period Obligation",
+        json_schema_extra={"column": "J"},
     )
     Current_Period_Expenditure__c: condecimal(max_digits=12, decimal_places=2) = Field(
-        ..., serialization_alias="Current Period Expenditure", json_schema_extra={"column":"K"}
+        ...,
+        serialization_alias="Current Period Expenditure",
+        json_schema_extra={"column": "K"},
     )
     Cumulative_Obligation__c: condecimal(max_digits=12, decimal_places=2) = Field(
-        ..., serialization_alias="Cumulative Obligation", json_schema_extra={"column":"L"}
+        ...,
+        serialization_alias="Cumulative Obligation",
+        json_schema_extra={"column": "L"},
     )
     Cumulative_Expenditure__c: condecimal(max_digits=12, decimal_places=2) = Field(
-        ..., serialization_alias="Cumulative Expenditure", json_schema_extra={"column":"M"}
+        ...,
+        serialization_alias="Cumulative Expenditure",
+        json_schema_extra={"column": "M"},
     )
-    Cost_Overview__c: constr(strip_whitespace=True, min_length=1, max_length=3000) = Field(
-        ..., serialization_alias="Cost Overview", json_schema_extra={"column":"N"}
+    Cost_Overview__c: constr(strip_whitespace=True, min_length=1, max_length=3000) = (
+        Field(
+            ..., serialization_alias="Cost Overview", json_schema_extra={"column": "N"}
+        )
     )
     Project_Status__c: ProjectStatusType = Field(
-        ..., serialization_alias="Project Status", json_schema_extra={"column":"O"}
+        ..., serialization_alias="Project Status", json_schema_extra={"column": "O"}
     )
     Projected_Con_Start_Date__c: Optional[datetime] = Field(
-        default=None, serialization_alias="Projected Con. Start Date", json_schema_extra={"column":"P"}
+        default=None,
+        serialization_alias="Projected Con. Start Date",
+        json_schema_extra={"column": "P"},
     )
     Projected_Con_Completion__c: Optional[datetime] = Field(
-        default=None, serialization_alias="Projected Con. Completion", json_schema_extra={"column":"Q"}
+        default=None,
+        serialization_alias="Projected Con. Completion",
+        json_schema_extra={"column": "Q"},
     )
     Projected_Init_of_Operations__c: Optional[datetime] = Field(
-        default=None, serialization_alias="Projected Init. of Operations", json_schema_extra={"column":"R"}
+        default=None,
+        serialization_alias="Projected Init. of Operations",
+        json_schema_extra={"column": "R"},
     )
     Actual_Con_Start_Date__c: Optional[datetime] = Field(
-        default=None, serialization_alias="Actual Con. Start Date", json_schema_extra={"column":"S"}
+        default=None,
+        serialization_alias="Actual Con. Start Date",
+        json_schema_extra={"column": "S"},
     )
     Actual_Con_Completion__c: Optional[datetime] = Field(
-        default=None, serialization_alias="Actual Con. Completion", json_schema_extra={"column":"T"}
+        default=None,
+        serialization_alias="Actual Con. Completion",
+        json_schema_extra={"column": "T"},
     )
     Operations_initiated__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Operations Initiated", json_schema_extra={"column":"U"}
+        default=None,
+        serialization_alias="Operations Initiated",
+        json_schema_extra={"column": "U"},
     )
     Actual_operations_date__c: Optional[datetime] = Field(
-        default=None, serialization_alias="Actual operations date", json_schema_extra={"column":"V"}
+        default=None,
+        serialization_alias="Actual operations date",
+        json_schema_extra={"column": "V"},
     )
     Operations_explanation__c: Optional[str] = Field(
-        default=None, serialization_alias="Operations explanation", max_length=3000, json_schema_extra={"column":"W"}
+        default=None,
+        serialization_alias="Operations explanation",
+        max_length=3000,
+        json_schema_extra={"column": "W"},
     )
     Other_Federal_Funding__c: YesNoType = Field(
-        ..., serialization_alias="Other Federal Funding?", json_schema_extra={"column":"X"}
+        ...,
+        serialization_alias="Other Federal Funding?",
+        json_schema_extra={"column": "X"},
     )
-    Matching_Funds__c: YesNoType = Field(..., serialization_alias="Matching Funds?", json_schema_extra={"column":"Y"})
+    Matching_Funds__c: YesNoType = Field(
+        ..., serialization_alias="Matching Funds?", json_schema_extra={"column": "Y"}
+    )
     Program_Information__c: Optional[str] = Field(
-        default=None, serialization_alias="Program Information", max_length=50, json_schema_extra={"column":"Z"}
+        default=None,
+        serialization_alias="Program Information",
+        max_length=50,
+        json_schema_extra={"column": "Z"},
     )
     Amount_of_Matching_Funds__c: Optional[
         condecimal(max_digits=12, decimal_places=2)
-    ] = Field(default=None, serialization_alias="Amount of Matching Funds", json_schema_extra={"column":"AA"})
+    ] = Field(
+        default=None,
+        serialization_alias="Amount of Matching Funds",
+        json_schema_extra={"column": "AA"},
+    )
     Target_Project_Info__c: Optional[str] = Field(
-        default=None, serialization_alias="Target Project Info", max_length=3000, json_schema_extra={"column":"AB"}
+        default=None,
+        serialization_alias="Target Project Info",
+        max_length=3000,
+        json_schema_extra={"column": "AB"},
     )
     Davis_Bacon_Certification__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Davis Bacon Certification?", json_schema_extra={"column":"AC"}
+        default=None,
+        serialization_alias="Davis Bacon Certification?",
+        json_schema_extra={"column": "AC"},
     )
     Number_of_Direct_Employees__c: Optional[conint(ge=0, le=99999999999)] = Field(
-        default=None, serialization_alias="Number of Direct Employees", json_schema_extra={"column":"AD"}
+        default=None,
+        serialization_alias="Number of Direct Employees",
+        json_schema_extra={"column": "AD"},
     )
     Number_of_Contractor_Employees__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Number of Contractor Employees", json_schema_extra={"column":"AE"}
+        default=None,
+        serialization_alias="Number of Contractor Employees",
+        json_schema_extra={"column": "AE"},
     )
     Number_of_3rd_Party_Employees__c: Optional[conint(ge=0, le=999999999999)] = Field(
-        default=None, serialization_alias="Number of 3rd Party Employees", json_schema_extra={"column":"AF"}
+        default=None,
+        serialization_alias="Number of 3rd Party Employees",
+        json_schema_extra={"column": "AF"},
     )
     Any_Wages_Less_Than_Prevailing__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Any Wages Less Than Prevailing?", json_schema_extra={"column":"AG"}
+        default=None,
+        serialization_alias="Any Wages Less Than Prevailing?",
+        json_schema_extra={"column": "AG"},
     )
     Wages_and_benefits__c: Optional[str] = Field(
         default=None,
         serialization_alias="Wages and benefits of workers on the project by classification",
         max_length=3000,
-        json_schema_extra={"column":"AH"}
+        json_schema_extra={"column": "AH"},
     )
     Project_Labor_Certification__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Project Labor Certification?", json_schema_extra={"column":"AI"}
+        default=None,
+        serialization_alias="Project Labor Certification?",
+        json_schema_extra={"column": "AI"},
     )
     Assurance_of_Adequate_Labor__c: Optional[str] = Field(
         default=None,
         serialization_alias="Assurance of Adequate Labor?",
         max_length=3000,
-        json_schema_extra={"column":"AJ"}
+        json_schema_extra={"column": "AJ"},
     )
     Minimizing_Risks__c: Optional[str] = Field(
-        default=None, serialization_alias="Minimizing Risks?", max_length=3000, json_schema_extra={"column":"AK"}
+        default=None,
+        serialization_alias="Minimizing Risks?",
+        max_length=3000,
+        json_schema_extra={"column": "AK"},
     )
     Safe_and_Healthy_Workplace__c: Optional[str] = Field(
         default=None,
         serialization_alias="Explain Safe and Healthy Workplace",
         max_length=3000,
-        json_schema_extra={"column":"AL"}
+        json_schema_extra={"column": "AL"},
     )
     Adequate_Wages__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Adequate Wages?", json_schema_extra={"column":"AM"}
+        default=None,
+        serialization_alias="Adequate Wages?",
+        json_schema_extra={"column": "AM"},
     )
     Project_Labor_Agreement__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Project Labor Agreement?", json_schema_extra={"column":"AN"}
+        default=None,
+        serialization_alias="Project Labor Agreement?",
+        json_schema_extra={"column": "AN"},
     )
     Prioritize_Local_Hires__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Prioritize Local Hires?", json_schema_extra={"column":"AO"}
+        default=None,
+        serialization_alias="Prioritize Local Hires?",
+        json_schema_extra={"column": "AO"},
     )
     Community_Benefit_Agreement__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Community Benefit Agreement?", json_schema_extra={"column":"AP"}
+        default=None,
+        serialization_alias="Community Benefit Agreement?",
+        json_schema_extra={"column": "AP"},
     )
     Description_of_Community_Ben_Agr__c: Optional[str] = Field(
         default=None,
         serialization_alias="Description of Community Ben. Agr.",
         max_length=3000,
-        json_schema_extra={"column":"AQ"}
+        json_schema_extra={"column": "AQ"},
     )
 
     @field_validator(
@@ -266,111 +361,143 @@ class BaseProjectRow(BaseModel):
     @classmethod
     def validate_field(cls, v: Any, info: ValidationInfo, **kwargs):
         if isinstance(v, str) and v.strip == "":
-            raise ValueError(
-                f"Value is required for {info.field_name}"
-            )
+            raise ValueError(f"Value is required for {info.field_name}")
         return v
 
 
 class Project1ARow(BaseProjectRow):
     Technology_Type_Planned__c: TechType = Field(
-        ..., serialization_alias="Technology Type (Planned)", json_schema_extra={"column":"AR"}
+        ...,
+        serialization_alias="Technology Type (Planned)",
+        json_schema_extra={"column": "AR"},
     )
     Technology_Type_Actual__c: Optional[TechType] = Field(
-        default=None, serialization_alias="Technology Type (Actual)", json_schema_extra={"column":"AS"}
+        default=None,
+        serialization_alias="Technology Type (Actual)",
+        json_schema_extra={"column": "AS"},
     )
     If_Other_Specify_Planned__c: Optional[str] = Field(
         default=None,
         serialization_alias="If Other, Specify (Planned)?",
         max_length=3000,
-        json_schema_extra={"column":"AT"}
+        json_schema_extra={"column": "AT"},
     )
     If_Other_Specify_Actual__c: Optional[str] = Field(
         default=None,
         serialization_alias="If Other, Specify (Actual?)?",
         max_length=3000,
-        json_schema_extra={"column":"AU"}
+        json_schema_extra={"column": "AU"},
     )
     Total_Miles_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="Total Miles of Fiber Deployed (Planned)", json_schema_extra={"column":"AV"}
+        ...,
+        serialization_alias="Total Miles of Fiber Deployed (Planned)",
+        json_schema_extra={"column": "AV"},
     )
     Total_Miles_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
-        default=None, serialization_alias="Total Miles of Fiber Deployed (Actual)", json_schema_extra={"column":"AW"}
+        default=None,
+        serialization_alias="Total Miles of Fiber Deployed (Actual)",
+        json_schema_extra={"column": "AW"},
     )
     Locations_Served_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="A) Total Number of Locations Served (Planned)", json_schema_extra={"column":"AX"}
+        ...,
+        serialization_alias="A) Total Number of Locations Served (Planned)",
+        json_schema_extra={"column": "AX"},
     )
     Locations_Served_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
-        default=None, serialization_alias="A) Total Number of Locations Served (Actual)", json_schema_extra={"column":"AY"}
+        default=None,
+        serialization_alias="A) Total Number of Locations Served (Actual)",
+        json_schema_extra={"column": "AY"},
     )
     X25_3_Mbps_or_below_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="B) Less than 25/3 Mbps (Planned)", json_schema_extra={"column":"AZ"}
+        ...,
+        serialization_alias="B) Less than 25/3 Mbps (Planned)",
+        json_schema_extra={"column": "AZ"},
     )
     X25_3_Mbps_and_100_20_Mbps_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="C) 25/3 Mbps and 100/20 Mbps (Planned)", json_schema_extra={"column":"BA"}
+        ...,
+        serialization_alias="C) 25/3 Mbps and 100/20 Mbps (Planned)",
+        json_schema_extra={"column": "BA"},
     )
     Minimum_100_100_Mbps_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="D) Minimum 100/100 Mbps (Planned) ", json_schema_extra={"column":"BB"}
+        ...,
+        serialization_alias="D) Minimum 100/100 Mbps (Planned) ",
+        json_schema_extra={"column": "BB"},
     )
     Minimum_100_100_Mbps_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
-        default=None, serialization_alias="D) Minimum 100/100 Mbps (Actual) ", json_schema_extra={"column":"BC"}
+        default=None,
+        serialization_alias="D) Minimum 100/100 Mbps (Actual) ",
+        json_schema_extra={"column": "BC"},
     )
     X100_20_Mbps_to_100_100_Mbps_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="E) 100/20 Mbps to 100/100 Mbps (Planned)", json_schema_extra={"column":"BD"}
+        ...,
+        serialization_alias="E) 100/20 Mbps to 100/100 Mbps (Planned)",
+        json_schema_extra={"column": "BD"},
     )
     X100_20_Mbps_to_100_100_Mbps_Actual__c: Optional[conint(ge=0, le=999999999)] = (
         Field(
-            default=None, serialization_alias="E) 100/20 Mbps to 100/100 Mbps (Actual)", json_schema_extra={"column":"BE"}
+            default=None,
+            serialization_alias="E) 100/20 Mbps to 100/100 Mbps (Actual)",
+            json_schema_extra={"column": "BE"},
         )
     )
     Explanation_of_Discrepancy__c: Optional[str] = Field(
         default=None,
         serialization_alias="Explanation of Discrepancy (Location by Speed)",
         max_length=3000,
-        json_schema_extra={"column":"BF"}
+        json_schema_extra={"column": "BF"},
     )
     Number_of_Locations_Planned__c: conint(ge=0, le=999999999) = Field(
         ...,
         serialization_alias="F) Total Number of Locations Served by Type - Residential (Planned)",
-        json_schema_extra={"column":"BG"}
+        json_schema_extra={"column": "BG"},
     )
     Number_of_Locations_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
         default=None,
         serialization_alias="F) Total Number of Locations Served by Type - Residential (Actual)",
-        json_schema_extra={"column":"BH"}
+        json_schema_extra={"column": "BH"},
     )
     Housing_Units_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="G) Total Housing Units (Planned)", json_schema_extra={"column":"BI"}
+        ...,
+        serialization_alias="G) Total Housing Units (Planned)",
+        json_schema_extra={"column": "BI"},
     )
     Housing_Units_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
-        default=None, serialization_alias="G) Total Housing Units (Actual)", json_schema_extra={"column":"BJ"}
+        default=None,
+        serialization_alias="G) Total Housing Units (Actual)",
+        json_schema_extra={"column": "BJ"},
     )
     Number_of_Bus_Locations_Planned__c: conint(ge=0, le=999999999) = Field(
         ...,
         serialization_alias="H) Total Number of Locations Served by Type - Business (Planned)",
-        json_schema_extra={"column":"BK"}
+        json_schema_extra={"column": "BK"},
     )
     Number_of_Bus_Locations_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
         default=None,
         serialization_alias="H) Total Number of Locations Served by Type - Business (Actual)",
-        json_schema_extra={"column":"BL"}
+        json_schema_extra={"column": "BL"},
     )
     Number_of_CAI_Planned__c: conint(ge=0, le=999999999) = Field(
         ...,
         serialization_alias="I) Total Number of Locations Served by Type - Community Anchor Institution (Planned)",
-        json_schema_extra={"column":"BM"}
+        json_schema_extra={"column": "BM"},
     )
     Number_of_CAI_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
         default=None,
         serialization_alias="I) Total Number of Locations Served by Type - Community Anchor Institution (Actual)",
-        json_schema_extra={"column":"BN"}
+        json_schema_extra={"column": "BN"},
     )
     Explanation_Planned__c: Optional[str] = Field(
-        default=None, serialization_alias="Explanation (Planned)", max_length=3000, json_schema_extra={"column":"BO"}
+        default=None,
+        serialization_alias="Explanation (Planned)",
+        max_length=3000,
+        json_schema_extra={"column": "BO"},
     )
     Affordable_Connectivity_Program_ACP__c: YesNoType = Field(
-        ..., serialization_alias="Affordable Connectivity Program (ACP)?", json_schema_extra={"column":"BP"}
+        ...,
+        serialization_alias="Affordable Connectivity Program (ACP)?",
+        json_schema_extra={"column": "BP"},
     )
+
     @field_validator(
         "Technology_Type_Planned__c",
         "Total_Miles_Planned__c",
@@ -388,43 +515,72 @@ class Project1ARow(BaseProjectRow):
     @classmethod
     def validate_field(cls, v: Any, info: ValidationInfo, **kwargs):
         if isinstance(v, str) and v.strip == "":
-            raise ValueError(
-                f"Value is required for {info.field_name}"
-            )
+            raise ValueError(f"Value is required for {info.field_name}")
         return v
 
+
 class AddressFields(BaseModel):
-    Street_1_Planned__c: constr(strip_whitespace=True, min_length=1, max_length=40) = Field(
-        ..., serialization_alias="Street 1 (Planned)", json_schema_extra={"column":"BQ"}
+    Street_1_Planned__c: constr(strip_whitespace=True, min_length=1, max_length=40) = (
+        Field(
+            ...,
+            serialization_alias="Street 1 (Planned)",
+            json_schema_extra={"column": "BQ"},
+        )
     )
     Street_2_Planned__c: Optional[str] = Field(
-        default=None, serialization_alias="Street 2 (Planned)", max_length=40, json_schema_extra={"column":"BR"}
+        default=None,
+        serialization_alias="Street 2 (Planned)",
+        max_length=40,
+        json_schema_extra={"column": "BR"},
     )
-    Same_Address__c: Optional[YesNoType] = Field(default=None, serialization_alias="Same Address", json_schema_extra={"column":"BS"})
+    Same_Address__c: Optional[YesNoType] = Field(
+        default=None,
+        serialization_alias="Same Address",
+        json_schema_extra={"column": "BS"},
+    )
     Street_1_Actual__c: Optional[str] = Field(
-        default=None, serialization_alias="Street 1 (Actual)", max_length=40, json_schema_extra={"column":"BT"}
+        default=None,
+        serialization_alias="Street 1 (Actual)",
+        max_length=40,
+        json_schema_extra={"column": "BT"},
     )
     Street_2_Actual__c: Optional[str] = Field(
-        default=None, serialization_alias="Street 2 (Actual)", max_length=40, json_schema_extra={"column":"BU"}
+        default=None,
+        serialization_alias="Street 2 (Actual)",
+        max_length=40,
+        json_schema_extra={"column": "BU"},
     )
     City_Planned__c: constr(strip_whitespace=True, min_length=1, max_length=40) = Field(
-        ..., serialization_alias="City (Planned)", json_schema_extra={"column":"BV"}
+        ..., serialization_alias="City (Planned)", json_schema_extra={"column": "BV"}
     )
     City_Actual__c: Optional[str] = Field(
-        default=None, serialization_alias="City (Actual)", max_length=40, json_schema_extra={"column":"BW"}
+        default=None,
+        serialization_alias="City (Actual)",
+        max_length=40,
+        json_schema_extra={"column": "BW"},
     )
     State_Planned__c: StateAbbreviation = Field(
-        ..., serialization_alias="State (Planned)", json_schema_extra={"column":"BX"}
+        ..., serialization_alias="State (Planned)", json_schema_extra={"column": "BX"}
     )
     State_Actual__c: Optional[StateAbbreviation] = Field(
-        default=None, serialization_alias="State (Actual)", json_schema_extra={"column":"BY"}
+        default=None,
+        serialization_alias="State (Actual)",
+        json_schema_extra={"column": "BY"},
     )
-    Zip_Code_Planned__c: constr(strip_whitespace=True, min_length=1, max_length=5) = Field(
-        ..., serialization_alias="Zip Code (Planned)", json_schema_extra={"column":"BZ"}
+    Zip_Code_Planned__c: constr(strip_whitespace=True, min_length=1, max_length=5) = (
+        Field(
+            ...,
+            serialization_alias="Zip Code (Planned)",
+            json_schema_extra={"column": "BZ"},
+        )
     )
     Zip_Code_Actual__c: Optional[str] = Field(
-        default=None, serialization_alias="Zip Code (Actual)", max_length=5, json_schema_extra={"column":"CA"}
+        default=None,
+        serialization_alias="Zip Code (Actual)",
+        max_length=5,
+        json_schema_extra={"column": "CA"},
     )
+
     @field_validator(
         "Street_1_Planned__c",
         "City_Planned__c",
@@ -433,100 +589,158 @@ class AddressFields(BaseModel):
     @classmethod
     def validate_field(cls, v: Any, info: ValidationInfo, **kwargs):
         if isinstance(v, str) and v.strip == "":
-            raise ValueError(
-                f"Value is required for {info.field_name}"
-            )
+            raise ValueError(f"Value is required for {info.field_name}")
         return v
+
 
 class Project1BRow(BaseProjectRow, AddressFields):
     Laptops_Planned__c: conint(ge=0, le=9999999999) = Field(
-        ..., serialization_alias="Laptops (Planned)", json_schema_extra={"column":"CB"}
+        ..., serialization_alias="Laptops (Planned)", json_schema_extra={"column": "CB"}
     )
     Laptops_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Laptops (Actual)", json_schema_extra={"column":"CC"}
+        default=None,
+        serialization_alias="Laptops (Actual)",
+        json_schema_extra={"column": "CC"},
     )
     Laptops_Expenditures_Planned__c: condecimal(max_digits=13, decimal_places=2) = (
-        Field(..., serialization_alias="Laptops Expenditure (Planned)", json_schema_extra={"column":"CD"})
+        Field(
+            ...,
+            serialization_alias="Laptops Expenditure (Planned)",
+            json_schema_extra={"column": "CD"},
+        )
     )
-    Laptops_Expenditures_Actual__c: Optional[condecimal(max_digits=13, decimal_places=2)] = Field(
-        default=None, serialization_alias="Laptops Expenditure (Actual)", json_schema_extra={"column":"CE"}
+    Laptops_Expenditures_Actual__c: Optional[
+        condecimal(max_digits=13, decimal_places=2)
+    ] = Field(
+        default=None,
+        serialization_alias="Laptops Expenditure (Actual)",
+        json_schema_extra={"column": "CE"},
     )
     Tablets_Planned__c: conint(ge=0, le=9999999999) = Field(
-        ..., serialization_alias="Tablets (Planned)", json_schema_extra={"column":"CF"}
+        ..., serialization_alias="Tablets (Planned)", json_schema_extra={"column": "CF"}
     )
     Tablets_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Tablets (Actual)", json_schema_extra={"column":"CG"}
+        default=None,
+        serialization_alias="Tablets (Actual)",
+        json_schema_extra={"column": "CG"},
     )
     Tablet_Expenditures_Planned__c: condecimal(max_digits=13, decimal_places=2) = Field(
-        ..., serialization_alias="Tablets Expenditure (Planned)", json_schema_extra={"column":"CH"}
+        ...,
+        serialization_alias="Tablets Expenditure (Planned)",
+        json_schema_extra={"column": "CH"},
     )
-    Tablets_Expenditures_Actual__c: Optional[condecimal(max_digits=13, decimal_places=2)] = Field(
-        default=None, serialization_alias="Tablets Expenditure (Actual)", json_schema_extra={"column":"CI"}
+    Tablets_Expenditures_Actual__c: Optional[
+        condecimal(max_digits=13, decimal_places=2)
+    ] = Field(
+        default=None,
+        serialization_alias="Tablets Expenditure (Actual)",
+        json_schema_extra={"column": "CI"},
     )
     Desktop_Computers_Planned__c: conint(ge=0, le=9999999999) = Field(
-        ..., serialization_alias="Desktop Computers (Planned)", json_schema_extra={"column":"CJ"}
+        ...,
+        serialization_alias="Desktop Computers (Planned)",
+        json_schema_extra={"column": "CJ"},
     )
     Desktop_Computers_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Desktop Computers (Actual)", json_schema_extra={"column":"CK"}
+        default=None,
+        serialization_alias="Desktop Computers (Actual)",
+        json_schema_extra={"column": "CK"},
     )
-    Desktop_Computers_Expenditures_Planned__c: condecimal(max_digits=13, decimal_places=2) = Field(
+    Desktop_Computers_Expenditures_Planned__c: condecimal(
+        max_digits=13, decimal_places=2
+    ) = Field(
         ...,
         serialization_alias="Desktop Computers Expenditure (Planned)",
-        json_schema_extra={"column":"CL"}
+        json_schema_extra={"column": "CL"},
     )
-    Desktop_Computers_Expenditures_Actual__c: Optional[condecimal(max_digits=13, decimal_places=2)] = Field(
+    Desktop_Computers_Expenditures_Actual__c: Optional[
+        condecimal(max_digits=13, decimal_places=2)
+    ] = Field(
         default=None,
         serialization_alias="Desktop Computers Expenditure (Actual)",
-        json_schema_extra={"column":"CM"}
+        json_schema_extra={"column": "CM"},
     )
     Public_WiFi_Planned__c: conint(ge=0, le=9999999999) = Field(
-        ..., serialization_alias="Public WiFi (Planned)", json_schema_extra={"column":"CN"}
+        ...,
+        serialization_alias="Public WiFi (Planned)",
+        json_schema_extra={"column": "CN"},
     )
     Public_WiFi_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Public WiFi (Actual)", json_schema_extra={"column":"CO"}
+        default=None,
+        serialization_alias="Public WiFi (Actual)",
+        json_schema_extra={"column": "CO"},
     )
     Public_WiFi_Expenditures_Planned__c: condecimal(max_digits=13, decimal_places=2) = (
-        Field(..., serialization_alias="Public Wifi Expenditures (Planned)", json_schema_extra={"column":"CP"})
+        Field(
+            ...,
+            serialization_alias="Public Wifi Expenditures (Planned)",
+            json_schema_extra={"column": "CP"},
+        )
     )
-    Public_WiFi_Expenditures_Actual__c: Optional[condecimal(max_digits=13, decimal_places=2)] = (
-        Field(default=None, serialization_alias="Public Wifi Expenditures (Actual)", json_schema_extra={"column":"CQ"})
+    Public_WiFi_Expenditures_Actual__c: Optional[
+        condecimal(max_digits=13, decimal_places=2)
+    ] = Field(
+        default=None,
+        serialization_alias="Public Wifi Expenditures (Actual)",
+        json_schema_extra={"column": "CQ"},
     )
     Other_Devices_Planned__c: conint(ge=0, le=9999999999) = Field(
-        ..., serialization_alias="Other Devices (Planned)", json_schema_extra={"column":"CR"}
+        ...,
+        serialization_alias="Other Devices (Planned)",
+        json_schema_extra={"column": "CR"},
     )
     Other_Devices_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Other Devices (Actual)", json_schema_extra={"column":"CS"}
+        default=None,
+        serialization_alias="Other Devices (Actual)",
+        json_schema_extra={"column": "CS"},
     )
     Other_Expenditures_Planned__c: condecimal(max_digits=7, decimal_places=2) = Field(
-        ..., serialization_alias="Other Expenditures (Planned)", json_schema_extra={"column":"CT"}
+        ...,
+        serialization_alias="Other Expenditures (Planned)",
+        json_schema_extra={"column": "CT"},
     )
-    Other_Expenditures_Actual__c: Optional[condecimal(max_digits=7, decimal_places=2)] = Field(
-        default=None, serialization_alias="Other Expenditures (Actual)", json_schema_extra={"column":"CU"}
+    Other_Expenditures_Actual__c: Optional[
+        condecimal(max_digits=7, decimal_places=2)
+    ] = Field(
+        default=None,
+        serialization_alias="Other Expenditures (Actual)",
+        json_schema_extra={"column": "CU"},
     )
     Explanation_of_Other_Expend__c: Optional[str] = Field(
         default=None,
         serialization_alias="Explanation of Other Expenditures",
         max_length=3000,
-        json_schema_extra={"column":"CV"}
+        json_schema_extra={"column": "CV"},
     )
     Number_of_Users_Planned__c: conint(ge=0, le=9999999999) = Field(
-        ..., serialization_alias="Number of Users (Planned)", json_schema_extra={"column":"CW"}
+        ...,
+        serialization_alias="Number of Users (Planned)",
+        json_schema_extra={"column": "CW"},
     )
     Number_of_Users_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Number of Users (Actual)", json_schema_extra={"column":"CX"}
+        default=None,
+        serialization_alias="Number of Users (Actual)",
+        json_schema_extra={"column": "CX"},
     )
-    Brief_Narrative_Planned__c: constr(strip_whitespace=True, min_length=1, max_length=3000) = Field(
-        ..., serialization_alias="Brief Narrative (Planned)", json_schema_extra={"column":"CY"}
+    Brief_Narrative_Planned__c: constr(
+        strip_whitespace=True, min_length=1, max_length=3000
+    ) = Field(
+        ...,
+        serialization_alias="Brief Narrative (Planned)",
+        json_schema_extra={"column": "CY"},
     )
     Brief_Narrative_Actual__c: Optional[str] = Field(
         default=None,
         serialization_alias="Brief Narrative (Actual)",
         max_length=3000,
-        json_schema_extra={"column":"CZ"}
+        json_schema_extra={"column": "CZ"},
     )
     Measurement_of_Effectiveness__c: YesNoType = Field(
-        ..., serialization_alias="Measurement of Effectiveness?", json_schema_extra={"column":"DA"}
+        ...,
+        serialization_alias="Measurement of Effectiveness?",
+        json_schema_extra={"column": "DA"},
     )
+
     @field_validator(
         "Laptops_Planned__c",
         "Laptops_Expenditures_Planned__c",
@@ -545,129 +759,179 @@ class Project1BRow(BaseProjectRow, AddressFields):
     @classmethod
     def validate_field(cls, v: Any, info: ValidationInfo, **kwargs):
         if isinstance(v, str) and v.strip == "":
-            raise ValueError(
-                f"Value is required for {info.field_name}"
-            )
+            raise ValueError(f"Value is required for {info.field_name}")
         return v
+
 
 class Project1CRow(BaseProjectRow, AddressFields):
     Type_of_Investment__c: Optional[str] = Field(
-        default=None, serialization_alias="Type of Investment", json_schema_extra={"column":"DB"}
+        default=None,
+        serialization_alias="Type of Investment",
+        json_schema_extra={"column": "DB"},
     )
     Additional_Address__c: Optional[str] = Field(
-        default=None, serialization_alias="Additional Addresses", max_length=32000, json_schema_extra={"column":"DC"}
+        default=None,
+        serialization_alias="Additional Addresses",
+        max_length=32000,
+        json_schema_extra={"column": "DC"},
     )
     Classrooms_Planned__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Classrooms (Planned)", json_schema_extra={"column":"DD"}
+        default=None,
+        serialization_alias="Classrooms (Planned)",
+        json_schema_extra={"column": "DD"},
     )
     Classrooms_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Classrooms (Actual)", json_schema_extra={"column":"DE"}
+        default=None,
+        serialization_alias="Classrooms (Actual)",
+        json_schema_extra={"column": "DE"},
     )
     Computer_labs_Planned__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Computer labs (Planned)", json_schema_extra={"column":"DF"}
+        default=None,
+        serialization_alias="Computer labs (Planned)",
+        json_schema_extra={"column": "DF"},
     )
     Computer_labs_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Computer labs (Actual)", json_schema_extra={"column":"DG"}
+        default=None,
+        serialization_alias="Computer labs (Actual)",
+        json_schema_extra={"column": "DG"},
     )
     Multi_purpose_Spaces_Planned__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Multi-purpose Spaces (Planned)", json_schema_extra={"column":"DH"}
+        default=None,
+        serialization_alias="Multi-purpose Spaces (Planned)",
+        json_schema_extra={"column": "DH"},
     )
     Multi_purpose_Spaces_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Multi-purpose Spaces (Actual)", json_schema_extra={"column":"DI"}
+        default=None,
+        serialization_alias="Multi-purpose Spaces (Actual)",
+        json_schema_extra={"column": "DI"},
     )
     Telemedicine_Rooms_Planned__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Telemedicine Rooms (Planned)", json_schema_extra={"column":"DJ"}
+        default=None,
+        serialization_alias="Telemedicine Rooms (Planned)",
+        json_schema_extra={"column": "DJ"},
     )
     Telemedicine_Rooms_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Telemedicine Rooms (Actual)", json_schema_extra={"column":"DK"}
+        default=None,
+        serialization_alias="Telemedicine Rooms (Actual)",
+        json_schema_extra={"column": "DK"},
     )
     Other_Capital_Assets_Planned__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Other Capital Assets (Planned)", json_schema_extra={"column":"DL"}
+        default=None,
+        serialization_alias="Other Capital Assets (Planned)",
+        json_schema_extra={"column": "DL"},
     )
     Other_Capital_Assets_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Other Capital Assets (Actual)", json_schema_extra={"column":"DM"}
+        default=None,
+        serialization_alias="Other Capital Assets (Actual)",
+        json_schema_extra={"column": "DM"},
     )
     Type_and_Features__c: Optional[str] = Field(
-        default=None, serialization_alias="Type and Features", max_length=3000, json_schema_extra={"column":"DN"}
+        default=None,
+        serialization_alias="Type and Features",
+        max_length=3000,
+        json_schema_extra={"column": "DN"},
     )
     Total_square_footage_Planned__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Total square footage (Planned)", json_schema_extra={"column":"DO"}
+        default=None,
+        serialization_alias="Total square footage (Planned)",
+        json_schema_extra={"column": "DO"},
     )
     Total_square_footage_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Total square footage (Actual)", json_schema_extra={"column":"DP"}
+        default=None,
+        serialization_alias="Total square footage (Actual)",
+        json_schema_extra={"column": "DP"},
     )
     Total_Number_of_Users_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Total Number of Users (Actual)", json_schema_extra={"column":"DQ"}
+        default=None,
+        serialization_alias="Total Number of Users (Actual)",
+        json_schema_extra={"column": "DQ"},
     )
     Further_Explanation__c: Optional[str] = Field(
-        default=None, serialization_alias="Further Explanation", max_length=2000, json_schema_extra={"column":"DR"}
+        default=None,
+        serialization_alias="Further Explanation",
+        max_length=2000,
+        json_schema_extra={"column": "DR"},
     )
     Access_to_Public_Transit__c: YesNoType = Field(
-        ..., serialization_alias="Access to Public Transit?", json_schema_extra={"column":"DS"}
+        ...,
+        serialization_alias="Access to Public Transit?",
+        json_schema_extra={"column": "DS"},
     )
-    @field_validator(
-        "Access_to_Public_Transit__c"
-    )
+
+    @field_validator("Access_to_Public_Transit__c")
     @classmethod
     def validate_field(cls, v: Any, info: ValidationInfo, **kwargs):
         if isinstance(v, str) and v.strip == "":
-            raise ValueError(
-                f"Value is required for {info.field_name}"
-            )
+            raise ValueError(f"Value is required for {info.field_name}")
         return v
+
 
 class SubrecipientRow(BaseModel):
     model_config = ConfigDict(coerce_numbers_to_str=True, loc_by_alias=False)
 
     Name: constr(strip_whitespace=True, min_length=1, max_length=80) = Field(
-        ...,
-        serialization_alias="Subrecipient Name",
-        json_schema_extra={"column":"C"}
+        ..., serialization_alias="Subrecipient Name", json_schema_extra={"column": "C"}
     )
     EIN__c: constr(strip_whitespace=True, min_length=9, max_length=9) = Field(
         ...,
         serialization_alias="Subrecipient Tax ID Number (TIN)",
-        json_schema_extra={"column":"D"}
+        json_schema_extra={"column": "D"},
     )
-    Unique_Entity_Identifier__c: constr(strip_whitespace=True, min_length=12, max_length=12) = Field(
+    Unique_Entity_Identifier__c: constr(
+        strip_whitespace=True, min_length=12, max_length=12
+    ) = Field(
         ...,
         serialization_alias="Unique Entity Identifier (UEI)",
-        json_schema_extra={"column":"E"}
+        json_schema_extra={"column": "E"},
     )
     POC_Name__c: constr(strip_whitespace=True, min_length=1, max_length=100) = Field(
-        ...,
-        serialization_alias="POC Name",
-        json_schema_extra={"column":"F"}
+        ..., serialization_alias="POC Name", json_schema_extra={"column": "F"}
     )
-    POC_Phone_Number__c: constr(strip_whitespace=True, min_length=1, max_length=10) = Field(
-        ..., serialization_alias="POC Phone Number", json_schema_extra={"column":"G"}
+    POC_Phone_Number__c: constr(strip_whitespace=True, min_length=1, max_length=10) = (
+        Field(
+            ...,
+            serialization_alias="POC Phone Number",
+            json_schema_extra={"column": "G"},
+        )
     )
-    POC_Email_Address__c: constr(strip_whitespace=True, min_length=1, max_length=80) = Field(
-        ..., serialization_alias="POC Email Address", json_schema_extra={"column":"H"}
+    POC_Email_Address__c: constr(strip_whitespace=True, min_length=1, max_length=80) = (
+        Field(
+            ...,
+            serialization_alias="POC Email Address",
+            json_schema_extra={"column": "H"},
+        )
     )
     Zip__c: constr(strip_whitespace=True, min_length=1, max_length=5) = Field(
-        ...,
-        serialization_alias="Zip5",
-        json_schema_extra={"column":"I"}
+        ..., serialization_alias="Zip5", json_schema_extra={"column": "I"}
     )
-    Zip_4__c: Optional[str] = Field(default=None, serialization_alias="Zip4", max_length=4, json_schema_extra={"column":"J"})
+    Zip_4__c: Optional[str] = Field(
+        default=None,
+        serialization_alias="Zip4",
+        max_length=4,
+        json_schema_extra={"column": "J"},
+    )
     Address__c: constr(strip_whitespace=True, min_length=1, max_length=40) = Field(
-        ...,
-        serialization_alias="Address Line 1",
-        json_schema_extra={"column":"K"}
+        ..., serialization_alias="Address Line 1", json_schema_extra={"column": "K"}
     )
     Address_2__c: Optional[str] = Field(
-        default=None, serialization_alias="Address Line 2", max_length=40, json_schema_extra={"column":"L"}
+        default=None,
+        serialization_alias="Address Line 2",
+        max_length=40,
+        json_schema_extra={"column": "L"},
     )
     Address_3__c: Optional[str] = Field(
-        default=None, serialization_alias="Address Line 3", max_length=40, json_schema_extra={"column":"M"}
+        default=None,
+        serialization_alias="Address Line 3",
+        max_length=40,
+        json_schema_extra={"column": "M"},
     )
     City__c: constr(strip_whitespace=True, min_length=1, max_length=100) = Field(
-        ..., serialization_alias="City", json_schema_extra={"column":"N"}
+        ..., serialization_alias="City", json_schema_extra={"column": "N"}
     )
     State_Abbreviated__c: StateAbbreviation = Field(
-        ..., serialization_alias="State Abbreviated", json_schema_extra={"column":"O"}
+        ..., serialization_alias="State Abbreviated", json_schema_extra={"column": "O"}
     )
+
     @field_validator(
         "Name",
         "EIN__c",
@@ -683,10 +947,9 @@ class SubrecipientRow(BaseModel):
     @classmethod
     def validate_field(cls, v: Any, info: ValidationInfo, **kwargs):
         if isinstance(v, str) and v.strip == "":
-            raise ValueError(
-                f"Value is required for {info.field_name}"
-            )
+            raise ValueError(f"Value is required for {info.field_name}")
         return v
+
 
 METADATA_BY_SHEET = {
     "Cover": {
@@ -717,26 +980,19 @@ class CoverSheetRow(BaseModel):
     model_config = ConfigDict(loc_by_alias=False)
 
     project_use_code: constr(strip_whitespace=True, min_length=1) = Field(
-        ...,
-        alias="Project Use Code", json_schema_extra={"column":"A"}
+        ..., alias="Project Use Code", json_schema_extra={"column": "A"}
     )
     project_use_name: constr(strip_whitespace=True, min_length=1) = Field(
-        ...,
-        alias="Project Use Name",
-        json_schema_extra={"column":"B"}
+        ..., alias="Project Use Name", json_schema_extra={"column": "B"}
     )
 
     @field_validator("project_use_code")
     @classmethod
     def validate_code(cls, v: Any, info: ValidationInfo, **kwargs):
         if v is None or v.strip() == "":
-            raise ValueError(
-                f"EC code must be set"
-            )
+            raise ValueError(f"EC code must be set")
         elif v not in ProjectType:
-            raise ValueError(
-                f"EC code '{v}' is not recognized."
-            )
+            raise ValueError(f"EC code '{v}' is not recognized.")
         return v
 
     @field_validator("project_use_name")

--- a/python/src/schemas/schema_V2024_04_01.py
+++ b/python/src/schemas/schema_V2024_04_01.py
@@ -107,10 +107,14 @@ class BaseProjectRow(BaseModel):
     model_config = ConfigDict(coerce_numbers_to_str=True, loc_by_alias=False)
 
     row_num: conint(ge=1) = Field(
-        default=1, serialization_alias="Row Number", json_schema_extra={"column":"NONE"}
+        default=1,
+        serialization_alias="Row Number",
+        json_schema_extra={"column": "NONE"},
     )
-    Project_Name__c: constr(strip_whitespace=True, min_length=1, max_length=100) = Field(
-        ..., serialization_alias="Project Name", json_schema_extra={"column":"C"}
+    Project_Name__c: constr(strip_whitespace=True, min_length=1, max_length=100) = (
+        Field(
+            ..., serialization_alias="Project Name", json_schema_extra={"column": "C"}
+        )
     )
     Identification_Number__c: constr(
         strip_whitespace=True, min_length=1, max_length=20

--- a/python/src/schemas/schema_V2024_04_01.py
+++ b/python/src/schemas/schema_V2024_04_01.py
@@ -991,9 +991,7 @@ class CoverSheetRow(BaseModel):
     @classmethod
     def validate_code(cls, v: Any, info: ValidationInfo, **kwargs):
         if v is None or v.strip() == "":
-            raise ValueError(
-                "EC code must be set"
-            )
+            raise ValueError("EC code must be set")
         return v
 
     @field_validator("project_use_name")

--- a/python/src/schemas/schema_V2024_05_24.py
+++ b/python/src/schemas/schema_V2024_05_24.py
@@ -1096,9 +1096,7 @@ class CoverSheetRow(BaseModel):
     @classmethod
     def validate_code(cls, v: Any, info: ValidationInfo, **kwargs):
         if v is None or v.strip() == "":
-            raise ValueError(
-                "EC code must be set"
-            )
+            raise ValueError("EC code must be set")
         return v
 
     @field_validator("detailed_expenditure_category")

--- a/python/src/schemas/schema_V2024_05_24.py
+++ b/python/src/schemas/schema_V2024_05_24.py
@@ -2,8 +2,16 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Optional
 
-from pydantic import (BaseModel, ConfigDict, Field, condecimal, conint, constr,
-                      ValidationInfo, field_validator)
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    condecimal,
+    conint,
+    constr,
+    ValidationInfo,
+    field_validator,
+)
 from src.schemas.project_types import ProjectType, NAME_BY_PROJECT
 
 
@@ -97,144 +105,239 @@ class ProjectInvestmentType(str, Enum):
 class BaseProjectRow(BaseModel):
     model_config = ConfigDict(coerce_numbers_to_str=True, loc_by_alias=False)
 
-    Project_Name__c: constr(strip_whitespace=True, min_length=1, max_length=100) = Field(
-        ..., serialization_alias="Project Name", json_schema_extra={"column":"C"}
+    Project_Name__c: constr(strip_whitespace=True, min_length=1, max_length=100) = (
+        Field(
+            ..., serialization_alias="Project Name", json_schema_extra={"column": "C"}
+        )
     )
-    Identification_Number__c: constr(strip_whitespace=True, min_length=1, max_length=20) = Field(
-        ..., serialization_alias="Identification Number", json_schema_extra={"column":"D"}
+    Identification_Number__c: constr(
+        strip_whitespace=True, min_length=1, max_length=20
+    ) = Field(
+        ...,
+        serialization_alias="Identification Number",
+        json_schema_extra={"column": "D"},
     )
-    Subrecipient_UEI__c: constr(strip_whitespace=True, min_length=12, max_length=12) = Field(
-        ..., serialization_alias="Subrecipient UEI", json_schema_extra={"column":"E"}
+    Subrecipient_UEI__c: constr(strip_whitespace=True, min_length=12, max_length=12) = (
+        Field(
+            ...,
+            serialization_alias="Subrecipient UEI",
+            json_schema_extra={"column": "E"},
+        )
     )
-    Subrecipient_TIN__c: constr(strip_whitespace=True, min_length=9, max_length=9) = Field(
-        ..., serialization_alias="Subrecipient TIN", json_schema_extra={"column":"F"}
+    Subrecipient_TIN__c: constr(strip_whitespace=True, min_length=9, max_length=9) = (
+        Field(
+            ...,
+            serialization_alias="Subrecipient TIN",
+            json_schema_extra={"column": "F"},
+        )
     )
-    Project_Description__c: constr(strip_whitespace=True, min_length=1, max_length=3000) = Field(
-        ..., serialization_alias="Project Description", json_schema_extra={"column":"G"}
+    Project_Description__c: constr(
+        strip_whitespace=True, min_length=1, max_length=3000
+    ) = Field(
+        ...,
+        serialization_alias="Project Description",
+        json_schema_extra={"column": "G"},
     )
     Capital_Asset_Ownership_Type__c: CapitalAssetOwnershipType = Field(
-        ..., serialization_alias="Capital Asset Owenership Type", json_schema_extra={"column":"H"}
+        ...,
+        serialization_alias="Capital Asset Owenership Type",
+        json_schema_extra={"column": "H"},
     )
     Total_CPF_Funding_for_Project__c: condecimal(max_digits=13, decimal_places=2) = (
-        Field(..., serialization_alias="Total CPF Funding for Project", json_schema_extra={"column":"I"})
+        Field(
+            ...,
+            serialization_alias="Total CPF Funding for Project",
+            json_schema_extra={"column": "I"},
+        )
     )
     Total_from_all_funding_sources__c: condecimal(max_digits=13, decimal_places=2) = (
-        Field(..., serialization_alias="Total From all Funding Sources", json_schema_extra={"column":"J"})
+        Field(
+            ...,
+            serialization_alias="Total From all Funding Sources",
+            json_schema_extra={"column": "J"},
+        )
     )
     Narrative_Description__c: Optional[str] = Field(
-        default=None, serialization_alias="Narrative Description", max_length=3000, json_schema_extra={"column":"K"}
+        default=None,
+        serialization_alias="Narrative Description",
+        max_length=3000,
+        json_schema_extra={"column": "K"},
     )
     Current_Period_Obligation__c: condecimal(max_digits=12, decimal_places=2) = Field(
-        ..., serialization_alias="Current Period Obligation", json_schema_extra={"column":"L"}
+        ...,
+        serialization_alias="Current Period Obligation",
+        json_schema_extra={"column": "L"},
     )
     Current_Period_Expenditure__c: condecimal(max_digits=12, decimal_places=2) = Field(
-        ..., serialization_alias="Current Period Expenditure", json_schema_extra={"column":"M"}
+        ...,
+        serialization_alias="Current Period Expenditure",
+        json_schema_extra={"column": "M"},
     )
     Cumulative_Obligation__c: condecimal(max_digits=12, decimal_places=2) = Field(
-        ..., serialization_alias="Cumulative Obligation", json_schema_extra={"column":"N"}
+        ...,
+        serialization_alias="Cumulative Obligation",
+        json_schema_extra={"column": "N"},
     )
     Cumulative_Expenditure__c: condecimal(max_digits=12, decimal_places=2) = Field(
-        ..., serialization_alias="Cumulative Expenditure", json_schema_extra={"column":"O"}
+        ...,
+        serialization_alias="Cumulative Expenditure",
+        json_schema_extra={"column": "O"},
     )
-    Cost_Overview__c: constr(strip_whitespace=True, min_length=1, max_length=3000) = Field(
-        ..., serialization_alias="Cost Overview", json_schema_extra={"column":"P"}
+    Cost_Overview__c: constr(strip_whitespace=True, min_length=1, max_length=3000) = (
+        Field(
+            ..., serialization_alias="Cost Overview", json_schema_extra={"column": "P"}
+        )
     )
     Project_Status__c: ProjectStatusType = Field(
-        ..., serialization_alias="Project Status", json_schema_extra={"column":"Q"}
+        ..., serialization_alias="Project Status", json_schema_extra={"column": "Q"}
     )
     Projected_Con_Start_Date__c: Optional[datetime] = Field(
-        default=None, serialization_alias="Projected Con. Start Date", json_schema_extra={"column":"R"}
+        default=None,
+        serialization_alias="Projected Con. Start Date",
+        json_schema_extra={"column": "R"},
     )
     Projected_Con_Completion__c: Optional[datetime] = Field(
-        default=None, serialization_alias="Projected Con. Completion", json_schema_extra={"column":"S"}
+        default=None,
+        serialization_alias="Projected Con. Completion",
+        json_schema_extra={"column": "S"},
     )
     Projected_Init_of_Operations__c: Optional[datetime] = Field(
-        default=None, serialization_alias="Projected Init. of Operations", json_schema_extra={"column":"T"}
+        default=None,
+        serialization_alias="Projected Init. of Operations",
+        json_schema_extra={"column": "T"},
     )
     Actual_Con_Start_Date__c: Optional[datetime] = Field(
-        default=None, serialization_alias="Actual Con. Start Date", json_schema_extra={"column":"U"}
+        default=None,
+        serialization_alias="Actual Con. Start Date",
+        json_schema_extra={"column": "U"},
     )
     Actual_Con_Completion__c: Optional[datetime] = Field(
-        default=None, serialization_alias="Actual Con. Completion", json_schema_extra={"column":"V"}
+        default=None,
+        serialization_alias="Actual Con. Completion",
+        json_schema_extra={"column": "V"},
     )
     Operations_initiated__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Operations Initiated", json_schema_extra={"column":"W"}
+        default=None,
+        serialization_alias="Operations Initiated",
+        json_schema_extra={"column": "W"},
     )
     Actual_operations_date__c: Optional[datetime] = Field(
-        default=None, serialization_alias="Actual operations date", json_schema_extra={"column":"X"}
+        default=None,
+        serialization_alias="Actual operations date",
+        json_schema_extra={"column": "X"},
     )
     Operations_explanation__c: Optional[str] = Field(
-        default=None, serialization_alias="Operations explanation", max_length=3000, json_schema_extra={"column":"Y"}
+        default=None,
+        serialization_alias="Operations explanation",
+        max_length=3000,
+        json_schema_extra={"column": "Y"},
     )
     Other_Federal_Funding__c: YesNoType = Field(
-        ..., serialization_alias="Other Federal Funding?", json_schema_extra={"column":"Z"}
+        ...,
+        serialization_alias="Other Federal Funding?",
+        json_schema_extra={"column": "Z"},
     )
-    Matching_Funds__c: YesNoType = Field(..., serialization_alias="Matching Funds?", json_schema_extra={"column":"AA"})
+    Matching_Funds__c: YesNoType = Field(
+        ..., serialization_alias="Matching Funds?", json_schema_extra={"column": "AA"}
+    )
     Program_Information__c: Optional[str] = Field(
-        default=None, serialization_alias="Program Information", max_length=50, json_schema_extra={"column":"AB"}
+        default=None,
+        serialization_alias="Program Information",
+        max_length=50,
+        json_schema_extra={"column": "AB"},
     )
     Amount_of_Matching_Funds__c: Optional[
         condecimal(max_digits=12, decimal_places=2)
-    ] = Field(default=None, serialization_alias="Amount of Matching Funds", json_schema_extra={"column":"AC"})
+    ] = Field(
+        default=None,
+        serialization_alias="Amount of Matching Funds",
+        json_schema_extra={"column": "AC"},
+    )
     Target_Project_Info__c: Optional[str] = Field(
-        default=None, serialization_alias="Target Project Info", max_length=3000, json_schema_extra={"column":"AD"}
+        default=None,
+        serialization_alias="Target Project Info",
+        max_length=3000,
+        json_schema_extra={"column": "AD"},
     )
     Davis_Bacon_Certification__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Davis Bacon Certification?", json_schema_extra={"column":"AE"}
+        default=None,
+        serialization_alias="Davis Bacon Certification?",
+        json_schema_extra={"column": "AE"},
     )
     Number_of_Direct_Employees__c: Optional[conint(ge=0, le=99999999999)] = Field(
-        default=None, serialization_alias="Number of Direct Employees", json_schema_extra={"column":"AF"}
+        default=None,
+        serialization_alias="Number of Direct Employees",
+        json_schema_extra={"column": "AF"},
     )
     Number_of_Contractor_Employees__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Number of Contractor Employees", json_schema_extra={"column":"AG"}
+        default=None,
+        serialization_alias="Number of Contractor Employees",
+        json_schema_extra={"column": "AG"},
     )
     Number_of_3rd_Party_Employees__c: Optional[conint(ge=0, le=999999999999)] = Field(
-        default=None, serialization_alias="Number of 3rd Party Employees", json_schema_extra={"column":"AH"}
+        default=None,
+        serialization_alias="Number of 3rd Party Employees",
+        json_schema_extra={"column": "AH"},
     )
     Any_Wages_Less_Than_Prevailing__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Any Wages Less Than Prevailing?", json_schema_extra={"column":"AI"}
+        default=None,
+        serialization_alias="Any Wages Less Than Prevailing?",
+        json_schema_extra={"column": "AI"},
     )
     Wages_and_benefits__c: Optional[str] = Field(
         default=None,
         serialization_alias="Wages and benefits of workers on the project by classification",
         max_length=3000,
-        json_schema_extra={"column":"AJ"}
+        json_schema_extra={"column": "AJ"},
     )
     Project_Labor_Certification__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Project Labor Certification?", json_schema_extra={"column":"AK"}
+        default=None,
+        serialization_alias="Project Labor Certification?",
+        json_schema_extra={"column": "AK"},
     )
     Assurance_of_Adequate_Labor__c: Optional[str] = Field(
         default=None,
         serialization_alias="Assurance of Adequate Labor?",
         max_length=3000,
-        json_schema_extra={"column":"AL"}
+        json_schema_extra={"column": "AL"},
     )
     Minimizing_Risks__c: Optional[str] = Field(
-        default=None, serialization_alias="Minimizing Risks?", max_length=3000, json_schema_extra={"column":"AM"}
+        default=None,
+        serialization_alias="Minimizing Risks?",
+        max_length=3000,
+        json_schema_extra={"column": "AM"},
     )
     Safe_and_Healthy_Workplace__c: Optional[str] = Field(
         default=None,
         serialization_alias="Explain Safe and Healthy Workplace",
         max_length=3000,
-        json_schema_extra={"column":"AN"}
+        json_schema_extra={"column": "AN"},
     )
     Adequate_Wages__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Adequate Wages?", json_schema_extra={"column":"AO"}
+        default=None,
+        serialization_alias="Adequate Wages?",
+        json_schema_extra={"column": "AO"},
     )
     Project_Labor_Agreement__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Project Labor Agreement?", json_schema_extra={"column":"AP"}
+        default=None,
+        serialization_alias="Project Labor Agreement?",
+        json_schema_extra={"column": "AP"},
     )
     Prioritize_Local_Hires__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Prioritize Local Hires?", json_schema_extra={"column":"AQ"}
+        default=None,
+        serialization_alias="Prioritize Local Hires?",
+        json_schema_extra={"column": "AQ"},
     )
     Community_Benefit_Agreement__c: Optional[YesNoType] = Field(
-        default=None, serialization_alias="Community Benefit Agreement?", json_schema_extra={"column":"AR"}
+        default=None,
+        serialization_alias="Community Benefit Agreement?",
+        json_schema_extra={"column": "AR"},
     )
     Description_of_Community_Ben_Agr__c: Optional[str] = Field(
         default=None,
         serialization_alias="Description of Community Ben. Agr.",
         max_length=3000,
-        json_schema_extra={"column":"AS"}
+        json_schema_extra={"column": "AS"},
     )
 
     @field_validator(
@@ -271,116 +374,148 @@ class BaseProjectRow(BaseModel):
     @classmethod
     def validate_field(cls, v: Any, info: ValidationInfo, **kwargs):
         if isinstance(v, str) and v.strip == "":
-            raise ValueError(
-                f"Value is required for {info.field_name}"
-            )
+            raise ValueError(f"Value is required for {info.field_name}")
         return v
 
 
 class Project1ARow(BaseProjectRow):
     Technology_Type_Planned__c: TechType = Field(
-        ..., serialization_alias="Technology Type (Planned)", json_schema_extra={"column":"AT"}
+        ...,
+        serialization_alias="Technology Type (Planned)",
+        json_schema_extra={"column": "AT"},
     )
     Technology_Type_Actual__c: Optional[TechType] = Field(
-        default=None, serialization_alias="Technology Type (Actual)", json_schema_extra={"column":"AU"}
+        default=None,
+        serialization_alias="Technology Type (Actual)",
+        json_schema_extra={"column": "AU"},
     )
     If_Other_Specify_Planned__c: Optional[str] = Field(
         default=None,
         serialization_alias="If Other, Specify (Planned)?",
         max_length=3000,
-        json_schema_extra={"column":"AV"}
+        json_schema_extra={"column": "AV"},
     )
     If_Other_Specify_Actual__c: Optional[str] = Field(
         default=None,
         serialization_alias="If Other, Specify (Actual?)?",
         max_length=3000,
-        json_schema_extra={"column":"AW"}
+        json_schema_extra={"column": "AW"},
     )
     Total_Miles_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="Total Miles of Fiber Deployed (Planned)", json_schema_extra={"column":"AX"}
+        ...,
+        serialization_alias="Total Miles of Fiber Deployed (Planned)",
+        json_schema_extra={"column": "AX"},
     )
     Total_Miles_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
-        default=None, serialization_alias="Total Miles of Fiber Deployed (Actual)", json_schema_extra={"column":"AY"}
+        default=None,
+        serialization_alias="Total Miles of Fiber Deployed (Actual)",
+        json_schema_extra={"column": "AY"},
     )
     Locations_Served_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="A) Total Number of Locations Served (Planned)", json_schema_extra={"column":"AZ"}
+        ...,
+        serialization_alias="A) Total Number of Locations Served (Planned)",
+        json_schema_extra={"column": "AZ"},
     )
     Locations_Served_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
-        default=None, serialization_alias="A) Total Number of Locations Served (Actual)", json_schema_extra={"column":"BA"}
+        default=None,
+        serialization_alias="A) Total Number of Locations Served (Actual)",
+        json_schema_extra={"column": "BA"},
     )
     X25_3_Mbps_or_below_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="B) Less than 25/3 Mbps (Planned)", json_schema_extra={"column":"BB"}
+        ...,
+        serialization_alias="B) Less than 25/3 Mbps (Planned)",
+        json_schema_extra={"column": "BB"},
     )
     X25_3_Mbps_and_100_20_Mbps_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="C) 25/3 Mbps and 100/20 Mbps (Planned)", json_schema_extra={"column":"BC"}
+        ...,
+        serialization_alias="C) 25/3 Mbps and 100/20 Mbps (Planned)",
+        json_schema_extra={"column": "BC"},
     )
     Minimum_100_100_Mbps_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="D) Minimum 100/100 Mbps (Planned) ", json_schema_extra={"column":"BD"}
+        ...,
+        serialization_alias="D) Minimum 100/100 Mbps (Planned) ",
+        json_schema_extra={"column": "BD"},
     )
     Minimum_100_100_Mbps_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
-        default=None, serialization_alias="D) Minimum 100/100 Mbps (Actual) ", json_schema_extra={"column":"BE"}
+        default=None,
+        serialization_alias="D) Minimum 100/100 Mbps (Actual) ",
+        json_schema_extra={"column": "BE"},
     )
     X100_20_Mbps_to_100_100_Mbps_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="E) 100/20 Mbps to 100/100 Mbps (Planned)", json_schema_extra={"column":"BF"}
+        ...,
+        serialization_alias="E) 100/20 Mbps to 100/100 Mbps (Planned)",
+        json_schema_extra={"column": "BF"},
     )
     X100_20_Mbps_to_100_100_Mbps_Actual__c: Optional[conint(ge=0, le=999999999)] = (
         Field(
-            default=None, serialization_alias="E) 100/20 Mbps to 100/100 Mbps (Actual)", json_schema_extra={"column":"BG"}
+            default=None,
+            serialization_alias="E) 100/20 Mbps to 100/100 Mbps (Actual)",
+            json_schema_extra={"column": "BG"},
         )
     )
     Explanation_of_Discrepancy__c: Optional[str] = Field(
         default=None,
         serialization_alias="Explanation of Discrepancy (Location by Speed)",
         max_length=3000,
-        json_schema_extra={"column":"BH"}
+        json_schema_extra={"column": "BH"},
     )
     Number_of_Locations_Planned__c: conint(ge=0, le=999999999) = Field(
         ...,
         serialization_alias="F) Total Number of Locations Served by Type - Residential (Planned)",
-        json_schema_extra={"column":"BI"}
+        json_schema_extra={"column": "BI"},
     )
     Number_of_Locations_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
         default=None,
         serialization_alias="F) Total Number of Locations Served by Type - Residential (Actual)",
-        json_schema_extra={"column":"BJ"}
+        json_schema_extra={"column": "BJ"},
     )
     Housing_Units_Planned__c: conint(ge=0, le=999999999) = Field(
-        ..., serialization_alias="G) Total Housing Units (Planned)", json_schema_extra={"column":"BK"}
+        ...,
+        serialization_alias="G) Total Housing Units (Planned)",
+        json_schema_extra={"column": "BK"},
     )
     Housing_Units_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
-        default=None, serialization_alias="G) Total Housing Units (Actual)", json_schema_extra={"column":"BL"}
+        default=None,
+        serialization_alias="G) Total Housing Units (Actual)",
+        json_schema_extra={"column": "BL"},
     )
     Number_of_Bus_Locations_Planned__c: conint(ge=0, le=999999999) = Field(
         ...,
         serialization_alias="H) Total Number of Locations Served by Type - Business (Planned)",
-        json_schema_extra={"column":"BM"}
+        json_schema_extra={"column": "BM"},
     )
     Number_of_Bus_Locations_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
         default=None,
         serialization_alias="H) Total Number of Locations Served by Type - Business (Actual)",
-        json_schema_extra={"column":"BN"}
+        json_schema_extra={"column": "BN"},
     )
     Number_of_CAI_Planned__c: conint(ge=0, le=999999999) = Field(
         ...,
         serialization_alias="I) Total Number of Locations Served by Type - Community Anchor Institution (Planned)",
-        json_schema_extra={"column":"BO"}
+        json_schema_extra={"column": "BO"},
     )
     Number_of_CAI_Actual__c: Optional[conint(ge=0, le=999999999)] = Field(
         default=None,
         serialization_alias="I) Total Number of Locations Served by Type - Community Anchor Institution (Actual)",
-        json_schema_extra={"column":"BP"}
+        json_schema_extra={"column": "BP"},
     )
     Explanation_Planned__c: Optional[str] = Field(
-        default=None, serialization_alias="Explanation (Planned)", max_length=3000, json_schema_extra={"column":"BQ"}
+        default=None,
+        serialization_alias="Explanation (Planned)",
+        max_length=3000,
+        json_schema_extra={"column": "BQ"},
     )
     Affordable_Connectivity_Program_ACP__c: YesNoType = Field(
-        ..., serialization_alias="Affordable Connectivity Program (ACP)?", json_schema_extra={"column":"BR"}
+        ...,
+        serialization_alias="Affordable Connectivity Program (ACP)?",
+        json_schema_extra={"column": "BR"},
     )
     Is_this_a_middle_mile_Project__c: Optional[YesNoType] = Field(
         default=None,
         serialization_alias="Is this a middle mile Project?",
-        json_schema_extra={"column":"DV"}
+        json_schema_extra={"column": "DV"},
     )
+
     @field_validator(
         "Technology_Type_Planned__c",
         "Total_Miles_Planned__c",
@@ -398,43 +533,72 @@ class Project1ARow(BaseProjectRow):
     @classmethod
     def validate_field(cls, v: Any, info: ValidationInfo, **kwargs):
         if isinstance(v, str) and v.strip == "":
-            raise ValueError(
-                f"Value is required for {info.field_name}"
-            )
+            raise ValueError(f"Value is required for {info.field_name}")
         return v
 
+
 class AddressFields(BaseModel):
-    Street_1_Planned__c: constr(strip_whitespace=True, min_length=1, max_length=40) = Field(
-        ..., serialization_alias="Street 1 (Planned)", json_schema_extra={"column":"BS"}
+    Street_1_Planned__c: constr(strip_whitespace=True, min_length=1, max_length=40) = (
+        Field(
+            ...,
+            serialization_alias="Street 1 (Planned)",
+            json_schema_extra={"column": "BS"},
+        )
     )
     Street_2_Planned__c: Optional[str] = Field(
-        default=None, serialization_alias="Street 2 (Planned)", max_length=40, json_schema_extra={"column":"BT"}
+        default=None,
+        serialization_alias="Street 2 (Planned)",
+        max_length=40,
+        json_schema_extra={"column": "BT"},
     )
-    Same_Address__c: Optional[YesNoType] = Field(default=None, serialization_alias="Same Address", json_schema_extra={"column":"BU"})
+    Same_Address__c: Optional[YesNoType] = Field(
+        default=None,
+        serialization_alias="Same Address",
+        json_schema_extra={"column": "BU"},
+    )
     Street_1_Actual__c: Optional[str] = Field(
-        default=None, serialization_alias="Street 1 (Actual)", max_length=40, json_schema_extra={"column":"BV"}
+        default=None,
+        serialization_alias="Street 1 (Actual)",
+        max_length=40,
+        json_schema_extra={"column": "BV"},
     )
     Street_2_Actual__c: Optional[str] = Field(
-        default=None, serialization_alias="Street 2 (Actual)", max_length=40, json_schema_extra={"column":"BW"}
+        default=None,
+        serialization_alias="Street 2 (Actual)",
+        max_length=40,
+        json_schema_extra={"column": "BW"},
     )
     City_Planned__c: constr(strip_whitespace=True, min_length=1, max_length=40) = Field(
-        ..., serialization_alias="City (Planned)", json_schema_extra={"column":"BX"}
+        ..., serialization_alias="City (Planned)", json_schema_extra={"column": "BX"}
     )
     City_Actual__c: Optional[str] = Field(
-        default=None, serialization_alias="City (Actual)", max_length=40, json_schema_extra={"column":"BY"}
+        default=None,
+        serialization_alias="City (Actual)",
+        max_length=40,
+        json_schema_extra={"column": "BY"},
     )
     State_Planned__c: StateAbbreviation = Field(
-        ..., serialization_alias="State (Planned)", json_schema_extra={"column":"BZ"}
+        ..., serialization_alias="State (Planned)", json_schema_extra={"column": "BZ"}
     )
     State_Actual__c: Optional[StateAbbreviation] = Field(
-        default=None, serialization_alias="State (Actual)", json_schema_extra={"column":"CA"}
+        default=None,
+        serialization_alias="State (Actual)",
+        json_schema_extra={"column": "CA"},
     )
-    Zip_Code_Planned__c: constr(strip_whitespace=True, min_length=1, max_length=5) = Field(
-        ..., serialization_alias="Zip Code (Planned)", json_schema_extra={"column":"CB"}
+    Zip_Code_Planned__c: constr(strip_whitespace=True, min_length=1, max_length=5) = (
+        Field(
+            ...,
+            serialization_alias="Zip Code (Planned)",
+            json_schema_extra={"column": "CB"},
+        )
     )
     Zip_Code_Actual__c: Optional[str] = Field(
-        default=None, serialization_alias="Zip Code (Actual)", max_length=5, json_schema_extra={"column":"CC"}
+        default=None,
+        serialization_alias="Zip Code (Actual)",
+        max_length=5,
+        json_schema_extra={"column": "CC"},
     )
+
     @field_validator(
         "Street_1_Planned__c",
         "City_Planned__c",
@@ -443,132 +607,198 @@ class AddressFields(BaseModel):
     @classmethod
     def validate_field(cls, v: Any, info: ValidationInfo, **kwargs):
         if isinstance(v, str) and v.strip == "":
-            raise ValueError(
-                f"Value is required for {info.field_name}"
-            )
+            raise ValueError(f"Value is required for {info.field_name}")
         return v
+
 
 class Project1BRow(BaseProjectRow, AddressFields):
     Laptops_Planned__c: conint(ge=0, le=9999999999) = Field(
-        ..., serialization_alias="Laptops (Planned)", json_schema_extra={"column":"CD"}
+        ..., serialization_alias="Laptops (Planned)", json_schema_extra={"column": "CD"}
     )
     Laptops_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Laptops (Actual)", json_schema_extra={"column":"CE"}
+        default=None,
+        serialization_alias="Laptops (Actual)",
+        json_schema_extra={"column": "CE"},
     )
     Laptops_Expenditures_Planned__c: condecimal(max_digits=13, decimal_places=2) = (
-        Field(..., serialization_alias="Laptops Expenditure (Planned)", json_schema_extra={"column":"CF"})
+        Field(
+            ...,
+            serialization_alias="Laptops Expenditure (Planned)",
+            json_schema_extra={"column": "CF"},
+        )
     )
-    Laptops_Expenditures_Actual__c: Optional[condecimal(max_digits=13, decimal_places=2)] = Field(
-        default=None, serialization_alias="Laptops Expenditure (Actual)", json_schema_extra={"column":"CG"}
+    Laptops_Expenditures_Actual__c: Optional[
+        condecimal(max_digits=13, decimal_places=2)
+    ] = Field(
+        default=None,
+        serialization_alias="Laptops Expenditure (Actual)",
+        json_schema_extra={"column": "CG"},
     )
     Tablets_Planned__c: conint(ge=0, le=9999999999) = Field(
-        ..., serialization_alias="Tablets (Planned)", json_schema_extra={"column":"CH"}
+        ..., serialization_alias="Tablets (Planned)", json_schema_extra={"column": "CH"}
     )
     Tablets_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Tablets (Actual)", json_schema_extra={"column":"CI"}
+        default=None,
+        serialization_alias="Tablets (Actual)",
+        json_schema_extra={"column": "CI"},
     )
     Tablet_Expenditures_Planned__c: condecimal(max_digits=13, decimal_places=2) = Field(
-        ..., serialization_alias="Tablets Expenditure (Planned)", json_schema_extra={"column":"CJ"}
+        ...,
+        serialization_alias="Tablets Expenditure (Planned)",
+        json_schema_extra={"column": "CJ"},
     )
-    Tablets_Expenditures_Actual__c: Optional[condecimal(max_digits=13, decimal_places=2)] = Field(
-        default=None, serialization_alias="Tablets Expenditure (Actual)", json_schema_extra={"column":"CK"}
+    Tablets_Expenditures_Actual__c: Optional[
+        condecimal(max_digits=13, decimal_places=2)
+    ] = Field(
+        default=None,
+        serialization_alias="Tablets Expenditure (Actual)",
+        json_schema_extra={"column": "CK"},
     )
     Desktop_Computers_Planned__c: conint(ge=0, le=9999999999) = Field(
-        ..., serialization_alias="Desktop Computers (Planned)", json_schema_extra={"column":"CL"}
+        ...,
+        serialization_alias="Desktop Computers (Planned)",
+        json_schema_extra={"column": "CL"},
     )
     Desktop_Computers_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Desktop Computers (Actual)", json_schema_extra={"column":"CM"}
+        default=None,
+        serialization_alias="Desktop Computers (Actual)",
+        json_schema_extra={"column": "CM"},
     )
-    Desktop_Computers_Expenditures_Planned__c: condecimal(max_digits=13, decimal_places=2) = Field(
+    Desktop_Computers_Expenditures_Planned__c: condecimal(
+        max_digits=13, decimal_places=2
+    ) = Field(
         ...,
         serialization_alias="Desktop Computers Expenditure (Planned)",
-        json_schema_extra={"column":"CN"}
+        json_schema_extra={"column": "CN"},
     )
-    Desktop_Computers_Expenditures_Actual__c: Optional[condecimal(max_digits=13, decimal_places=2)] = Field(
+    Desktop_Computers_Expenditures_Actual__c: Optional[
+        condecimal(max_digits=13, decimal_places=2)
+    ] = Field(
         default=None,
         serialization_alias="Desktop Computers Expenditure (Actual)",
-        json_schema_extra={"column":"CO"}
+        json_schema_extra={"column": "CO"},
     )
     Public_WiFi_Planned__c: conint(ge=0, le=9999999999) = Field(
-        ..., serialization_alias="Public WiFi (Planned)", json_schema_extra={"column":"CP"}
+        ...,
+        serialization_alias="Public WiFi (Planned)",
+        json_schema_extra={"column": "CP"},
     )
     Public_WiFi_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Public WiFi (Actual)", json_schema_extra={"column":"CQ"}
+        default=None,
+        serialization_alias="Public WiFi (Actual)",
+        json_schema_extra={"column": "CQ"},
     )
     Public_WiFi_Expenditures_Planned__c: condecimal(max_digits=13, decimal_places=2) = (
-        Field(..., serialization_alias="Public Wifi Expenditures (Planned)", json_schema_extra={"column":"CR"})
+        Field(
+            ...,
+            serialization_alias="Public Wifi Expenditures (Planned)",
+            json_schema_extra={"column": "CR"},
+        )
     )
-    Public_WiFi_Expenditures_Actual__c: Optional[condecimal(max_digits=13, decimal_places=2)] = (
-        Field(default=None, serialization_alias="Public Wifi Expenditures (Actual)", json_schema_extra={"column":"CS"})
+    Public_WiFi_Expenditures_Actual__c: Optional[
+        condecimal(max_digits=13, decimal_places=2)
+    ] = Field(
+        default=None,
+        serialization_alias="Public Wifi Expenditures (Actual)",
+        json_schema_extra={"column": "CS"},
     )
     Other_Devices_Planned__c: conint(ge=0, le=9999999999) = Field(
-        ..., serialization_alias="Other Devices (Planned)", json_schema_extra={"column":"CT"}
+        ...,
+        serialization_alias="Other Devices (Planned)",
+        json_schema_extra={"column": "CT"},
     )
     Other_Devices_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Other Devices (Actual)", json_schema_extra={"column":"CU"}
+        default=None,
+        serialization_alias="Other Devices (Actual)",
+        json_schema_extra={"column": "CU"},
     )
     Other_Expenditures_Planned__c: condecimal(max_digits=7, decimal_places=2) = Field(
-        ..., serialization_alias="Other Expenditures (Planned)", json_schema_extra={"column":"CV"}
+        ...,
+        serialization_alias="Other Expenditures (Planned)",
+        json_schema_extra={"column": "CV"},
     )
-    Other_Expenditures_Actual__c: Optional[condecimal(max_digits=7, decimal_places=2)] = Field(
-        default=None, serialization_alias="Other Expenditures (Actual)", json_schema_extra={"column":"CW"}
+    Other_Expenditures_Actual__c: Optional[
+        condecimal(max_digits=7, decimal_places=2)
+    ] = Field(
+        default=None,
+        serialization_alias="Other Expenditures (Actual)",
+        json_schema_extra={"column": "CW"},
     )
     Explanation_of_Other_Expend__c: Optional[str] = Field(
         default=None,
         serialization_alias="Explanation of Other Expenditures",
         max_length=3000,
-        json_schema_extra={"column":"CX"}
+        json_schema_extra={"column": "CX"},
     )
     Number_of_Users_Planned__c: conint(ge=0, le=9999999999) = Field(
-        ..., serialization_alias="Number of Users (Planned)", json_schema_extra={"column":"CY"}
+        ...,
+        serialization_alias="Number of Users (Planned)",
+        json_schema_extra={"column": "CY"},
     )
     Number_of_Users_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Number of Users (Actual)", json_schema_extra={"column":"CZ"}
+        default=None,
+        serialization_alias="Number of Users (Actual)",
+        json_schema_extra={"column": "CZ"},
     )
-    Brief_Narrative_Planned__c: constr(strip_whitespace=True, min_length=1, max_length=3000) = Field(
-        ..., serialization_alias="Brief Narrative (Planned)", json_schema_extra={"column":"DA"}
+    Brief_Narrative_Planned__c: constr(
+        strip_whitespace=True, min_length=1, max_length=3000
+    ) = Field(
+        ...,
+        serialization_alias="Brief Narrative (Planned)",
+        json_schema_extra={"column": "DA"},
     )
     Brief_Narrative_Actual__c: Optional[str] = Field(
         default=None,
         serialization_alias="Brief Narrative (Actual)",
         max_length=3000,
-        json_schema_extra={"column":"DB"}
+        json_schema_extra={"column": "DB"},
     )
     Measurement_of_Effectiveness__c: YesNoType = Field(
-        ..., serialization_alias="Measurement of Effectiveness?", json_schema_extra={"column":"DC"}
+        ...,
+        serialization_alias="Measurement of Effectiveness?",
+        json_schema_extra={"column": "DC"},
     )
     # Columns below exist on Project1CRow as well as Project1BRow, so they jump in column defs
-    Current_Program_Income_Earned__c: Optional[condecimal(max_digits=15, decimal_places=2)] = Field(
+    Current_Program_Income_Earned__c: Optional[
+        condecimal(max_digits=15, decimal_places=2)
+    ] = Field(
         default=None,
         serialization_alias="Current Period Program Income Earned",
-        json_schema_extra={"column":"DW"}
+        json_schema_extra={"column": "DW"},
     )
-    Current_Program_Income_Expended__c: Optional[condecimal(max_digits=15, decimal_places=2)] = Field(
+    Current_Program_Income_Expended__c: Optional[
+        condecimal(max_digits=15, decimal_places=2)
+    ] = Field(
         default=None,
         serialization_alias="Current Period Program Income Expended",
-        json_schema_extra={"column":"DX"}
+        json_schema_extra={"column": "DX"},
     )
-    Cumulative_Program_Income_Earned__c: Optional[condecimal(max_digits=15, decimal_places=2)] = Field(
+    Cumulative_Program_Income_Earned__c: Optional[
+        condecimal(max_digits=15, decimal_places=2)
+    ] = Field(
         default=None,
         serialization_alias="Cumulative Program Income Earned",
-        json_schema_extra={"column":"DY"}
+        json_schema_extra={"column": "DY"},
     )
-    Cumulative_Program_Income_Expended__c: Optional[condecimal(max_digits=15, decimal_places=2)] = Field(
+    Cumulative_Program_Income_Expended__c: Optional[
+        condecimal(max_digits=15, decimal_places=2)
+    ] = Field(
         default=None,
         serialization_alias="Cumulative Program Income Expended",
-        json_schema_extra={"column":"DZ"}
+        json_schema_extra={"column": "DZ"},
     )
     Program_Income_2_CFR__c: Optional[YesNoType] = Field(
         default=None,
         serialization_alias="Program Income Pursuant",
-        json_schema_extra={"column":"EA"}
+        json_schema_extra={"column": "EA"},
     )
     Program_Income_2_CFR_Explanation__c: Optional[str] = Field(
         default=None,
         serialization_alias="Program Income Pursuant Explanation",
         max_length=3000,
-        json_schema_extra={"column":"EB"}
+        json_schema_extra={"column": "EB"},
     )
+
     @field_validator(
         "Laptops_Planned__c",
         "Laptops_Expenditures_Planned__c",
@@ -587,166 +817,226 @@ class Project1BRow(BaseProjectRow, AddressFields):
     @classmethod
     def validate_field(cls, v: Any, info: ValidationInfo, **kwargs):
         if isinstance(v, str) and v.strip == "":
-            raise ValueError(
-                f"Value is required for {info.field_name}"
-            )
+            raise ValueError(f"Value is required for {info.field_name}")
         return v
+
 
 class Project1CRow(BaseProjectRow, AddressFields):
     Type_of_Investment__c: Optional[str] = Field(
-        default=None, serialization_alias="Type of Investment", json_schema_extra={"column":"DD"}
+        default=None,
+        serialization_alias="Type of Investment",
+        json_schema_extra={"column": "DD"},
     )
     Additional_Address__c: Optional[str] = Field(
-        default=None, serialization_alias="Additional Addresses", max_length=32000, json_schema_extra={"column":"DE"}
+        default=None,
+        serialization_alias="Additional Addresses",
+        max_length=32000,
+        json_schema_extra={"column": "DE"},
     )
     Classrooms_Planned__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Classrooms (Planned)", json_schema_extra={"column":"DF"}
+        default=None,
+        serialization_alias="Classrooms (Planned)",
+        json_schema_extra={"column": "DF"},
     )
     Classrooms_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Classrooms (Actual)", json_schema_extra={"column":"DG"}
+        default=None,
+        serialization_alias="Classrooms (Actual)",
+        json_schema_extra={"column": "DG"},
     )
     Computer_labs_Planned__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Computer labs (Planned)", json_schema_extra={"column":"DH"}
+        default=None,
+        serialization_alias="Computer labs (Planned)",
+        json_schema_extra={"column": "DH"},
     )
     Computer_labs_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Computer labs (Actual)", json_schema_extra={"column":"DI"}
+        default=None,
+        serialization_alias="Computer labs (Actual)",
+        json_schema_extra={"column": "DI"},
     )
     Multi_purpose_Spaces_Planned__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Multi-purpose Spaces (Planned)", json_schema_extra={"column":"DJ"}
+        default=None,
+        serialization_alias="Multi-purpose Spaces (Planned)",
+        json_schema_extra={"column": "DJ"},
     )
     Multi_purpose_Spaces_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Multi-purpose Spaces (Actual)", json_schema_extra={"column":"DK"}
+        default=None,
+        serialization_alias="Multi-purpose Spaces (Actual)",
+        json_schema_extra={"column": "DK"},
     )
     Telemedicine_Rooms_Planned__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Telemedicine Rooms (Planned)", json_schema_extra={"column":"DL"}
+        default=None,
+        serialization_alias="Telemedicine Rooms (Planned)",
+        json_schema_extra={"column": "DL"},
     )
     Telemedicine_Rooms_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Telemedicine Rooms (Actual)", json_schema_extra={"column":"DM"}
+        default=None,
+        serialization_alias="Telemedicine Rooms (Actual)",
+        json_schema_extra={"column": "DM"},
     )
     Other_Capital_Assets_Planned__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Other Capital Assets (Planned)", json_schema_extra={"column":"DN"}
+        default=None,
+        serialization_alias="Other Capital Assets (Planned)",
+        json_schema_extra={"column": "DN"},
     )
     Other_Capital_Assets_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Other Capital Assets (Actual)", json_schema_extra={"column":"DO"}
+        default=None,
+        serialization_alias="Other Capital Assets (Actual)",
+        json_schema_extra={"column": "DO"},
     )
     Type_and_Features__c: Optional[str] = Field(
-        default=None, serialization_alias="Type and Features", max_length=3000, json_schema_extra={"column":"DP"}
+        default=None,
+        serialization_alias="Type and Features",
+        max_length=3000,
+        json_schema_extra={"column": "DP"},
     )
     Total_square_footage_Planned__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Total square footage (Planned)", json_schema_extra={"column":"DQ"}
+        default=None,
+        serialization_alias="Total square footage (Planned)",
+        json_schema_extra={"column": "DQ"},
     )
     Total_square_footage_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Total square footage (Actual)", json_schema_extra={"column":"DR"}
+        default=None,
+        serialization_alias="Total square footage (Actual)",
+        json_schema_extra={"column": "DR"},
     )
     Total_Number_of_Users_Actual__c: Optional[conint(ge=0, le=9999999999)] = Field(
-        default=None, serialization_alias="Total Number of Users (Actual)", json_schema_extra={"column":"DS"}
+        default=None,
+        serialization_alias="Total Number of Users (Actual)",
+        json_schema_extra={"column": "DS"},
     )
     Further_Explanation__c: Optional[str] = Field(
-        default=None, serialization_alias="Further Explanation", max_length=2000, json_schema_extra={"column":"DT"}
+        default=None,
+        serialization_alias="Further Explanation",
+        max_length=2000,
+        json_schema_extra={"column": "DT"},
     )
     Access_to_Public_Transit__c: YesNoType = Field(
-        ..., serialization_alias="Access to Public Transit?", json_schema_extra={"column":"DU"}
+        ...,
+        serialization_alias="Access to Public Transit?",
+        json_schema_extra={"column": "DU"},
     )
     # Columns below exist on Project1BRow as well as Project1CRow
-    Current_Program_Income_Earned__c: Optional[condecimal(max_digits=15, decimal_places=2)] = Field(
+    Current_Program_Income_Earned__c: Optional[
+        condecimal(max_digits=15, decimal_places=2)
+    ] = Field(
         default=None,
         serialization_alias="Current Period Program Income Earned",
-        json_schema_extra={"column":"DW"}
+        json_schema_extra={"column": "DW"},
     )
-    Current_Program_Income_Expended__c: Optional[condecimal(max_digits=15, decimal_places=2)] = Field(
+    Current_Program_Income_Expended__c: Optional[
+        condecimal(max_digits=15, decimal_places=2)
+    ] = Field(
         default=None,
         serialization_alias="Current Period Program Income Expended",
-        json_schema_extra={"column":"DX"}
+        json_schema_extra={"column": "DX"},
     )
-    Cumulative_Program_Income_Earned__c: Optional[condecimal(max_digits=15, decimal_places=2)] = Field(
+    Cumulative_Program_Income_Earned__c: Optional[
+        condecimal(max_digits=15, decimal_places=2)
+    ] = Field(
         default=None,
         serialization_alias="Cumulative Program Income Earned",
-        json_schema_extra={"column":"DY"}
+        json_schema_extra={"column": "DY"},
     )
-    Cumulative_Program_Income_Expended__c: Optional[condecimal(max_digits=15, decimal_places=2)] = Field(
+    Cumulative_Program_Income_Expended__c: Optional[
+        condecimal(max_digits=15, decimal_places=2)
+    ] = Field(
         default=None,
         serialization_alias="Cumulative Program Income Expended",
-        json_schema_extra={"column":"DZ"}
+        json_schema_extra={"column": "DZ"},
     )
     Program_Income_2_CFR__c: Optional[YesNoType] = Field(
         default=None,
         serialization_alias="Program Income Pursuant",
-        json_schema_extra={"column":"EA"}
+        json_schema_extra={"column": "EA"},
     )
     Program_Income_2_CFR_Explanation__c: Optional[str] = Field(
         default=None,
         serialization_alias="Program Income Pursuant Explanation",
         max_length=3000,
-        json_schema_extra={"column":"EB"}
+        json_schema_extra={"column": "EB"},
     )
-    @field_validator(
-        "Access_to_Public_Transit__c"
-    )
+
+    @field_validator("Access_to_Public_Transit__c")
     @classmethod
     def validate_field(cls, v: Any, info: ValidationInfo, **kwargs):
         if isinstance(v, str) and v.strip == "":
-            raise ValueError(
-                f"Value is required for {info.field_name}"
-            )
+            raise ValueError(f"Value is required for {info.field_name}")
         return v
+
 
 class SubrecipientRow(BaseModel):
     model_config = ConfigDict(coerce_numbers_to_str=True, loc_by_alias=False)
 
     Name: constr(strip_whitespace=True, min_length=1, max_length=80) = Field(
-        ...,
-        serialization_alias="Subrecipient Name",
-        json_schema_extra={"column":"C"}
+        ..., serialization_alias="Subrecipient Name", json_schema_extra={"column": "C"}
     )
-    Recipient_Profile_ID__c: Optional[constr(strip_whitespace=True, min_length=1, max_length=100)] = Field(
+    Recipient_Profile_ID__c: Optional[
+        constr(strip_whitespace=True, min_length=1, max_length=100)
+    ] = Field(
         default=None,
         serialization_alias="Recipient ID",
-        json_schema_extra={"column":"D"}
+        json_schema_extra={"column": "D"},
     )
     EIN__c: constr(strip_whitespace=True, min_length=9, max_length=9) = Field(
         ...,
         serialization_alias="Subrecipient Tax ID Number (TIN)",
-        json_schema_extra={"column":"E"}
+        json_schema_extra={"column": "E"},
     )
-    Unique_Entity_Identifier__c: constr(strip_whitespace=True, min_length=12, max_length=12) = Field(
+    Unique_Entity_Identifier__c: constr(
+        strip_whitespace=True, min_length=12, max_length=12
+    ) = Field(
         ...,
         serialization_alias="Unique Entity Identifier (UEI)",
-        json_schema_extra={"column":"F"}
+        json_schema_extra={"column": "F"},
     )
     POC_Name__c: constr(strip_whitespace=True, min_length=1, max_length=100) = Field(
-        ...,
-        serialization_alias="POC Name",
-        json_schema_extra={"column":"G"}
+        ..., serialization_alias="POC Name", json_schema_extra={"column": "G"}
     )
-    POC_Phone_Number__c: constr(strip_whitespace=True, min_length=1, max_length=10) = Field(
-        ..., serialization_alias="POC Phone Number", json_schema_extra={"column":"H"}
+    POC_Phone_Number__c: constr(strip_whitespace=True, min_length=1, max_length=10) = (
+        Field(
+            ...,
+            serialization_alias="POC Phone Number",
+            json_schema_extra={"column": "H"},
+        )
     )
-    POC_Email_Address__c: constr(strip_whitespace=True, min_length=1, max_length=80) = Field(
-        ..., serialization_alias="POC Email Address", json_schema_extra={"column":"I"}
+    POC_Email_Address__c: constr(strip_whitespace=True, min_length=1, max_length=80) = (
+        Field(
+            ...,
+            serialization_alias="POC Email Address",
+            json_schema_extra={"column": "I"},
+        )
     )
     Zip__c: constr(strip_whitespace=True, min_length=1, max_length=5) = Field(
-        ...,
-        serialization_alias="Zip5",
-        json_schema_extra={"column":"J"}
+        ..., serialization_alias="Zip5", json_schema_extra={"column": "J"}
     )
-    Zip_4__c: Optional[str] = Field(default=None, serialization_alias="Zip4", max_length=4, json_schema_extra={"column":"K"})
+    Zip_4__c: Optional[str] = Field(
+        default=None,
+        serialization_alias="Zip4",
+        max_length=4,
+        json_schema_extra={"column": "K"},
+    )
     Address__c: constr(strip_whitespace=True, min_length=1, max_length=40) = Field(
-        ...,
-        serialization_alias="Address Line 1",
-        json_schema_extra={"column":"L"}
+        ..., serialization_alias="Address Line 1", json_schema_extra={"column": "L"}
     )
     Address_2__c: Optional[str] = Field(
-        default=None, serialization_alias="Address Line 2", max_length=40, json_schema_extra={"column":"M"}
+        default=None,
+        serialization_alias="Address Line 2",
+        max_length=40,
+        json_schema_extra={"column": "M"},
     )
     Address_3__c: Optional[str] = Field(
-        default=None, serialization_alias="Address Line 3", max_length=40, json_schema_extra={"column":"N"}
+        default=None,
+        serialization_alias="Address Line 3",
+        max_length=40,
+        json_schema_extra={"column": "N"},
     )
     City__c: constr(strip_whitespace=True, min_length=1, max_length=100) = Field(
-        ..., serialization_alias="City", json_schema_extra={"column":"O"}
+        ..., serialization_alias="City", json_schema_extra={"column": "O"}
     )
     State_Abbreviated__c: StateAbbreviation = Field(
-        ..., serialization_alias="State Abbreviated", json_schema_extra={"column":"P"}
+        ..., serialization_alias="State Abbreviated", json_schema_extra={"column": "P"}
     )
+
     @field_validator(
         "Name",
         "EIN__c",
@@ -762,10 +1052,9 @@ class SubrecipientRow(BaseModel):
     @classmethod
     def validate_field(cls, v: Any, info: ValidationInfo, **kwargs):
         if isinstance(v, str) and v.strip == "":
-            raise ValueError(
-                f"Value is required for {info.field_name}"
-            )
+            raise ValueError(f"Value is required for {info.field_name}")
         return v
+
 
 METADATA_BY_SHEET = {
     "Cover": {
@@ -796,26 +1085,19 @@ class CoverSheetRow(BaseModel):
     model_config = ConfigDict(loc_by_alias=False)
 
     expenditure_category_group: constr(strip_whitespace=True, min_length=1) = Field(
-        ...,
-        alias="Expenditure Category Group", json_schema_extra={"column":"A"}
+        ..., alias="Expenditure Category Group", json_schema_extra={"column": "A"}
     )
     detailed_expenditure_category: constr(strip_whitespace=True, min_length=1) = Field(
-        ...,
-        alias="Detailed Expenditure Category",
-        json_schema_extra={"column":"B"}
+        ..., alias="Detailed Expenditure Category", json_schema_extra={"column": "B"}
     )
 
     @field_validator("expenditure_category_group")
     @classmethod
     def validate_code(cls, v: Any, info: ValidationInfo, **kwargs):
         if v is None or v.strip() == "":
-            raise ValueError(
-                f"EC code must be set"
-            )
+            raise ValueError(f"EC code must be set")
         elif v not in ProjectType:
-            raise ValueError(
-                f"EC code '{v}' is not recognized."
-            )
+            raise ValueError(f"EC code '{v}' is not recognized.")
         return v
 
     @field_validator("detailed_expenditure_category")

--- a/python/src/schemas/schema_V2024_05_24.py
+++ b/python/src/schemas/schema_V2024_05_24.py
@@ -107,10 +107,14 @@ class BaseProjectRow(BaseModel):
     model_config = ConfigDict(coerce_numbers_to_str=True, loc_by_alias=False)
 
     row_num: conint(ge=1) = Field(
-        default=1, serialization_alias="Row Number", json_schema_extra={"column":"NONE"}
+        default=1,
+        serialization_alias="Row Number",
+        json_schema_extra={"column": "NONE"},
     )
-    Project_Name__c: constr(strip_whitespace=True, min_length=1, max_length=100) = Field(
-        ..., serialization_alias="Project Name", json_schema_extra={"column":"C"}
+    Project_Name__c: constr(strip_whitespace=True, min_length=1, max_length=100) = (
+        Field(
+            ..., serialization_alias="Project Name", json_schema_extra={"column": "C"}
+        )
     )
     Identification_Number__c: constr(
         strip_whitespace=True, min_length=1, max_length=20
@@ -972,60 +976,83 @@ class SubrecipientRow(BaseModel):
     Name: constr(strip_whitespace=True, min_length=1, max_length=80) = Field(
         ...,
         serialization_alias="Subrecipient Name",
-        json_schema_extra={"column":"C", "output_column": "B"}
+        json_schema_extra={"column": "C", "output_column": "B"},
     )
     Recipient_Profile_ID__c: Optional[
         constr(strip_whitespace=True, min_length=1, max_length=100)
     ] = Field(
         default=None,
         serialization_alias="Recipient ID",
-        json_schema_extra={"column":"D", "output_column": "C"}
+        json_schema_extra={"column": "D", "output_column": "C"},
     )
     EIN__c: constr(strip_whitespace=True, min_length=9, max_length=9) = Field(
         ...,
         serialization_alias="Subrecipient Tax ID Number (TIN)",
-        json_schema_extra={"column":"E", "output_column": "D"}
+        json_schema_extra={"column": "E", "output_column": "D"},
     )
     Unique_Entity_Identifier__c: constr(
         strip_whitespace=True, min_length=12, max_length=12
     ) = Field(
         ...,
         serialization_alias="Unique Entity Identifier (UEI)",
-        json_schema_extra={"column":"F", "output_column": "E"}
+        json_schema_extra={"column": "F", "output_column": "E"},
     )
     POC_Name__c: constr(strip_whitespace=True, min_length=1, max_length=100) = Field(
         ...,
         serialization_alias="POC Name",
-        json_schema_extra={"column":"G", "output_column": "F"}
+        json_schema_extra={"column": "G", "output_column": "F"},
     )
-    POC_Phone_Number__c: constr(strip_whitespace=True, min_length=1, max_length=10) = Field(
-        ..., serialization_alias="POC Phone Number", json_schema_extra={"column":"H", "output_column": "G"}
+    POC_Phone_Number__c: constr(strip_whitespace=True, min_length=1, max_length=10) = (
+        Field(
+            ...,
+            serialization_alias="POC Phone Number",
+            json_schema_extra={"column": "H", "output_column": "G"},
+        )
     )
-    POC_Email_Address__c: constr(strip_whitespace=True, min_length=1, max_length=80) = Field(
-        ..., serialization_alias="POC Email Address", json_schema_extra={"column":"I", "output_column": "H"}
+    POC_Email_Address__c: constr(strip_whitespace=True, min_length=1, max_length=80) = (
+        Field(
+            ...,
+            serialization_alias="POC Email Address",
+            json_schema_extra={"column": "I", "output_column": "H"},
+        )
     )
     Zip__c: constr(strip_whitespace=True, min_length=1, max_length=5) = Field(
         ...,
         serialization_alias="Zip5",
-        json_schema_extra={"column":"J", "output_column": "I"}
+        json_schema_extra={"column": "J", "output_column": "I"},
     )
-    Zip_4__c: Optional[str] = Field(default=None, serialization_alias="Zip4", max_length=4, json_schema_extra={"column":"K", "output_column": "J"})
+    Zip_4__c: Optional[str] = Field(
+        default=None,
+        serialization_alias="Zip4",
+        max_length=4,
+        json_schema_extra={"column": "K", "output_column": "J"},
+    )
     Address__c: constr(strip_whitespace=True, min_length=1, max_length=40) = Field(
         ...,
         serialization_alias="Address Line 1",
-        json_schema_extra={"column":"L", "output_column": "K"}
+        json_schema_extra={"column": "L", "output_column": "K"},
     )
     Address_2__c: Optional[str] = Field(
-        default=None, serialization_alias="Address Line 2", max_length=40, json_schema_extra={"column":"M", "output_column": "L"}
+        default=None,
+        serialization_alias="Address Line 2",
+        max_length=40,
+        json_schema_extra={"column": "M", "output_column": "L"},
     )
     Address_3__c: Optional[str] = Field(
-        default=None, serialization_alias="Address Line 3", max_length=40, json_schema_extra={"column":"N", "output_column": "M"}
+        default=None,
+        serialization_alias="Address Line 3",
+        max_length=40,
+        json_schema_extra={"column": "N", "output_column": "M"},
     )
     City__c: constr(strip_whitespace=True, min_length=1, max_length=100) = Field(
-        ..., serialization_alias="City", json_schema_extra={"column":"O", "output_column": "N"}
+        ...,
+        serialization_alias="City",
+        json_schema_extra={"column": "O", "output_column": "N"},
     )
     State_Abbreviated__c: StateAbbreviation = Field(
-        ..., serialization_alias="State Abbreviated", json_schema_extra={"column":"P", "output_column": "O"}
+        ...,
+        serialization_alias="State Abbreviated",
+        json_schema_extra={"column": "P", "output_column": "O"},
     )
 
     @field_validator(

--- a/python/src/schemas/schema_V2024_05_24.py
+++ b/python/src/schemas/schema_V2024_05_24.py
@@ -1095,7 +1095,7 @@ class CoverSheetRow(BaseModel):
     @classmethod
     def validate_code(cls, v: Any, info: ValidationInfo, **kwargs):
         if v is None or v.strip() == "":
-            raise ValueError(f"EC code must be set")
+            raise ValueError("EC code must be set")
         elif v not in ProjectType:
             raise ValueError(f"EC code '{v}' is not recognized.")
         return v

--- a/python/src/schemas/schema_versions.py
+++ b/python/src/schemas/schema_versions.py
@@ -1,28 +1,52 @@
 from enum import Enum
-from typing import Union, Type, Any
-from pydantic import BaseModel, Field, field_validator, ValidationInfo
+from typing import Any, Type, Union
+
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
+
+from src.schemas.project_types import ProjectType
+from src.schemas.schema_V2024_04_01 import (
+    METADATA_BY_SHEET as V2024_04_01_Metadata,
+)
+from src.schemas.schema_V2024_04_01 import (
+    CoverSheetRow as V2024_04_01_CoverSheetRow,
+)
+from src.schemas.schema_V2024_04_01 import (
+    Project1ARow as V2024_04_01_Project1ARow,
+)
+from src.schemas.schema_V2024_04_01 import (
+    Project1BRow as V2024_04_01_Project1BRow,
+)
+from src.schemas.schema_V2024_04_01 import (
+    Project1CRow as V2024_04_01_Project1CRow,
+)
 from src.schemas.schema_V2024_04_01 import (
     SubrecipientRow as V2024_04_01_SubrecipientRow,
-    CoverSheetRow as V2024_04_01_CoverSheetRow,
-    Project1ARow as V2024_04_01_Project1ARow,
-    Project1BRow as V2024_04_01_Project1BRow,
-    Project1CRow as V2024_04_01_Project1CRow,
-    METADATA_BY_SHEET as V2024_04_01_Metadata,
+)
+from src.schemas.schema_V2024_05_24 import (
+    METADATA_BY_SHEET as V2024_05_24_Metadata,
+)
+from src.schemas.schema_V2024_05_24 import (
+    CoverSheetRow as V2024_05_24_CoverSheetRow,
+)
+from src.schemas.schema_V2024_05_24 import (
+    Project1ARow as V2024_05_24_Project1ARow,
+)
+from src.schemas.schema_V2024_05_24 import (
+    Project1BRow as V2024_05_24_Project1BRow,
+)
+from src.schemas.schema_V2024_05_24 import (
+    Project1CRow as V2024_05_24_Project1CRow,
 )
 from src.schemas.schema_V2024_05_24 import (
     SubrecipientRow as V2024_05_24_SubrecipientRow,
-    CoverSheetRow as V2024_05_24_CoverSheetRow,
-    Project1ARow as V2024_05_24_Project1ARow,
-    Project1BRow as V2024_05_24_Project1BRow,
-    Project1CRow as V2024_05_24_Project1CRow,
-    METADATA_BY_SHEET as V2024_05_24_Metadata,
 )
-from src.schemas.project_types import ProjectType
 
-"""
-These are meant to be the canonical "type" for the various rows given whatever versions we have
-so that we can have classnames to pass around as return types and input types here and in workbook_validator
-When you add a new version, please import the types from its sheets and add them in here
+"""These are meant to be the canonical "type" for the various rows given whatever
+versions we have so that we can have classnames to pass around as return types
+and input types here and in workbook_validator.
+
+When you add a new version, please import the types from its sheets and add them
+in here.
 """
 
 

--- a/python/src/schemas/schema_versions.py
+++ b/python/src/schemas/schema_versions.py
@@ -1,20 +1,22 @@
 from enum import Enum
 from typing import Union, Type, Any
-from pydantic import (BaseModel, Field, field_validator, ValidationInfo)
+from pydantic import BaseModel, Field, field_validator, ValidationInfo
 from src.schemas.schema_V2024_04_01 import (
-    SubrecipientRow as V2024_04_01_SubrecipientRow, 
+    SubrecipientRow as V2024_04_01_SubrecipientRow,
     CoverSheetRow as V2024_04_01_CoverSheetRow,
     Project1ARow as V2024_04_01_Project1ARow,
     Project1BRow as V2024_04_01_Project1BRow,
     Project1CRow as V2024_04_01_Project1CRow,
-    METADATA_BY_SHEET as V2024_04_01_Metadata)
+    METADATA_BY_SHEET as V2024_04_01_Metadata,
+)
 from src.schemas.schema_V2024_05_24 import (
-    SubrecipientRow as V2024_05_24_SubrecipientRow, 
+    SubrecipientRow as V2024_05_24_SubrecipientRow,
     CoverSheetRow as V2024_05_24_CoverSheetRow,
     Project1ARow as V2024_05_24_Project1ARow,
     Project1BRow as V2024_05_24_Project1BRow,
     Project1CRow as V2024_05_24_Project1CRow,
-    METADATA_BY_SHEET as V2024_05_24_Metadata)
+    METADATA_BY_SHEET as V2024_05_24_Metadata,
+)
 from src.schemas.project_types import ProjectType
 
 """
@@ -22,11 +24,27 @@ These are meant to be the canonical "type" for the various rows given whatever v
 so that we can have classnames to pass around as return types and input types here and in workbook_validator
 When you add a new version, please import the types from its sheets and add them in here
 """
-class SubrecipientRow: Type[Union[V2024_04_01_SubrecipientRow, V2024_05_24_SubrecipientRow]]
-class CoverSheetRow: Type[Union[V2024_04_01_CoverSheetRow, V2024_05_24_CoverSheetRow]]
-class Project1ARow: Type[Union[V2024_04_01_Project1ARow, V2024_05_24_Project1ARow]]
-class Project1BRow: Type[Union[V2024_04_01_Project1BRow, V2024_05_24_Project1BRow]]
-class Project1CRow: Type[Union[V2024_04_01_Project1CRow, V2024_05_24_Project1CRow]]
+
+
+class SubrecipientRow:
+    Type[Union[V2024_04_01_SubrecipientRow, V2024_05_24_SubrecipientRow]]
+
+
+class CoverSheetRow:
+    Type[Union[V2024_04_01_CoverSheetRow, V2024_05_24_CoverSheetRow]]
+
+
+class Project1ARow:
+    Type[Union[V2024_04_01_Project1ARow, V2024_05_24_Project1ARow]]
+
+
+class Project1BRow:
+    Type[Union[V2024_04_01_Project1BRow, V2024_05_24_Project1BRow]]
+
+
+class Project1CRow:
+    Type[Union[V2024_04_01_Project1CRow, V2024_05_24_Project1CRow]]
+
 
 class Version(Enum):
     V2023_12_12 = "v:20231212"
@@ -34,12 +52,11 @@ class Version(Enum):
     V2024_04_01 = "v:20240401"
     V2024_05_24 = "v:20240524"
 
+
 class LogicSheetVersion(BaseModel):
     version: Version = Field(...)
 
-    @field_validator(
-        "version"
-    )
+    @field_validator("version")
     @classmethod
     def validate_field(cls, v: Any, info: ValidationInfo, **kwargs):
         if v != Version.V2024_05_24:
@@ -70,7 +87,8 @@ def getSubrecipientRowClass(version_string: str) -> SubrecipientRow:
             return V2024_05_24_SubrecipientRow
         case _:
             return V2024_04_01_SubrecipientRow
-    
+
+
 def getCoverSheetRowClass(version_string: str) -> CoverSheetRow:
     version = getVersionFromString(version_string)
     match version:
@@ -78,9 +96,11 @@ def getCoverSheetRowClass(version_string: str) -> CoverSheetRow:
             return V2024_05_24_CoverSheetRow
         case _:
             return V2024_04_01_CoverSheetRow
-    
 
-def getSchemaByProject(version_string: str, project_type: ProjectType) -> Type[Union[Project1ARow, Project1BRow, Project1CRow]]:
+
+def getSchemaByProject(
+    version_string: str, project_type: ProjectType
+) -> Type[Union[Project1ARow, Project1BRow, Project1CRow]]:
     version = getVersionFromString(version_string)
     match project_type:
         case ProjectType._1A:
@@ -98,6 +118,7 @@ def getProject1ARow(version: Version) -> Project1ARow:
         case _:
             return V2024_04_01_Project1ARow
 
+
 def getProject1BRow(version: Version) -> Project1BRow:
     match version:
         case Version.V2024_05_24:
@@ -105,13 +126,15 @@ def getProject1BRow(version: Version) -> Project1BRow:
         case _:
             return V2024_04_01_Project1BRow
 
+
 def getProject1CRow(version: Version) -> Project1CRow:
     match version:
         case Version.V2024_05_24:
             return V2024_05_24_Project1CRow
         case _:
             return V2024_04_01_Project1CRow
-        
+
+
 def getSchemaMetadata(version_string: str) -> dict:
     version = getVersionFromString(version_string)
     match version:
@@ -119,5 +142,3 @@ def getSchemaMetadata(version_string: str) -> dict:
             return V2024_05_24_Metadata
         case _:
             return V2024_04_01_Metadata
-    
-    

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -21,13 +21,16 @@ def valid_file() -> BinaryIO:
 def valid_workbook() -> openpyxl.Workbook:
     return openpyxl.load_workbook(_SAMPLE_VALID_XLSM_V2024_05_24)
 
+
 @pytest.fixture
 def valid_workbook_old_schema() -> openpyxl.Workbook:
     return openpyxl.load_workbook(_SAMPLE_VALID_XLSM)
 
+
 @pytest.fixture
 def valid_coversheet(valid_workbook) -> openpyxl.worksheet.worksheet.Worksheet:
     return valid_workbook["Cover"]
+
 
 @pytest.fixture
 def valid_project_sheet(valid_workbook) -> openpyxl.worksheet.worksheet.Worksheet:

--- a/python/tests/src/lib/test_workbook_validator.py
+++ b/python/tests/src/lib/test_workbook_validator.py
@@ -160,8 +160,10 @@ class TestValidateproject_sheet:
     def test_valid_project_sheet(self, valid_project_sheet: Worksheet):
         errors, projects = validate_project_sheet(
             valid_project_sheet,
-            getSchemaByProject(V2024_05_24_VERSION_STRING, SAMPLE_EXPENDITURE_CATEGORY_GROUP),
-            V2024_05_24_VERSION_STRING
+            getSchemaByProject(
+                V2024_05_24_VERSION_STRING, SAMPLE_EXPENDITURE_CATEGORY_GROUP
+            ),
+            V2024_05_24_VERSION_STRING,
         )
         assert errors == []
         assert len(projects) == 1
@@ -187,7 +189,9 @@ class TestValidateproject_sheet:
         )
         assert error.severity == ErrorLevel.ERR.name
 
-    def test_invalid_project_sheet_missing_field(self, invalid_project_sheet_missing_field: Worksheet):
+    def test_invalid_project_sheet_missing_field(
+        self, invalid_project_sheet_missing_field: Worksheet
+    ):
         errors, _ = validate_project_sheet(
             invalid_project_sheet_missing_field,
             getSchemaByProject(
@@ -202,7 +206,9 @@ class TestValidateproject_sheet:
         assert "Value is required for Identification_Number__c" in error.message
         assert error.severity == ErrorLevel.ERR.name
 
-    def test_invalid_project_sheet_empty_field(self, invalid_project_sheet_empty_field: Worksheet):
+    def test_invalid_project_sheet_empty_field(
+        self, invalid_project_sheet_empty_field: Worksheet
+    ):
         errors, _ = validate_project_sheet(
             invalid_project_sheet_empty_field,
             getSchemaByProject(
@@ -220,14 +226,18 @@ class TestValidateproject_sheet:
 
 class TestValidateSubrecipientSheet:
     def test_valid_subrecipient_sheet(self, valid_subrecipientsheet: Worksheet):
-        errors, subrecipients = validate_subrecipient_sheet(valid_subrecipientsheet, V2024_05_24_VERSION_STRING)
+        errors, subrecipients = validate_subrecipient_sheet(
+            valid_subrecipientsheet, V2024_05_24_VERSION_STRING
+        )
         assert errors == []
         assert len(subrecipients) == 1
         assert subrecipients[0].EIN__c == "123123123"
         assert subrecipients[0].Unique_Entity_Identifier__c == "123412341234"
 
     def test_invalid_subrecipient_sheet(self, invalid_subrecipient_sheet: Worksheet):
-        errors, _ = validate_subrecipient_sheet(invalid_subrecipient_sheet, V2024_05_24_VERSION_STRING)
+        errors, _ = validate_subrecipient_sheet(
+            invalid_subrecipient_sheet, V2024_05_24_VERSION_STRING
+        )
         assert errors != []
         error = errors[0]
         assert "EIN__c should have at least 9 characters" in error.message
@@ -235,14 +245,22 @@ class TestValidateSubrecipientSheet:
         assert error.col == "E"
         assert error.severity == ErrorLevel.ERR.name
 
-    def test_valid_subrecipient_sheet_blank_optional_fields(self, valid_subrecipient_sheet_blank_optional_fields: Worksheet):
-        errors, _ = validate_subrecipient_sheet(valid_subrecipient_sheet_blank_optional_fields, V2024_05_24_VERSION_STRING)
+    def test_valid_subrecipient_sheet_blank_optional_fields(
+        self, valid_subrecipient_sheet_blank_optional_fields: Worksheet
+    ):
+        errors, _ = validate_subrecipient_sheet(
+            valid_subrecipient_sheet_blank_optional_fields, V2024_05_24_VERSION_STRING
+        )
         assert errors == []
 
 
 class TestValidateMatchingSubrecipientSheet:
-    def test_invalid_project_sheet_unmatching_subrecipient_tin_field(self, invalid_project_sheet_unmatching_subrecipient_tin_field: Worksheet):
-        errors, _ = validate_workbook(invalid_project_sheet_unmatching_subrecipient_tin_field)
+    def test_invalid_project_sheet_unmatching_subrecipient_tin_field(
+        self, invalid_project_sheet_unmatching_subrecipient_tin_field: Worksheet
+    ):
+        errors, _ = validate_workbook(
+            invalid_project_sheet_unmatching_subrecipient_tin_field
+        )
         assert errors != []
         error = errors[0]
         assert "You must submit a subrecipient" in error.message
@@ -250,8 +268,12 @@ class TestValidateMatchingSubrecipientSheet:
         assert error.col == "E, F"
         assert error.severity == ErrorLevel.ERR.name
 
-    def test_invalid_project_sheet_unmatching_subrecipient_uei_field(self, invalid_project_sheet_unmatching_subrecipient_uei_field: Worksheet):
-        errors, _ = validate_workbook(invalid_project_sheet_unmatching_subrecipient_uei_field)
+    def test_invalid_project_sheet_unmatching_subrecipient_uei_field(
+        self, invalid_project_sheet_unmatching_subrecipient_uei_field: Worksheet
+    ):
+        errors, _ = validate_workbook(
+            invalid_project_sheet_unmatching_subrecipient_uei_field
+        )
         assert errors != []
         error = errors[0]
         assert "You must submit a subrecipient" in error.message
@@ -259,14 +281,19 @@ class TestValidateMatchingSubrecipientSheet:
         assert error.col == "E, F"
         assert error.severity == ErrorLevel.ERR.name
 
-    def test_invalid_project_sheet_unmatching_subrecipient_tin_uei_field(self, invalid_project_sheet_unmatching_subrecipient_tin_uei_field: Worksheet):
-        errors, _ = validate_workbook(invalid_project_sheet_unmatching_subrecipient_tin_uei_field)
+    def test_invalid_project_sheet_unmatching_subrecipient_tin_uei_field(
+        self, invalid_project_sheet_unmatching_subrecipient_tin_uei_field: Worksheet
+    ):
+        errors, _ = validate_workbook(
+            invalid_project_sheet_unmatching_subrecipient_tin_uei_field
+        )
         assert errors != []
         error = errors[0]
         assert "You must submit a subrecipient" in error.message
         assert error.row == 13
         assert error.col == "E, F"
         assert error.severity == ErrorLevel.ERR.name
+
 
 class TestGetProjectUseCode:
     def test_get_project_use_code(self, valid_coversheet: Worksheet):

--- a/python/tests/src/lib/test_workbook_validator.py
+++ b/python/tests/src/lib/test_workbook_validator.py
@@ -3,22 +3,29 @@ from typing import BinaryIO
 import pytest
 from openpyxl import Workbook
 from openpyxl.worksheet.worksheet import Worksheet
-from src.lib.workbook_validator import (ErrorLevel,
-                                        get_project_use_code, is_empty_row,
-                                        validate, validate_cover_sheet,
-                                        validate_project_sheet,
-                                        validate_subrecipient_sheet,
-                                        validate_workbook,
-                                        validate_workbook_sheets,
-                                        validate_logic_sheet)
+from src.lib.workbook_validator import (
+    ErrorLevel,
+    get_project_use_code,
+    is_empty_row,
+    validate,
+    validate_cover_sheet,
+    validate_project_sheet,
+    validate_subrecipient_sheet,
+    validate_workbook,
+    validate_workbook_sheets,
+    validate_logic_sheet,
+)
 from src.schemas.schema_versions import getSchemaByProject
 
 SAMPLE_EXPENDITURE_CATEGORY_GROUP = "1A"
 V2024_05_24_VERSION_STRING = "v:20240524"
 
+
 class TestValidateWorkbookWithOldSchema:
     def test_valid_workbook_old_schema(self, valid_workbook_old_schema: Workbook):
-        errors, version_string = validate_logic_sheet(valid_workbook_old_schema["Logic"])
+        errors, version_string = validate_logic_sheet(
+            valid_workbook_old_schema["Logic"]
+        )
         assert len(errors) == 1
         assert "Using outdated version of template." in errors[0].message
 
@@ -72,11 +79,12 @@ class TestValidateWorkbook:
         assert errors[0].severity == ErrorLevel.WARN.name
         assert errors[1].tab == "Project"
 
+
 class TestWorkbookSheets:
     def test_valid_set_of_sheets(self, valid_workbook: Workbook):
         errors = validate_workbook_sheets(valid_workbook)
         assert errors == []
-    
+
     def test_missing_sheets(self, valid_workbook: Workbook):
         valid_workbook.remove(valid_workbook["Cover"])
         errors = validate_workbook_sheets(valid_workbook)
@@ -86,15 +94,22 @@ class TestWorkbookSheets:
         assert errors[0].tab == "N/A"
         assert errors[0].severity == ErrorLevel.ERR.name
 
+
 class TestValidateCoverSheet:
     def test_valid_cover_sheet(self, valid_coversheet: Worksheet):
-        errors, schema, project_use_code = validate_cover_sheet(valid_coversheet, V2024_05_24_VERSION_STRING)
+        errors, schema, project_use_code = validate_cover_sheet(
+            valid_coversheet, V2024_05_24_VERSION_STRING
+        )
         assert errors == []
         assert project_use_code == SAMPLE_EXPENDITURE_CATEGORY_GROUP
-        assert schema == getSchemaByProject(V2024_05_24_VERSION_STRING, SAMPLE_EXPENDITURE_CATEGORY_GROUP)
+        assert schema == getSchemaByProject(
+            V2024_05_24_VERSION_STRING, SAMPLE_EXPENDITURE_CATEGORY_GROUP
+        )
 
     def test_invalid_cover_sheet(self, invalid_cover_sheet: Worksheet):
-        errors, schema, project_use_code = validate_cover_sheet(invalid_cover_sheet, V2024_05_24_VERSION_STRING)
+        errors, schema, project_use_code = validate_cover_sheet(
+            invalid_cover_sheet, V2024_05_24_VERSION_STRING
+        )
         assert errors != []
         error = errors[0]
         assert "EC code 'INVALID' is not recognized." in error.message
@@ -104,10 +119,13 @@ class TestValidateCoverSheet:
         assert error.severity == ErrorLevel.ERR.name
         assert schema is None
         assert project_use_code is None
-    
-    
-    def test_invalid_cover_sheet_missing_code(self, invalid_cover_sheet_missing_code: Worksheet):
-        errors, schema, project_use_code = validate_cover_sheet(invalid_cover_sheet_missing_code, V2024_05_24_VERSION_STRING)
+
+    def test_invalid_cover_sheet_missing_code(
+        self, invalid_cover_sheet_missing_code: Worksheet
+    ):
+        errors, schema, project_use_code = validate_cover_sheet(
+            invalid_cover_sheet_missing_code, V2024_05_24_VERSION_STRING
+        )
         assert errors != []
         error = errors[0]
         assert "EC code must be set" in error.message
@@ -117,10 +135,13 @@ class TestValidateCoverSheet:
         assert error.severity == ErrorLevel.ERR.name
         assert schema is None
         assert project_use_code is None
-    
-    
-    def test_invalid_cover_sheet_empty_code(self, invalid_cover_sheet_empty_code: Worksheet):
-        errors, schema, project_use_code = validate_cover_sheet(invalid_cover_sheet_empty_code, V2024_05_24_VERSION_STRING)
+
+    def test_invalid_cover_sheet_empty_code(
+        self, invalid_cover_sheet_empty_code: Worksheet
+    ):
+        errors, schema, project_use_code = validate_cover_sheet(
+            invalid_cover_sheet_empty_code, V2024_05_24_VERSION_STRING
+        )
         assert errors != []
         error = errors[0]
         assert "EC code must be set" in error.message
@@ -135,17 +156,21 @@ class TestValidateCoverSheet:
 class TestValidateproject_sheet:
     def test_valid_project_sheet(self, valid_project_sheet: Worksheet):
         errors = validate_project_sheet(
-            valid_project_sheet, 
-            getSchemaByProject(V2024_05_24_VERSION_STRING, SAMPLE_EXPENDITURE_CATEGORY_GROUP),
-            V2024_05_24_VERSION_STRING
+            valid_project_sheet,
+            getSchemaByProject(
+                V2024_05_24_VERSION_STRING, SAMPLE_EXPENDITURE_CATEGORY_GROUP
+            ),
+            V2024_05_24_VERSION_STRING,
         )
         assert errors == []
 
     def test_invalid_project_sheet(self, invalid_project_sheet: Worksheet):
         errors = validate_project_sheet(
             invalid_project_sheet,
-            getSchemaByProject(V2024_05_24_VERSION_STRING, SAMPLE_EXPENDITURE_CATEGORY_GROUP),
-            V2024_05_24_VERSION_STRING
+            getSchemaByProject(
+                V2024_05_24_VERSION_STRING, SAMPLE_EXPENDITURE_CATEGORY_GROUP
+            ),
+            V2024_05_24_VERSION_STRING,
         )
         assert errors != []
         error = errors[0]
@@ -156,47 +181,53 @@ class TestValidateproject_sheet:
             in error.message
         )
         assert error.severity == ErrorLevel.ERR.name
-    
-    def test_invalid_project_sheet_missing_field(self, invalid_project_sheet_missing_field: Worksheet):
+
+    def test_invalid_project_sheet_missing_field(
+        self, invalid_project_sheet_missing_field: Worksheet
+    ):
         errors = validate_project_sheet(
             invalid_project_sheet_missing_field,
-            getSchemaByProject(V2024_05_24_VERSION_STRING, SAMPLE_EXPENDITURE_CATEGORY_GROUP),
-            V2024_05_24_VERSION_STRING
+            getSchemaByProject(
+                V2024_05_24_VERSION_STRING, SAMPLE_EXPENDITURE_CATEGORY_GROUP
+            ),
+            V2024_05_24_VERSION_STRING,
         )
         assert errors != []
         error = errors[0]
         assert error.row == "13"
         assert error.col == "D"
-        assert (
-            "Value is required for Identification_Number__c"
-            in error.message
-        )
+        assert "Value is required for Identification_Number__c" in error.message
         assert error.severity == ErrorLevel.ERR.name
-    
-    def test_invalid_project_sheet_empty_field(self, invalid_project_sheet_empty_field: Worksheet):
+
+    def test_invalid_project_sheet_empty_field(
+        self, invalid_project_sheet_empty_field: Worksheet
+    ):
         errors = validate_project_sheet(
             invalid_project_sheet_empty_field,
-            getSchemaByProject(V2024_05_24_VERSION_STRING, SAMPLE_EXPENDITURE_CATEGORY_GROUP),
-            V2024_05_24_VERSION_STRING
+            getSchemaByProject(
+                V2024_05_24_VERSION_STRING, SAMPLE_EXPENDITURE_CATEGORY_GROUP
+            ),
+            V2024_05_24_VERSION_STRING,
         )
         assert errors != []
         error = errors[0]
         assert error.row == "13"
         assert error.col == "D"
-        assert (
-            "Value is required for Identification_Number__c"
-            in error.message
-        )
+        assert "Value is required for Identification_Number__c" in error.message
         assert error.severity == ErrorLevel.ERR.name
 
 
 class TestValidateSubrecipientSheet:
     def test_valid_subrecipient_sheet(self, valid_subrecipientsheet: Worksheet):
-        errors = validate_subrecipient_sheet(valid_subrecipientsheet, V2024_05_24_VERSION_STRING)
+        errors = validate_subrecipient_sheet(
+            valid_subrecipientsheet, V2024_05_24_VERSION_STRING
+        )
         assert errors == []
 
     def test_invalid_subrecipient_sheet(self, invalid_subrecipient_sheet: Worksheet):
-        errors = validate_subrecipient_sheet(invalid_subrecipient_sheet, V2024_05_24_VERSION_STRING)
+        errors = validate_subrecipient_sheet(
+            invalid_subrecipient_sheet, V2024_05_24_VERSION_STRING
+        )
         assert errors != []
         error = errors[0]
         assert "EIN__c should have at least 9 characters" in error.message
@@ -204,14 +235,20 @@ class TestValidateSubrecipientSheet:
         assert error.col == "E"
         assert error.severity == ErrorLevel.ERR.name
 
-    def test_valid_subrecipient_sheet_blank_optional_fields(self, valid_subrecipient_sheet_blank_optional_fields: Worksheet):
-        errors = validate_subrecipient_sheet(valid_subrecipient_sheet_blank_optional_fields, V2024_05_24_VERSION_STRING)
+    def test_valid_subrecipient_sheet_blank_optional_fields(
+        self, valid_subrecipient_sheet_blank_optional_fields: Worksheet
+    ):
+        errors = validate_subrecipient_sheet(
+            valid_subrecipient_sheet_blank_optional_fields, V2024_05_24_VERSION_STRING
+        )
         assert errors == []
 
 
 class TestGetProjectUseCode:
     def test_get_project_use_code(self, valid_coversheet: Worksheet):
-        expenditure_category_group = get_project_use_code(valid_coversheet, V2024_05_24_VERSION_STRING)
+        expenditure_category_group = get_project_use_code(
+            valid_coversheet, V2024_05_24_VERSION_STRING
+        )
         assert expenditure_category_group == SAMPLE_EXPENDITURE_CATEGORY_GROUP
 
     def test_get_project_use_code_raises_error(self, invalid_cover_sheet: Worksheet):

--- a/python/tests/src/lib/test_workbook_validator.py
+++ b/python/tests/src/lib/test_workbook_validator.py
@@ -103,10 +103,16 @@ class TestValidateCoverSheet:
         )
         assert errors == []
         assert project_use_code == SAMPLE_EXPENDITURE_CATEGORY_GROUP
-        assert schema == getSchemaByProject(V2024_05_24_VERSION_STRING, SAMPLE_EXPENDITURE_CATEGORY_GROUP)
+        assert schema == getSchemaByProject(
+            V2024_05_24_VERSION_STRING, SAMPLE_EXPENDITURE_CATEGORY_GROUP
+        )
 
-    def test_invalid_cover_sheet_missing_code(self, invalid_cover_sheet_missing_code: Worksheet):
-        errors, schema, project_use_code = validate_cover_sheet(invalid_cover_sheet_missing_code, V2024_05_24_VERSION_STRING)
+    def test_invalid_cover_sheet_missing_code(
+        self, invalid_cover_sheet_missing_code: Worksheet
+    ):
+        errors, schema, project_use_code = validate_cover_sheet(
+            invalid_cover_sheet_missing_code, V2024_05_24_VERSION_STRING
+        )
         assert errors != []
         error = errors[0]
         assert "EC code must be set" in error.message
@@ -133,8 +139,12 @@ class TestValidateCoverSheet:
         assert schema is None
         assert project_use_code is None
 
-    def test_invalid_cover_sheet_empty_desc(self, invalid_cover_sheet_empty_desc: Worksheet):
-        errors, schema, project_use_code = validate_cover_sheet(invalid_cover_sheet_empty_desc, V2024_05_24_VERSION_STRING)
+    def test_invalid_cover_sheet_empty_desc(
+        self, invalid_cover_sheet_empty_desc: Worksheet
+    ):
+        errors, schema, project_use_code = validate_cover_sheet(
+            invalid_cover_sheet_empty_desc, V2024_05_24_VERSION_STRING
+        )
         assert errors != []
         error = errors[0]
         assert "Value is required for detailed_expenditure_category" in error.message

--- a/scripts/onboardOrganization.ts
+++ b/scripts/onboardOrganization.ts
@@ -1,17 +1,13 @@
 // To access your database
 // Append api/* to import from api and web/* to import from web
 import { getPrismaClient } from 'api/src/lib/db'
-import {
-  getOrCreateOrganization
-} from 'api/src/services/organizations/organizations'
-import {
-  getOrCreateAgencies
-} from 'api/src/services/agencies/agencies'
-import { getOrCreateUsers } from 'api/src/services/users/users'
-import { getOrCreateReportingPeriod } from 'api/src/services/reportingPeriods/reportingPeriods'
-import { getOrCreateInputTemplate } from 'api/src/services/inputTemplates/inputTemplates'
-import { getOrCreateOutputTemplate } from 'api/src/services/outputTemplates/outputTemplates'
+import { getOrCreateAgencies } from 'api/src/services/agencies/agencies'
 import { createOrSkipInitialExpenditureCategories } from 'api/src/services/expenditureCategories/expenditureCategories'
+import { getOrCreateInputTemplate } from 'api/src/services/inputTemplates/inputTemplates'
+import { getOrCreateOrganization } from 'api/src/services/organizations/organizations'
+import { getOrCreateOutputTemplate } from 'api/src/services/outputTemplates/outputTemplates'
+import { getOrCreateReportingPeriod } from 'api/src/services/reportingPeriods/reportingPeriods'
+import { getOrCreateUsers } from 'api/src/services/users/users'
 
 export default async ({ args }) => {
   /*

--- a/scripts/passageAuth.ts
+++ b/scripts/passageAuth.ts
@@ -16,11 +16,12 @@ export default async ({ args }) => {
   const { action, email, id } = args
 
   switch (action) {
-    case 'create':
+    case 'create': {
       const newUser = await createPassageUser(email)
       console.log('User successfully created:')
       console.log(newUser)
       break
+    }
     case 'delete':
       await deletePassageUser(id)
       console.log('User successfully deleted.')


### PR DESCRIPTION
This PR ensures that our CI workflow correctly enforces our configured linter requirements for both `eslint` (JavaScript) and `ruff` (Python).

Changes to CI workflow:
- The "Lint python" job now fails when `ruff` detects an issue with Python code. Previously, an error message (`Process completed with exit code 1.`) would be listed as an annotation for the workflow, but the actual job would still (incorrectly) report as successful.
- The "Lint JavaScript" job now includes an additional step for running `eslint` against the `scripts/` directory. Previously, this directory was excluded from linter checks.

As part of these changes, all JavaScript/TypeScript and Python linter issues have been fixed, which provides a clean slate for these new enforcements.

Additionally, PR configures the `njpwerner.autodocstring` VSCode extension to help encourage docstring standards in Python code. No conventions are enforced by CI for docstrings at this time.