### PR TITLE
Provide DB client to validator function when creating user

### DIFF
--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -186,7 +186,7 @@ export const createUser: MutationResolvers['createUser'] = async ({
   return validateUniqueness(
     'user',
     { email },
-    { message: 'This email is already in use' },
+    { message: 'This email is already in use', db: db },
     (db) => db.user.create({ data: input })
   )
 }


### PR DESCRIPTION
Fixes #284 
I can't reproduce the error locally, but that's likely because the DB is created differently in local vs staging. But looking at the [validator source](https://github.com/redwoodjs/redwood/blob/a3879f37a717105893455028027fe10f2890e853/packages/api/src/validations/validations.ts#L720), if the db isn't provided, it uses the default, which wouldn't work for staging. I think this should fix it in staging, but I'm not sure how to test that. 