### PR TITLE
feat: add ability to delete and reset testfiles

### DIFF
--- a/api/src/lib/aws.ts
+++ b/api/src/lib/aws.ts
@@ -118,9 +118,7 @@ export async function s3PutSignedUrl(
 
 export async function deleteUploadFile(upload: Upload) {
   const fileKey = `uploads/${upload.agency.organizationId}/${upload.agencyId}/${upload.reportingPeriodId}/${upload.id}/${upload.filename}`
-  const fileJsonKey = `uploads/${upload.agency.organizationId}/${upload.agencyId}/${upload.reportingPeriodId}/${upload.id}/${upload.filename}.json`
   await s3DeleteObject(fileKey)
-  await s3DeleteObject(fileJsonKey)
 }
 
 async function s3DeleteObject(key: string) {

--- a/api/src/services/uploads/uploads.test.ts
+++ b/api/src/services/uploads/uploads.test.ts
@@ -1,5 +1,6 @@
 import type { Upload } from '@prisma/client'
 
+import { deleteUploadFile, s3PutSignedUrl, getSignedUrl } from 'src/lib/aws'
 import { db } from 'src/lib/db'
 
 import {
@@ -19,6 +20,11 @@ import type { StandardScenario } from './uploads.scenarios'
 //       https://redwoodjs.com/docs/testing#testing-services
 // https://redwoodjs.com/docs/testing#jest-expect-type-considerations
 
+jest.mock('src/lib/aws', () => ({
+  deleteUploadFile: jest.fn(),
+  s3PutSignedUrl: jest.fn(),
+  getSignedUrl: jest.fn(),
+}))
 describe('uploads', () => {
   async function uploadsBelongToOrganization(uploads, expectedOrganizationId) {
     const uploadOrganizationIds = await Promise.all(
@@ -100,6 +106,7 @@ describe('uploads', () => {
       },
     })
 
+    expect(s3PutSignedUrl).toHaveBeenCalled()
     expect(result.filename).toEqual('String')
     expect(result.uploadedById).toEqual(scenario.upload.one.uploadedById)
     expect(result.agencyId).toEqual(scenario.upload.two.agencyId)
@@ -126,12 +133,11 @@ describe('uploads', () => {
   })
 
   scenario('deletes an upload', async (scenario: StandardScenario) => {
-    const original = (await deleteUpload({
+    // mock the s3DeleteObject function
+    await deleteUpload({
       id: scenario.upload.one.id,
-    })) as Upload
-    const result = await upload({ id: original.id })
-
-    expect(result).toEqual(null)
+    })
+    expect(deleteUploadFile).toHaveBeenCalled()
   })
 
   scenario(
@@ -189,7 +195,7 @@ describe('downloads', () => {
   scenario('returns a download link', async (scenario: StandardScenario) => {
     const result = await downloadUploadFile({ id: scenario.upload.one.id })
     console.log(result)
-    expect(result).toMatch(/^https:\/\/.*\.amazonaws\.com\/uploads\/.*$/)
+    expect(getSignedUrl).toHaveBeenCalled()
   })
   scenario('handles a missing value', async (_scenario: StandardScenario) => {
     await expect(downloadUploadFile({ id: -1 })).rejects.toThrow(

--- a/scripts/deleteTestFiles.ts
+++ b/scripts/deleteTestFiles.ts
@@ -1,0 +1,51 @@
+// To access your database
+// Append api/* to import from api and web/* to import from web
+import { db, getPrismaClient } from 'api/src/lib/db'
+import { deleteUpload } from 'api/src/services/uploads/uploads'
+
+export default async ({ args }) => {
+  /*
+  Useful to create a new organization, agencies, and users.
+
+  Example:
+    yarn redwood exec onboardOrganization \
+      --orgName 'Sample Org' \
+      --uploadIds '[1, 2, 3]'
+  */
+  await getPrismaClient()
+  console.log(':: Executing script with args ::')
+  console.log(`Received following arguments: ${Object.keys(args)}`)
+
+  if (!args.orgName) {
+    throw new Error('Organization name is required')
+  }
+  // for every upload in the organization. delete the uploadvaliation, upload, and file from s3
+  const organization = await db.organization.findFirst({
+    where: { name: args.orgName },
+  })
+  if (!organization) {
+    throw new Error(`Organization ${args.orgName} not found`)
+  }
+  console.log(`Organization found: ${organization.name}`)
+  // find all uploads
+
+  const whereClause: any = {
+    agency: { organizationId: organization.id },
+  }
+
+  if (args.uploadIds) {
+    // only delete the uploads that were requested by the user
+    whereClause.id = { in: args.uploadIds }
+  }
+  const uploads = await db.upload.findMany({
+    where: whereClause,
+  })
+
+  // iterate through every upload and delete it
+  for (const upload of uploads) {
+    console.log(`Deleting upload ${upload.id}`)
+    await deleteUpload({ id: upload.id })
+  }
+
+  console.log(':: Script executed ::')
+}

--- a/scripts/deleteTestFiles.ts
+++ b/scripts/deleteTestFiles.ts
@@ -5,10 +5,10 @@ import { deleteUpload } from 'api/src/services/uploads/uploads'
 
 export default async ({ args }) => {
   /*
-  Useful to create a new organization, agencies, and users.
+  Useful to reset a new organization by deleting any unnecessary uploads.
 
   Example:
-    yarn redwood exec onboardOrganization \
+    yarn redwood exec deleteTestFiles \
       --orgName 'Sample Org' \
       --uploadIds '[1, 2, 3]'
   */
@@ -27,7 +27,6 @@ export default async ({ args }) => {
     throw new Error(`Organization ${args.orgName} not found`)
   }
   console.log(`Organization found: ${organization.name}`)
-  // find all uploads
 
   const whereClause: any = {
     agency: { organizationId: organization.id },
@@ -35,8 +34,10 @@ export default async ({ args }) => {
 
   if (args.uploadIds) {
     // only delete the uploads that were requested by the user
-    whereClause.id = { in: args.uploadIds }
+    whereClause.id = { in: JSON.parse(args.uploadIds) }
   }
+
+  // find all the relevant uploads
   const uploads = await db.upload.findMany({
     where: whereClause,
   })


### PR DESCRIPTION
#333

This PR ensures that we can delete the test upload files that partners have added in production. Running the script does the following:
1. Identifies all uploads for the organization (optionally filtered by IDs if passed in)
2. Deletes the `UploadValidation` record
3. Deletes the `Upload` record
4. Deletes the file from s3

Unit tests have been added and ran the script locally.