### PR TITLE
Make subrecipients into JSON explicitly

### DIFF
--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -1,4 +1,5 @@
 from enum import Enum
+import json
 from typing import IO, Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 from openpyxl import Workbook, load_workbook
@@ -284,7 +285,7 @@ def validate_workbook(workbook: Workbook) -> Tuple[Errors, Optional[str]]:
         )
 
     
-    subrecipients = [subrecipient.json() for subrecipient in subrecipients]
+    subrecipients = [subrecipient.model_dump() for subrecipient in subrecipients]
 
     return (errors, project_use_code, subrecipients)
 

--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -283,6 +283,9 @@ def validate_workbook(workbook: Workbook) -> Tuple[Errors, Optional[str]]:
             projects, subrecipients, version_string
         )
 
+    
+    subrecipients = [subrecipient.json() for subrecipient in subrecipients]
+
     return (errors, project_use_code, subrecipients)
 
 

--- a/python/src/lib/workbook_validator.py
+++ b/python/src/lib/workbook_validator.py
@@ -1,5 +1,4 @@
 from enum import Enum
-import json
 from typing import IO, Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 from openpyxl import Workbook, load_workbook

--- a/python/src/schemas/schema_V2024_04_01.py
+++ b/python/src/schemas/schema_V2024_04_01.py
@@ -16,7 +16,7 @@ from pydantic import (
 from src.schemas.project_types import NAME_BY_PROJECT
 
 
-class StateAbbreviation(Enum):
+class StateAbbreviation(str, Enum):
     AL = "AL"
     AK = "AK"
     AZ = "AZ"

--- a/python/src/schemas/schema_V2024_05_24.py
+++ b/python/src/schemas/schema_V2024_05_24.py
@@ -16,7 +16,7 @@ from pydantic import (
 from src.schemas.project_types import NAME_BY_PROJECT
 
 
-class StateAbbreviation(Enum):
+class StateAbbreviation(str, Enum):
     AL = "AL"
     AK = "AK"
     AZ = "AZ"


### PR DESCRIPTION
* Mapping each subrecipient to a JSON serializable object with `.model_dumps` so we can `json.dumps()` it in `validate_workbook.py`