### PR TITLE
fix: ensure reporting period is able to be created correctly

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -100,7 +100,6 @@ export default async () => {
       endDate: new Date(),
       inputTemplateId: lastInputTemplateId,
       outputTemplateId: lastOutputTemplateId,
-      organizationId: organizationRecord.id,
     }
     const reportingPeriod = await db.reportingPeriod.create({
       data: reportingPeriodData,
@@ -113,7 +112,7 @@ export default async () => {
         preferences: {
           current_reporting_period_id: reportingPeriod.id,
         },
-      }
+      },
     })
 
     const expendtitureCategoriesData = [


### PR DESCRIPTION
Ran into the following error when setting up my dev environment from scratch:

```
Please define your seed data.
PrismaClientValidationError: 
Invalid `db.reportingPeriod.create()` invocation in
/home/node/app/scripts/seed.ts:105:54

  102   outputTemplateId: lastOutputTemplateId,
  103   organizationId: organizationRecord.id,
  104 }
→ 105 const reportingPeriod = await db.reportingPeriod.create({
        data: {
          name: "First Reporting Period",
          startDate: new Date("2024-08-13T15:04:42.144Z"),
          endDate: new Date("2024-08-13T15:04:42.144Z"),
          inputTemplateId: 1,
          outputTemplateId: 1,
          organizationId: 1,
          ~~~~~~~~~~~~~~
      ?   id?: Int,
      ?   validationRulesId?: Int | Null,
      ?   createdAt?: DateTime,
      ?   updatedAt?: DateTime,
      ?   uploads?: UploadUncheckedCreateNestedManyWithoutReportingPeriodInput,
      ?   projects?: ProjectUncheckedCreateNestedManyWithoutOriginationPeriodInput
        }
      })

Unknown argument `organizationId`. Available options are marked with ?.
    at Tn (/home/node/app/node_modules/@prisma/client/runtime/library.js:115:5888)
    at In.handleRequestError (/home/node/app/node_modules/@prisma/client/runtime/library.js:122:6510)
    at In.handleAndLogRequestError (/home/node/app/node_modules/@prisma/client/runtime/library.js:122:6188)
    at In.request (/home/node/app/node_modules/@prisma/client/runtime/library.js:122:5896)
    at l (/home/node/app/node_modules/@prisma/client/runtime/library.js:127:10871)
    at Object._default [as default] (/home/node/app/scripts/seed.ts:105:29)
    at runScriptFunction (/home/node/app/node_modules/@redwoodjs/cli/dist/lib/exec.js:44:23)
    at _Task.task [as taskFn] (/home/node/app/node_modules/@redwoodjs/cli/dist/commands/execHandler.js:143:11)
    at _Task.run (/home/node/app/node_modules/listr2/dist/index.cjs:2049:11) {
  clientVersion: '5.11.0'
}
```


This PR fixes this error so others will not have to manually fix the `seed.ts` file.