### PR TITLE
Use real version passed in to save `SubrecipientUpload`

### DIFF
--- a/api/src/functions/processValidationJson/processValidationJson.ts
+++ b/api/src/functions/processValidationJson/processValidationJson.ts
@@ -46,7 +46,6 @@ type ResultSchema = {
   projectUseCode: string
   subrecipients: Subrecipient[]
   versionString: string
-
 }
 
 type UploadValidationS3Client = {
@@ -233,10 +232,12 @@ async function saveSubrecipientInfo(
   uploadId: number,
   versionString: string
 ) {
-  let version = Version[versionString];
+  let version = Version[versionString]
   if (!version) {
     version = Version.V2024_05_24
-    logger.error(`Error obtaining version from version passed in results ${versionString}, falling back on ${version}`)
+    logger.error(
+      `Error obtaining version from version passed in results ${versionString}, falling back on ${version}`
+    )
   }
 
   try {

--- a/api/src/functions/processValidationJson/processValidationJson.ts
+++ b/api/src/functions/processValidationJson/processValidationJson.ts
@@ -1,5 +1,5 @@
 import { GetObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
-import { Prisma } from '@prisma/client'
+import { Prisma, Version } from '@prisma/client'
 import { S3Handler, S3ObjectCreatedNotificationEvent } from 'aws-lambda'
 
 import aws from 'src/lib/aws'
@@ -45,6 +45,8 @@ type ResultSchema = {
   }[]
   projectUseCode: string
   subrecipients: Subrecipient[]
+  versionString: string
+
 }
 
 type UploadValidationS3Client = {
@@ -198,7 +200,7 @@ export const processRecord = async (
     // If we passed validation, we will save the subrecipient info into our DB
     if (passed) {
       result.subrecipients.forEach((subrecipient) =>
-        saveSubrecipientInfo(subrecipient, key, uploadId)
+        saveSubrecipientInfo(subrecipient, key, uploadId, result.versionString)
       )
       try {
         // TODO upload a subrecipients JSON file to S3
@@ -228,8 +230,15 @@ export const processRecord = async (
 async function saveSubrecipientInfo(
   subrecipientInput: Subrecipient,
   key: string,
-  uploadId: number
+  uploadId: number,
+  versionString: string
 ) {
+  let version = Version[versionString];
+  if (!version) {
+    version = Version.V2024_05_24
+    logger.error(`Error obtaining version from version passed in results ${versionString}, falling back on ${version}`)
+  }
+
   try {
     const ueiTinCombo = `${subrecipientInput.Unique_Entity_Identifier__c}_${subrecipientInput.EIN__c}`
     // Per documentation here: https://www.prisma.io/docs/orm/prisma-client/queries/crud#update-or-create-records
@@ -248,7 +257,7 @@ async function saveSubrecipientInfo(
         subrecipientId: subrecipient.id,
         uploadId,
         rawSubrecipient: subrecipientInput,
-        version: 'V2024_05_24', // TODO -- we should pass the version enum through on the `ResultsSchema` as well, for now just using the latest one
+        version,
       },
       update: {
         rawSubrecipient: subrecipientInput,


### PR DESCRIPTION
- Use the `versionString` passed in to save on `SubrecipientUpload`
- If we can't cast the string provided to a `Version`, default to latest one