### PR TITLE
Expose subrecipients on ValidationResults in workbook_validator

### DIFF
--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -24,6 +24,7 @@ from src.schemas.schema_versions import (
 )
 
 type Errors = List[WorkbookError]
+type Subrecipients = List[SubrecipientRow]
 
 LOGIC_SHEET = "Logic"
 COVER_SHEET = "Cover"
@@ -198,7 +199,7 @@ def get_workbook_errors_for_row(
     return workbook_errors
 
 
-def validate(workbook: IO[bytes]) -> Tuple[Errors, Optional[str]]:
+def validate(workbook: IO[bytes]) -> Tuple[Errors, Optional[str], Subrecipients]:
     """Validates a given Excel workbook according to CPF validation rules.
 
     Args:
@@ -282,7 +283,7 @@ def validate_workbook(workbook: Workbook) -> Tuple[Errors, Optional[str]]:
             projects, subrecipients, version_string
         )
 
-    return (errors, project_use_code)
+    return (errors, project_use_code, subrecipients)
 
 
 def validate_workbook_sheets(workbook: Workbook) -> Errors:

--- a/python/tests/src/lib/test_workbook_validator.py
+++ b/python/tests/src/lib/test_workbook_validator.py
@@ -261,7 +261,7 @@ class TestValidateMatchingSubrecipientSheet:
     def test_invalid_project_sheet_unmatching_subrecipient_tin_field(
         self, invalid_project_sheet_unmatching_subrecipient_tin_field: Worksheet
     ):
-        errors, _ = validate_workbook(
+        errors, _, _ = validate_workbook(
             invalid_project_sheet_unmatching_subrecipient_tin_field
         )
         assert errors != []
@@ -274,7 +274,7 @@ class TestValidateMatchingSubrecipientSheet:
     def test_invalid_project_sheet_unmatching_subrecipient_uei_field(
         self, invalid_project_sheet_unmatching_subrecipient_uei_field: Worksheet
     ):
-        errors, _ = validate_workbook(
+        errors, _, _ = validate_workbook(
             invalid_project_sheet_unmatching_subrecipient_uei_field
         )
         assert errors != []
@@ -287,7 +287,7 @@ class TestValidateMatchingSubrecipientSheet:
     def test_invalid_project_sheet_unmatching_subrecipient_tin_uei_field(
         self, invalid_project_sheet_unmatching_subrecipient_tin_uei_field: Worksheet
     ):
-        errors, _ = validate_workbook(
+        errors, _, _ = validate_workbook(
             invalid_project_sheet_unmatching_subrecipient_tin_uei_field
         )
         assert errors != []


### PR DESCRIPTION
* Expose subrecipients on ValidationResults in workbook_validator
* Putting this up by itself because I _believe_ that I'm not able to test S3 upload / the full flow locally yet? So my thought was to get this in staging, then upload a doc in staging and use it to test the "second piece" (reading the subrecipients key and saving them) via the workflow [here](https://github.com/usdigitalresponse/cpf-reporter/blob/02d37aa39770d98cb154ac73de0c4a779e6d7d8d/api/src/functions/processValidationJson/processValidationJson.ts#L52) -- but let me know if my understanding is incorrect!