### PR TITLE
CPF-380 Users and Agencies tabs visible for org users

### DIFF
--- a/api/src/graphql/agencies.sdl.ts
+++ b/api/src/graphql/agencies.sdl.ts
@@ -29,8 +29,10 @@ export const schema = gql`
   }
 
   type Mutation {
-    createAgency(input: CreateAgencyInput!): Agency! @requireAuth
-    updateAgency(id: Int!, input: UpdateAgencyInput!): Agency! @requireAuth
+    createAgency(input: CreateAgencyInput!): Agency!
+      @requireAuth(roles: ["USDR_ADMIN", "ORGANIZATION_ADMIN"])
+    updateAgency(id: Int!, input: UpdateAgencyInput!): Agency!
+      @requireAuth(roles: ["USDR_ADMIN", "ORGANIZATION_ADMIN"])
     deleteAgency(id: Int!): Agency! @requireAuth
   }
 `

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -66,7 +66,7 @@ export const runPermissionsCreateOrUpdateValidations = async (input) => {
   const { currentUser } = context
 
   validateWithSync(() => {
-    if (!currentUser?.roles?.includes(ROLES.ORGANIZATION_ADMIN))
+    if (currentUser?.roles?.includes(ROLES.ORGANIZATION_STAFF))
       throw new AuthenticationError("You don't have permission to do that")
   })
 

--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -23,36 +23,37 @@ const Routes = () => {
         <Route path="/uploads/{id:Int}/edit" page={UploadEditUploadPage} name="editUpload" />
         <Route path="/uploads/{id:Int}" page={UploadUploadPage} name="upload" />
         <Route path="/upload-template/{id:Int}" page={UploadTemplatePage} name="uploadTemplate" />
-        {/* TODO: Remove USDR_ADMIN check when ready || 2024-05-13 Milestone */}
-        <PrivateSet unauthenticated="forbidden" roles="USDR_ADMIN">
-          {/* Agencies */}
+        {/* Agencies */}
+        <PrivateSet unauthenticated="forbidden" roles={['USDR_ADMIN', 'ORGANIZATION_ADMIN']}>
           <Route path="/agencies/{id:Int}/edit" page={AgencyEditAgencyPage} name="editAgency" />
           <Route path="/agencies/{id:Int}" page={AgencyAgencyPage} name="agency" />
           <Route path="/agencies/new" page={AgencyNewAgencyPage} name="newAgency" />
           <Route path="/agencies" page={AgencyAgenciesPage} name="agencies" />
-          {/* Users */}
-          <PrivateSet unauthenticated="forbidden" roles={['USDR_ADMIN', 'ORGANIZATION_ADMIN']}>
-            <Route path="/users/new" page={UserNewUserPage} name="newUser" />
-            <Route path="/users/{id:Int}/edit" page={UserEditUserPage} name="editUser" />
-            <Route path="/users/{id:Int}" page={UserUserPage} name="user" />
-            <Route path="/users" page={UserUsersPage} name="users" />
-          </PrivateSet>
-          {/* Reporting Periods */}
+        </PrivateSet>
+        {/* Users */}
+        <PrivateSet unauthenticated="forbidden" roles={['USDR_ADMIN', 'ORGANIZATION_ADMIN']}>
+          <Route path="/users/new" page={UserNewUserPage} name="newUser" />
+          <Route path="/users/{id:Int}/edit" page={UserEditUserPage} name="editUser" />
+          <Route path="/users/{id:Int}" page={UserUserPage} name="user" />
+          <Route path="/users" page={UserUsersPage} name="users" />
+        </PrivateSet>
+        {/* Reporting Periods */}
+        <PrivateSet unauthenticated="forbidden" roles="USDR_ADMIN">
           <Route path="/reporting-periods/new" page={ReportingPeriodNewReportingPeriodPage} name="newReportingPeriod" />
           <Route path="/reporting-periods/{id:Int}/edit" page={ReportingPeriodEditReportingPeriodPage} name="editReportingPeriod" />
           <Route path="/reporting-periods/{id:Int}" page={ReportingPeriodReportingPeriodPage} name="reportingPeriod" />
           <Route path="/reporting-periods" page={ReportingPeriodReportingPeriodsPage} name="reportingPeriods" />
-          {/* Organizations */}
-          <PrivateSet unauthenticated="forbidden" roles="USDR_ADMIN">
-            <Route path="/organizations/new" page={OrganizationNewOrganizationPage} name="newOrganization" />
-            <Route path="/organizations/{id:Int}/edit" page={OrganizationEditOrganizationPage} name="editOrganization" />
-            <Route path="/organizations/{id:Int}" page={OrganizationOrganizationPage} name="organization" />
-            <Route path="/organizations" page={OrganizationOrganizationsPage} name="organizations" />
-          </PrivateSet>
-          {/* Developer Tools */}
-          <PrivateSet unauthenticated="forbidden" roles="USDR_ADMIN">
-            <Route path="/treasury-report-developer-tools" page={ToolsPageTreasuryReportGenerationPage} name="treasuryReportGenerationDeveloperTools" />
-          </PrivateSet>
+        </PrivateSet>
+        {/* Organizations */}
+        <PrivateSet unauthenticated="forbidden" roles="USDR_ADMIN">
+          <Route path="/organizations/new" page={OrganizationNewOrganizationPage} name="newOrganization" />
+          <Route path="/organizations/{id:Int}/edit" page={OrganizationEditOrganizationPage} name="editOrganization" />
+          <Route path="/organizations/{id:Int}" page={OrganizationOrganizationPage} name="organization" />
+          <Route path="/organizations" page={OrganizationOrganizationsPage} name="organizations" />
+        </PrivateSet>
+        {/* Developer Tools */}
+        <PrivateSet unauthenticated="forbidden" roles="USDR_ADMIN">
+          <Route path="/treasury-report-developer-tools" page={ToolsPageTreasuryReportGenerationPage} name="treasuryReportGenerationDeveloperTools" />
         </PrivateSet>
         {/* Forbidden page */}
         <Route path="/forbidden" page={ForbiddenPage} name="forbidden" />

--- a/web/src/components/Navigation/Navigation.tsx
+++ b/web/src/components/Navigation/Navigation.tsx
@@ -6,9 +6,8 @@ import { NavLink, routes } from '@redwoodjs/router'
 
 const Navigation = () => {
   const { hasRole } = useAuth()
-  const canViewUsersTab =
+  const canViewAdminTabs =
     hasRole(ROLES.USDR_ADMIN) || hasRole(ROLES.ORGANIZATION_ADMIN)
-  const canViewAdminTabs = hasRole(ROLES.USDR_ADMIN)
 
   return (
     <div className="tabs-wrapper row">
@@ -22,23 +21,24 @@ const Navigation = () => {
             Uploads
           </NavLink>
         </Nav.Item>
-        {/* TODO: Remove USDR_ADMIN check when ready || 2024-05-13 Milestone */}
         {canViewAdminTabs && (
-          <>
-            <Nav.Item>
-              <NavLink
-                to={routes.agencies()}
-                activeClassName="active"
-                className="nav-link"
-              >
-                Agencies
-              </NavLink>
-            </Nav.Item>
-            <Nav.Item>
-              <div className="nav-link disabled">Subrecipients</div>
-            </Nav.Item>
-            {/* TODO: Use the code below when "Subrecipients" page is ready */}
-            {/* <Nav.Item>
+          <Nav.Item>
+            <NavLink
+              to={routes.agencies()}
+              activeClassName="active"
+              className="nav-link"
+            >
+              Agencies
+            </NavLink>
+          </Nav.Item>
+        )}
+        {hasRole(ROLES.USDR_ADMIN) && (
+          <Nav.Item>
+            <div className="nav-link disabled">Subrecipients</div>
+          </Nav.Item>
+        )}
+        {/* TODO: Use the code below when "Subrecipients" page is ready */}
+        {/* <Nav.Item>
               <NavLink
                 to={routes.subrecipients()}
                 activeClassName="active"
@@ -47,17 +47,19 @@ const Navigation = () => {
                 Subrecipients
               </NavLink>
             </Nav.Item> */}
-            {canViewUsersTab && (
-              <Nav.Item>
-                <NavLink
-                  to={routes.users()}
-                  activeClassName="active"
-                  className="nav-link"
-                >
-                  Users
-                </NavLink>
-              </Nav.Item>
-            )}
+        {canViewAdminTabs && (
+          <Nav.Item>
+            <NavLink
+              to={routes.users()}
+              activeClassName="active"
+              className="nav-link"
+            >
+              Users
+            </NavLink>
+          </Nav.Item>
+        )}
+        {hasRole(ROLES.USDR_ADMIN) && (
+          <>
             <Nav.Item>
               <NavLink
                 to={routes.reportingPeriods()}
@@ -67,28 +69,24 @@ const Navigation = () => {
                 Reporting Periods
               </NavLink>
             </Nav.Item>
-            {hasRole(ROLES.USDR_ADMIN) && (
-              <Nav.Item>
-                <NavLink
-                  to={routes.organizations()}
-                  activeClassName="active"
-                  className="nav-link"
-                >
-                  Organizations
-                </NavLink>
-              </Nav.Item>
-            )}
-            {hasRole(ROLES.USDR_ADMIN) && (
-              <Nav.Item>
-                <NavLink
-                  to={routes.treasuryReportGenerationDeveloperTools()}
-                  activeClassName="active"
-                  className="nav-link"
-                >
-                  Treasury Report Generation Developer Tool
-                </NavLink>
-              </Nav.Item>
-            )}
+            <Nav.Item>
+              <NavLink
+                to={routes.organizations()}
+                activeClassName="active"
+                className="nav-link"
+              >
+                Organizations
+              </NavLink>
+            </Nav.Item>
+            <Nav.Item>
+              <NavLink
+                to={routes.treasuryReportGenerationDeveloperTools()}
+                activeClassName="active"
+                className="nav-link"
+              >
+                Treasury Report Generation Developer Tool
+              </NavLink>
+            </Nav.Item>
           </>
         )}
       </Nav>


### PR DESCRIPTION
# Ticket #380 

## Changes
- Users with "organization_admin" role can now see Users and Agencies tabs and navigate to those pages
- Users with "organization_admin" role now have permissions to add/edit users and agencies
- Added specific role requirements to use createAgency and updateAgency mutations to match the logic we're using for createUser and updateUser mutations.