### PR TITLE
CPF-289  Fetch all uploads under the same agency for "organization_staff" users

### DIFF
--- a/api/src/services/uploads/uploads.scenarios.ts
+++ b/api/src/services/uploads/uploads.scenarios.ts
@@ -84,6 +84,17 @@ export const standard = defineScenario<
         agency: true,
       },
     }),
+    four: (scenario) => ({
+      data: {
+        email: 'uniqueemail4@test.com',
+        name: 'String',
+        role: 'ORGANIZATION_STAFF',
+        agencyId: scenario.agency.two.id,
+      },
+      include: {
+        agency: true,
+      },
+    }),
   },
   reportingPeriod: {
     one: (scenario) => ({
@@ -166,6 +177,17 @@ export const standard = defineScenario<
       data: {
         filename: 'String',
         uploadedById: scenario.user.three.id,
+        agencyId: scenario.agency.two.id,
+        reportingPeriodId: scenario.reportingPeriod.one.id,
+        validations: {},
+        createdAt: '2024-01-21T18:10:17.000Z',
+        updatedAt: '2024-01-21T18:10:17.000Z',
+      },
+    }),
+    four: (scenario) => ({
+      data: {
+        filename: 'String',
+        uploadedById: scenario.user.four.id,
         agencyId: scenario.agency.two.id,
         reportingPeriodId: scenario.reportingPeriod.one.id,
         validations: {},

--- a/api/src/services/uploads/uploads.test.ts
+++ b/api/src/services/uploads/uploads.test.ts
@@ -72,7 +72,7 @@ describe('uploads', () => {
   )
 
   scenario(
-    'returns uploads for organization staff, only their own',
+    'returns all uploads in their agency for organization staff',
     async (scenario: StandardScenario) => {
       mockCurrentUser(scenario.user.three)
       const result = await uploads()
@@ -80,9 +80,12 @@ describe('uploads', () => {
         result,
         scenario.organization.two.id
       )
+      const uploadsBelongToAgency = result.every(async (upload) => {
+        return upload.agencyId === scenario.user.three.agencyId
+      })
 
-      expect(result.length).toEqual(1)
-      expect(result[0].uploadedById).toEqual(scenario.user.three.id)
+      expect(result.length).toEqual(2)
+      expect(uploadsBelongToAgency).toEqual(true)
       expect(uploadsBelongToOrg).toBe(true)
     }
   )

--- a/api/src/services/uploads/uploads.ts
+++ b/api/src/services/uploads/uploads.ts
@@ -14,8 +14,7 @@ import { logger } from 'src/lib/logger'
 import { ValidationError } from 'src/lib/validation-error'
 
 interface WhereInputs {
-  agency: { organizationId: number }
-  uploadedBy?: { id: number }
+  agency: { id?: number; organizationId: number }
 }
 
 export const uploads: QueryResolvers['uploads'] = () => {
@@ -28,7 +27,7 @@ export const uploads: QueryResolvers['uploads'] = () => {
   }
 
   if (hasRole(ROLES.ORGANIZATION_STAFF)) {
-    whereInputs.uploadedBy = { id: currentUser.id }
+    whereInputs.agency = { ...whereInputs.agency, id: currentUser.agency.id }
   }
 
   return db.upload.findMany({


### PR DESCRIPTION
# Ticket #289 

## Changes
- Users with "ORGANIZATION_STAFF" role can now view all uploads under their agency (previously they were only able to fetch their own uploads)
- Adjusted tests to include a scenario where an upload is from a different user but from the same agency
