### PR TITLE
fix: remove ability to delete from s3 due to permissions issue

### DIFF
--- a/api/src/services/uploads/uploads.test.ts
+++ b/api/src/services/uploads/uploads.test.ts
@@ -137,7 +137,7 @@ describe('uploads', () => {
     await deleteUpload({
       id: scenario.upload.one.id,
     })
-    expect(deleteUploadFile).toHaveBeenCalled()
+    expect(deleteUploadFile).not.toHaveBeenCalled()
   })
 
   scenario(

--- a/api/src/services/uploads/uploads.ts
+++ b/api/src/services/uploads/uploads.ts
@@ -95,7 +95,11 @@ export const deleteUpload: MutationResolvers['deleteUpload'] = ({ id }) => {
   if (!upload) {
     throw new ValidationError(`Upload with id ${id} not found`)
   }
-  deleteUploadFile(upload)
+  // TODO: fix aws permissions issue on ECS instance. For now, we'll just log the delete
+  // deleteUploadFile(upload)
+  logger.info(
+    `Deleted database record for upload ${id} - Need to delete this from s3`
+  )
 
   // 2. delete the upload
   return db.upload.delete({

--- a/api/src/services/uploads/uploads.ts
+++ b/api/src/services/uploads/uploads.ts
@@ -6,7 +6,7 @@ import type {
 } from 'types/graphql'
 
 import { hasRole } from 'src/lib/auth'
-import { s3PutSignedUrl, deleteUploadFile } from 'src/lib/aws'
+import { s3PutSignedUrl } from 'src/lib/aws'
 import aws from 'src/lib/aws'
 import { ROLES } from 'src/lib/constants'
 import { db } from 'src/lib/db'
@@ -97,9 +97,7 @@ export const deleteUpload: MutationResolvers['deleteUpload'] = ({ id }) => {
   }
   // TODO: fix aws permissions issue on ECS instance. For now, we'll just log the delete
   // deleteUploadFile(upload)
-  logger.info(
-    `Deleted database record for upload ${id} - Need to delete this from s3`
-  )
+  logger.info({ upload_id: id }, 'deleted database record for upload')
 
   // 2. delete the upload
   return db.upload.delete({


### PR DESCRIPTION
#333 

This PR will need to be reverted once the permissions issue of running `deleteTestFiles` script is fixed. However, for now we would need the ability to at least remove these records for our partners so they can begin upload production-ready input files.