### PR TITLE
Lambda to prepare archive of CSV's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,7 @@ __pycache__/
 # Python test and coverage output
 python/.coverage
 python/htmlcov/
+python/_tmp_test.zip
 
 # Python build artifacts
 python/dist/

--- a/python/src/functions/create_archive.py
+++ b/python/src/functions/create_archive.py
@@ -9,7 +9,7 @@ from aws_lambda_typing.events import SQSEvent
 from mypy_boto3_s3.client import S3Client
 from src.lib.logging import get_logger, reset_contextvars
 
-S3_BUCKET = os.environ["S3_BUCKET"]
+S3_BUCKET = os.environ.get("S3_BUCKET", "test_bucket")
 
 
 @reset_contextvars
@@ -70,6 +70,7 @@ def create_archive(
             logger.info(f"Created archive file: {file.name}")
             upload_key = f"{target_key}report.zip"
             # upload the zip file to the target key
+
             s3_client.upload_file(file.name, S3_BUCKET, upload_key)
             logger.info(f"Uploaded archive file to {upload_key}")
             logger.info(f"Uploaded archive file to {upload_key}")

--- a/python/src/functions/create_archive.py
+++ b/python/src/functions/create_archive.py
@@ -1,0 +1,75 @@
+import json
+import os
+import tempfile
+import zipfile
+
+import boto3
+from aws_lambda_typing.context import Context
+from aws_lambda_typing.events import SQSEvent
+from mypy_boto3_s3.client import S3Client
+from src.lib.logging import get_logger, reset_contextvars
+
+S3_BUCKET = os.environ["S3_BUCKET"]
+
+
+@reset_contextvars
+def handle(event: SQSEvent, _context: Context):
+    """Lambda handler for creating an archive of CSV files in S3
+
+    Args:
+        event: SQS event containing the org_id and reporting_period_id
+        context: Lambda context
+    """
+    logger = get_logger()
+    logger.info("Received new invocation event from SQS")
+    logger.info(event)
+    logger.info("Extracting payload")
+    payload = json.loads(event["Records"][0]["body"])
+    logger.info(payload)
+    reporting_period_id = payload["reporting_period_id"]
+    org_id = payload["org_id"]
+    logger.info(
+        f"Creating archive for org_id: {org_id}, reporting_period_id: {reporting_period_id}"
+    )
+    create_archive(org_id, reporting_period_id, boto3.client("s3"), logger)
+
+
+def create_archive(
+    org_id: str, reportiong_period_id: str, s3_client: S3Client, logger=None
+):
+    """Create a zip archive of CSV files in S3"""
+
+    if logger is None:
+        logger = get_logger()
+
+    target_key = f"treasuryreports/{org_id}/{reportiong_period_id}/"
+    logger.info(f"Creating archive for {target_key}")
+    # find all file names in the target key with the CSV suffix
+    paginator = s3_client.get_paginator("list_objects_v2")
+    response_iterator = paginator.paginate(Bucket=S3_BUCKET, Prefix=target_key)
+    target_files = []
+    for response in response_iterator:
+        for obj in response.get("Contents", []):
+            if obj["Key"].endswith(".csv"):
+                file_name = obj["Key"]
+                logger.info(f"Found CSV file: {file_name}")
+                target_files.append(file_name)
+    if not target_files:
+        logger.info("No CSV files found in the target key")
+        return
+
+    # create a zip file with all the CSV files
+    with tempfile.NamedTemporaryFile() as file:
+        with zipfile.ZipFile(file, "w") as zipf:
+            for target_file in target_files:
+                obj = s3_client.get_object(Bucket=S3_BUCKET, Key=target_file)
+                zipf.writestr(target_file, obj["Body"].read())
+
+            zipf.close()
+            file.flush()
+            logger.info(f"Created archive file: {file.name}")
+            upload_key = f"{target_key}report.zip"
+            # upload the zip file to the target key
+            s3_client.upload_file(file.name, S3_BUCKET, upload_key)
+            logger.info(f"Uploaded archive file to {upload_key}")
+            logger.info(f"Uploaded archive file to {upload_key}")

--- a/python/test-create-archive.sh
+++ b/python/test-create-archive.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+AWS_PAGER=""
+
+# generate a random prefix for resources
+RS_PREFIX=$(date +%s)
+QUEUE_NAME=${RS_PREFIX}-my-queue
+S3_BUCKET=${RS_PREFIX}-cpf-reporter
+LAMBDA_HANDLER=src.functions.create_archive.handle
+LAMBDA_ZIP=/Users/jakekreider/projects/cpf-reporter/python/dist/lambda.zip
+LAMBDA_NAME=${RS_PREFIX}-create-archive
+TEST_ORG_ID=123
+TEST_REPORTING_PERIOD_ID=456
+TEST_KEY_PATH=treasuryreports/${TEST_ORG_ID}/${TEST_REPORTING_PERIOD_ID}/
+
+# Create an SQS queue
+awslocal sqs create-queue --queue-name ${QUEUE_NAME}
+
+# create the bucket
+awslocal s3 mb s3://${S3_BUCKET}
+
+# create the lambda
+ awslocal lambda create-function --function-name ${LAMBDA_NAME} --runtime python3.12 --handler ${LAMBDA_HANDLER} --role arn:aws:iam::000000000000:role/irrelevant --zip-file fileb://${LAMBDA_ZIP} --environment Variables="{S3_BUCKET=${S3_BUCKET}}"
+
+awslocal lambda create-event-source-mapping --function-name ${LAMBDA_NAME} --batch-size 1 --event-source-arn arn:aws:sqs:us-west-2:000000000000:${QUEUE_NAME} --starting-position LATEST
+
+# Add fake files to the bucket
+touch ${RS_PREFIX}file1.csv
+awslocal s3 cp ${RS_PREFIX}file1.csv s3://${S3_BUCKET}/${TEST_KEY_PATH}
+rm ${RS_PREFIX}file1.csv
+# Send a message to the queue with fields org_id, reporting_period_id
+awslocal sqs send-message --queue-url http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/${QUEUE_NAME} --message-body "{\"org_id\": ${TEST_ORG_ID}, \"reporting_period_id\": ${TEST_REPORTING_PERIOD_ID}}"
+
+# invoke the function manually
+awslocal lambda invoke --cli-binary-format raw-in-base64-out --function-name ${LAMBDA_NAME} --payload "{\"org_id\": ${TEST_ORG_ID}, \"reporting_period_id\": ${TEST_REPORTING_PERIOD_ID}}" /dev/stdout
+
+# Get the function logs
+awslocal logs tail /aws/lambda/${LAMBDA_NAME}
+
+# check for the output in the bucket
+awslocal s3 ls s3://${S3_BUCKET}/${TEST_KEY_PATH}
+
+# clean-up 
+awslocal lambda delete-function --function-name ${LAMBDA_NAME}
+awslocal s3 rb s3://${S3_BUCKET} --force
+awslocal sqs delete-queue --queue-url http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/${QUEUE_NAME}

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -141,14 +141,14 @@ def template_workbook_two():
 
 @pytest.fixture
 def cpf_file_archive(sample_template):
-    cpf_archive_file = zipfile.ZipFile("test.zip", "w")
+    cpf_archive_file = zipfile.ZipFile("_tmp_test.zip", "w")
     cpf_archive_file.writestr("2024-05-19/TestFile.xlsx", sample_template.read())
     return CPFFileArchive(cpf_archive_file)
 
 
 @pytest.fixture
 def cpf_file_archive_two(sample_template):
-    cpf_archive_file = zipfile.ZipFile("test.zip", "w")
+    cpf_archive_file = zipfile.ZipFile("_tmp_test.zip", "w")
     cpf_archive_file.writestr("2024-05-19/TestFile.xlsx", sample_template.read())
     cpf_archive_file.writestr("2024-05-19/TestFile2.xlsx", sample_template.read())
     return CPFFileArchive(cpf_archive_file)

--- a/python/tests/src/lib/test_create_archive.py
+++ b/python/tests/src/lib/test_create_archive.py
@@ -1,0 +1,31 @@
+from unittest.mock import ANY, MagicMock
+
+from src.functions.create_archive import create_archive
+
+
+def test_create_archive_creates_zip():
+    org_id = "1234"
+    reportiong_period_id = "5678"
+    s3_client = MagicMock()
+    logger = MagicMock()
+
+    # Mock the response from S3
+    s3_client.get_paginator.return_value.paginate.return_value = [
+        {
+            "Contents": [
+                {"Key": "treasuryreports/1234/5678/file1.csv"},
+                {"Key": "treasuryreports/1234/5678/file2.csv"},
+            ]
+        }
+    ]
+    s3_client.get_object.return_value = {
+        "Body": MagicMock(read=lambda: b"file_content")
+    }
+
+    # Call the function
+    create_archive(org_id, reportiong_period_id, s3_client, logger)
+
+    # Assert that the file was attempted to be created
+    s3_client.upload_file.assert_called_with(
+        ANY, "test_bucket", "treasuryreports/1234/5678/report.zip"
+    )

--- a/python/tests/test-create-archive.sh
+++ b/python/tests/test-create-archive.sh
@@ -31,9 +31,7 @@ rm ${RS_PREFIX}file1.csv
 # Send a message to the queue with fields org_id, reporting_period_id
 awslocal sqs send-message --queue-url http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/${QUEUE_NAME} --message-body "{\"org_id\": ${TEST_ORG_ID}, \"reporting_period_id\": ${TEST_REPORTING_PERIOD_ID}}"
 
-# invoke the function manually
-awslocal lambda invoke --cli-binary-format raw-in-base64-out --function-name ${LAMBDA_NAME} --payload "{\"org_id\": ${TEST_ORG_ID}, \"reporting_period_id\": ${TEST_REPORTING_PERIOD_ID}}" /dev/stdout
-
+sleep 5
 # Get the function logs
 awslocal logs tail /aws/lambda/${LAMBDA_NAME}
 

--- a/python/tests/test_create_archive.bats
+++ b/python/tests/test_create_archive.bats
@@ -1,7 +1,4 @@
 #!/usr/bin/env bats
-bats_load_library "bats-support"
-bats_load_library "bats-assert"
-
 
 setup_file() {
   export AWS_PAGER=""
@@ -29,7 +26,7 @@ teardown_file() {
 }
 
 @test "Compile Lambda function" {
-  /bin/bash python/build-lambda.bash
+  /bin/bash ../python/build-lambda.bash
 }
 
 @test "Create Lambda function" {
@@ -49,6 +46,10 @@ teardown_file() {
 }
 
 @test "Get Lambda function logs" {
+  # echo the lambda name
+  echo ${LAMBDA_NAME} # debugging
+  # give the lambda a moment to run
+  sleep 5
   run awslocal logs tail /aws/lambda/${LAMBDA_NAME}
   [ "$status" -eq 0 ]
 }

--- a/python/tests/test_create_archive.bats
+++ b/python/tests/test_create_archive.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+bats_load_library "bats-support"
+bats_load_library "bats-assert"
+
+
+setup_file() {
+  export AWS_PAGER=""
+  export RS_PREFIX=$(date +%s) # random prefix for resources
+  export QUEUE_NAME=${RS_PREFIX}-my-queue
+  export S3_BUCKET=${RS_PREFIX}-cpf-reporter
+  export LAMBDA_HANDLER=src.functions.create_archive.handle
+  export LAMBDA_ZIP=/Users/jakekreider/projects/cpf-reporter/python/dist/lambda.zip
+  export LAMBDA_NAME=${RS_PREFIX}-create-archive
+  export TEST_ORG_ID=123
+  export TEST_REPORTING_PERIOD_ID=456
+  export TEST_KEY_PATH=treasuryreports/${TEST_ORG_ID}/${TEST_REPORTING_PERIOD_ID}/
+
+  # Create an SQS queue
+  awslocal sqs create-queue --queue-name ${QUEUE_NAME}
+
+  # create the bucket
+  awslocal s3 mb s3://${S3_BUCKET}
+}
+
+teardown_file() {
+  awslocal lambda delete-function --function-name ${LAMBDA_NAME}
+  awslocal s3 rb s3://${S3_BUCKET} --force
+  awslocal sqs delete-queue --queue-url http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/${QUEUE_NAME}
+}
+
+@test "Compile Lambda function" {
+  /bin/bash python/build-lambda.bash
+}
+
+@test "Create Lambda function" {
+  awslocal lambda create-function --function-name ${LAMBDA_NAME} --runtime python3.12 --handler ${LAMBDA_HANDLER} --role arn:aws:iam::000000000000:role/irrelevant --zip-file fileb://${LAMBDA_ZIP} --environment Variables="{S3_BUCKET=${S3_BUCKET}}"
+}
+
+@test "Create Lambda event source mapping" {
+  awslocal lambda create-event-source-mapping --function-name ${LAMBDA_NAME} --batch-size 1 --event-source-arn arn:aws:sqs:us-west-2:000000000000:${QUEUE_NAME} --starting-position LATEST
+}
+
+@test "Send message to SQS queue" {
+  touch ${RS_PREFIX}file1.csv
+  awslocal s3 cp ${RS_PREFIX}file1.csv s3://${S3_BUCKET}/${TEST_KEY_PATH}
+  rm ${RS_PREFIX}file1.csv
+  run awslocal sqs send-message --queue-url http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/${QUEUE_NAME} --message-body "{\"org_id\": ${TEST_ORG_ID}, \"reporting_period_id\": ${TEST_REPORTING_PERIOD_ID}}"
+  [ "$status" -eq 0 ]
+}
+
+@test "Get Lambda function logs" {
+  run awslocal logs tail /aws/lambda/${LAMBDA_NAME}
+  [ "$status" -eq 0 ]
+}
+
+@test "Check output in S3 bucket" {
+  run awslocal s3 ls s3://${S3_BUCKET}/${TEST_KEY_PATH}
+  [ "$status" -eq 0 ]
+  # make sure report.zip is in output
+
+  
+
+
+}

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -515,3 +515,135 @@ module "lambda_function-cpfValidation" {
     }
   }
 }
+
+
+module "lambda_function-cpfCreateArchive" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "4.2.0"
+
+  // Metadata
+  function_name = "${var.namespace}-cpfCreateArchive"
+  description   = "Reacts to SQS events and generates archive files of CSV's."
+
+  // Networking
+  vpc_subnet_ids         = null
+  vpc_security_group_ids = null
+  attach_network_policy  = false
+
+  // Permissions
+  role_permissions_boundary         = local.permissions_boundary_arn
+  attach_cloudwatch_logs_policy     = true
+  cloudwatch_logs_retention_in_days = var.log_retention_in_days
+  attach_policy_jsons               = length(local.lambda_default_execution_policies) > 0
+  number_of_policy_jsons            = length(local.lambda_default_execution_policies)
+  policy_jsons                      = local.lambda_default_execution_policies
+  attach_policy_statements          = true
+  policy_statements = {
+    AllowDownloadExcelObjects = {
+      effect = "Allow"
+      actions = [
+        "s3:GetObject",
+        "s3:HeadObject",
+      ]
+      resources = [
+        # Path: treasuryreports/{organization_id}/{reporting_period_id}/{filename}.csv
+        "${module.reporting_data_bucket.bucket_arn}/treasuryreports/*/*/*.csv",
+      ]
+    }
+    AllowUploadZipArchive = {
+      effect = "Allow"
+      actions = [
+        "s3:PutObject"
+      ]
+      resources = [
+        # Path: treasuryreports/{organization_id}/{reporting_period_id}/{filename}.zip
+        "${module.reporting_data_bucket.bucket_arn}/treasuryreports/*/*/*.zip",
+      ]
+    }
+  }
+
+  // Artifacts
+  publish        = true
+  create_package = false
+  s3_existing_package = {
+    bucket = aws_s3_object.lambda_artifact-python.bucket
+    key    = aws_s3_object.lambda_artifact-python.key
+  }
+
+  // Runtime
+  handler       = var.datadog_enabled ? local.datadog_lambda_py_handler : "src.functions.create_archive.handle"
+  runtime       = var.lambda_py_runtime
+  architectures = [var.lambda_arch]
+  layers        = local.lambda_py_layer_arns
+  timeout       = 60 # 1 minute, in seconds
+  memory_size   = 512
+  environment_variables = merge(local.lambda_default_environment_variables, {
+    DD_LAMBDA_HANDLER = "src.functions.create_archive.handle"
+    DD_LOGS_INJECTION = "true"
+    S3_BUCKET         = "${module.reporting_data_bucket.bucket_arn}"
+  })
+
+  // Triggers
+  event_source_mapping = {
+    sqs = {
+      event_source_arn        = module.archive_sqs_queue.queue_arn
+      function_response_types = ["ReportBatchItemFailures"]
+      scaling_config = {
+        maximum_concurrency = 20
+      }
+    }
+  }
+}
+
+module "archive_sqs_queue" {
+  source  = "terraform-aws-modules/sqs/aws"
+  version = "6.5.0"
+
+  name            = treasury-request-archive
+  use_name_prefix = true
+
+  # Primary queue
+  visibility_timeout_seconds = 900 # 15 MINUTES
+  delay_seconds              = 20
+  receive_wait_time_seconds  = 20
+  message_retention_seconds  = 10080 # 7 days, in seconds
+  max_message_size           = 1024  # 1 KiB, in bytes
+  sqs_managed_sse_enabled    = true
+  create_queue_policy        = true
+
+  # Dead-letter queue
+  create_dlq                    = true
+  dlq_message_retention_seconds = 1209600 # 14 days, in seconds
+  dlq_sqs_managed_sse_enabled   = true
+}
+
+module "consume_sqs_messages_policy" {
+  source  = "cloudposse/iam-policy/aws"
+  version = "1.0.1"
+  context = module.this.context
+
+  name = "consume-sqs-messages"
+
+  iam_policy = {
+    statements = [
+      {
+        sid    = "AllowConsumeMessages"
+        effect = "Allow"
+        actions = [
+          "sqs:DeleteMessage",
+          "sqs:ReceiveMessage",
+        ]
+        resources = [module.archive_sqs_queue.queue_arn]
+      },
+      {
+        sid    = "AllowReadMetadata"
+        effect = "Allow"
+        actions = [
+          "sqs:GetQueueAttributes",
+          "sqs:GetQueueUrl",
+        ]
+        resources = [module.archive_sqs_queue.queue_arn]
+      },
+    ]
+  }
+}

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -597,7 +597,7 @@ module "lambda_function-cpfCreateArchive" {
 
 module "archive_sqs_queue" {
   source  = "terraform-aws-modules/sqs/aws"
-  version = "6.5.0"
+  version = "4.2.0"
 
   name            = treasury-request-archive
   use_name_prefix = true

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -599,7 +599,7 @@ module "archive_sqs_queue" {
   source  = "terraform-aws-modules/sqs/aws"
   version = "4.2.0"
 
-  name            = treasury-request-archive
+  name            = "treasury-request-archive"
   use_name_prefix = true
 
   # Primary queue

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -560,6 +560,14 @@ module "lambda_function-cpfCreateArchive" {
         "${module.reporting_data_bucket.bucket_arn}/treasuryreports/*/*/*.zip",
       ]
     }
+    AllowSQSReceive = {
+      effect = "Allow"
+      actions = [
+        "sqs:ReceiveMessage",
+        "sqs:DeleteMessage",
+      ]
+      resources = [module.archive_sqs_queue.queue_arn]
+    }
   }
 
   // Artifacts
@@ -615,35 +623,4 @@ module "archive_sqs_queue" {
   create_dlq                    = true
   dlq_message_retention_seconds = 1209600 # 14 days, in seconds
   dlq_sqs_managed_sse_enabled   = true
-}
-
-module "consume_sqs_messages_policy" {
-  source  = "cloudposse/iam-policy/aws"
-  version = "1.0.1"
-  context = module.this.context
-
-  name = "consume-sqs-messages"
-
-  iam_policy = {
-    statements = [
-      {
-        sid    = "AllowConsumeMessages"
-        effect = "Allow"
-        actions = [
-          "sqs:DeleteMessage",
-          "sqs:ReceiveMessage",
-        ]
-        resources = [module.archive_sqs_queue.queue_arn]
-      },
-      {
-        sid    = "AllowReadMetadata"
-        effect = "Allow"
-        actions = [
-          "sqs:GetQueueAttributes",
-          "sqs:GetQueueUrl",
-        ]
-        resources = [module.archive_sqs_queue.queue_arn]
-      },
-    ]
-  }
 }


### PR DESCRIPTION
Closes #318 

Function to listen to SQS message on a new queue and generate an archive of CSV files for the given organization and reporting period. A few questions:

1. How will the email address of the user get to the next function #321 ? The plan in that one was to look at S3 files, but should that maybe be an SQS message as well? Or rolled all into this lambda?
2. Should the `report.zip` maybe be given some sort of timestamp in its name?
3. Some options for testing instructions:
	1. There's a shellscript that should run on its own, or can be used as a guide. Assumes presence of [`awslocal`](https://github.com/localstack/awscli-local), which is a localstack wrapper of the AWS CLI. 
	2. There's also a bats file - if there's interest in using that kind of framework, I can include the other bats submodules and flesh it out a bit more. If not, I can delete it.
	3. I can also delete both and just put the example here in the PR. 