### PR TITLE
Save subrecipient information to S3

### DIFF
--- a/api/src/functions/processValidationJson/processValidationJson.ts
+++ b/api/src/functions/processValidationJson/processValidationJson.ts
@@ -197,7 +197,7 @@ export const processRecord = async (
     }
 
     // If we passed validation, we will save the subrecipient info into our DB
-    if (passed) {
+    if (passed && result.subrecipients?.length) {
       const organizationId = extractOrganizationIdFromKey(key)
       result.subrecipients.forEach((subrecipient) =>
         saveSubrecipientInfo(
@@ -232,7 +232,7 @@ export const processRecord = async (
         const subrecipients = {
           subrecipients: subrecipientsWithUploads,
         }
-        aws.sendPutObjectToS3Bucket(
+        await aws.sendPutObjectToS3Bucket(
           bucket,
           subrecipientKey,
           JSON.stringify(subrecipients)


### PR DESCRIPTION
* Save subrecipient information (`Subrecipient` and `SubrecipientUpload` records where the `createdAt` is within the upload's reporting period) to S3
* Tested this w/LocalStack and confirmed:
1. Able to put to S3 successfully: 
![Screenshot 2024-07-15 at 1 09 54 PM](https://github.com/user-attachments/assets/a374b42d-6ae0-4b7b-a2ed-1d69f02e256a)
2. Able to download from S3 successfully: 
![Screenshot 2024-07-15 at 1 10 26 PM](https://github.com/user-attachments/assets/f9119f84-99f4-4bc2-90ec-8b2c83217b9f)
3. Downloaded was valid JSON: 
![Screenshot 2024-07-15 at 1 10 11 PM](https://github.com/user-attachments/assets/8acb4d7a-f131-47ce-a419-6ab8265e8055)
