### PR TITLE
fix: remove unsupported ProjectType field

### DIFF
--- a/terraform/treasury_generation_step_function.tf
+++ b/terraform/treasury_generation_step_function.tf
@@ -19,8 +19,7 @@ module "treasury_generation_step_function" {
                 "Resource" : "arn:aws:states:::lambda:invoke",
                 "OutputPath" : "$.Payload",
                 "Parameters" : {
-                  "Payload.$" : "$",
-                  "ProjectType" : "1A",
+                  "Payload.$" : "$.1A",
                   "FunctionName" : module.lambda_function-treasuryProjectFileGeneration.lambda_function_arn
                 },
                 "Retry" : [
@@ -48,8 +47,7 @@ module "treasury_generation_step_function" {
                 "Resource" : "arn:aws:states:::lambda:invoke",
                 "OutputPath" : "$.Payload",
                 "Parameters" : {
-                  "Payload.$" : "$",
-                  "ProjectType" : "1B",
+                  "Payload.$" : "$.1B",
                   "FunctionName" : module.lambda_function-treasuryProjectFileGeneration.lambda_function_arn
                 },
                 "Retry" : [
@@ -77,8 +75,7 @@ module "treasury_generation_step_function" {
                 "Resource" : "arn:aws:states:::lambda:invoke",
                 "OutputPath" : "$.Payload",
                 "Parameters" : {
-                  "Payload.$" : "$",
-                  "ProjectType" : "1C",
+                  "Payload.$" : "$.1C",
                   "FunctionName" : module.lambda_function-treasuryProjectFileGeneration.lambda_function_arn
                 },
                 "Retry" : [
@@ -106,7 +103,7 @@ module "treasury_generation_step_function" {
                 "Resource" : "arn:aws:states:::lambda:invoke",
                 "OutputPath" : "$.Payload",
                 "Parameters" : {
-                  "Payload.$" : "$",
+                  "Payload.$" : "$.Subrecipient",
                   "FunctionName" : module.lambda_function-subrecipientTreasuryReportGen.lambda_function_arn
                 },
                 "Retry" : [


### PR DESCRIPTION
## Context
There are deploy failures when attempting to deploy the latest step function changes:
```
aws_ecs_task_definition.console: Creating...
Error: creating Step Functions State Machine (cpfreporter-generate-treasury-report): InvalidDefinition: Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: The field "ProjectType" is not supported by Step Functions at /States/Parallel/Branches[0]/States/Generate Project 1A File/Parameters, SCHEMA_VALIDATION_FAILED: The field "ProjectType" is not supported by Step Functions at /States/Parallel/Branches[1]/States/Generate Project 1B File/Parameters, SCHEMA_VALIDATION_FAILED: The field "ProjectType" is not supported by Step Functions at /States/Parallel/Branches[2]/States/Generate Project 1C File/Parameters'
aws_s3_object.lambda_artifact-processValidationJson: Modifying... [id=processValidationJson.d0a0b5a7da45edc32a9ef2364e9b4d67.zip]

aws_s3_object.lambda_artifact-graphql: Modifying... [id=graphql.3f3cf84da1d36dcfd5f072076a350455.zip]
module.lambda_function-cpfValidation.aws_lambda_permission.current_version_triggers["S3BucketNotification"]: Destruction complete after 0s
aws_s3_object.lambda_artifact-python: Creating...
aws_ecs_task_definition.console: Creation complete after 0s [id=cpfreporter-console]
aws_ecs_service.console: Modifying... [id=arn:aws:ecs:us-west-2:3571508[18](https://github.com/usdigitalresponse/cpf-reporter/actions/runs/10207138086/job/28421688752#step:16:19)708:service/cpfreporter/cpfreporter-console]
  with module.treasury_generation_step_function.aws_sfn_state_machine.this[0],
  on .terraform/modules/treasury_generation_step_function/main.tf line 15, in resource "aws_sfn_state_machine" "this":
  15: resource "aws_sfn_state_machine" "this" {
```

For step functions invoking lambda functions there is only the following set of allowed parameters
[ClientContext](https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestParameters)

[FunctionName](https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestParameters)

[InvocationType](https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestParameters)

[Qualifier](https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestParameters)

[Payload](https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestParameters)

## Before
In order to add `ProjectType` context to the lambda function I added a custom parameter which was not supported.

## After this PR
1. The `ProjectType` will be passed in separately as part of the payload. Right now there are no code changes required since the payload is something we construct manually at the moment via the web-app.
2. The payload object for each lambda is now scoped to have only the relevant information needed to generate the particular file needed within that step.