### PR TITLE
chore: make tweaks to ensure step-function kick-off is consistent across file-generation lambdas

### DIFF
--- a/api/src/functions/processValidationJson/processValidationJson.ts
+++ b/api/src/functions/processValidationJson/processValidationJson.ts
@@ -223,7 +223,7 @@ export const processRecord = async (
       }
 
       try {
-        const subrecipientKey = `/${organizationId}/${reportingPeriod.id}/subrecipients`
+        const subrecipientKey = `treasuryreports/${organizationId}/${reportingPeriod.id}/subrecipients`
         const { startDate, endDate } = reportingPeriod
         const subrecipientsWithUploads = await db.subrecipient.findMany({
           where: { createdAt: { lte: endDate, gte: startDate } },

--- a/python/src/functions/generate_treasury_report.py
+++ b/python/src/functions/generate_treasury_report.py
@@ -123,11 +123,6 @@ def process_event(payload: ProjectLambdaPayload, logger):
     ProjectRowSchema = getSchemaByProject(VERSION, project_use_code)
 
     organization = payload.organization
-    organization_id = payload.organization.id
-    current_reporting_period_id = (
-        payload.organization.preferences.current_reporting_period_id
-    )
-    user = payload.user
 
     # If the treasury report file exists, download it and store the data
     # If it doesn't exist, download the output template

--- a/python/src/functions/generate_treasury_report.py
+++ b/python/src/functions/generate_treasury_report.py
@@ -1,42 +1,61 @@
-from datetime import datetime
-from openpyxl import load_workbook, Workbook
-from openpyxl.worksheet.worksheet import Worksheet
-from typing import List, Union, Dict
 import json
+import os
 import tempfile
-from typing import Any, Set
+from datetime import datetime
+from typing import IO, Dict, List, Set, Union
 
 import boto3
 import structlog
 from aws_lambda_typing.context import Context
-from aws_lambda_typing.events import S3Event
 from mypy_boto3_s3.client import S3Client
+from openpyxl import Workbook, load_workbook
+from openpyxl.worksheet.worksheet import Worksheet
+from pydantic import BaseModel
 
+from src.lib.constants import OUTPUT_TEMPLATE_FILENAME_BY_PROJECT
 from src.lib.logging import get_logger, reset_contextvars
+from src.lib.s3_helper import download_s3_object, upload_generated_file_to_s3
+from src.lib.treasury_generation_common import (
+    OrganizationObj,
+    UserObj,
+    get_output_template,
+)
+from src.lib.workbook_utils import convert_xlsx_to_csv
+from src.lib.workbook_validator import validate_project_sheet
+from src.schemas.project_types import ProjectType
 from src.schemas.schema_versions import (
-    Version,
-    getSchemaByProject,
     Project1ARow,
     Project1BRow,
     Project1CRow,
+    Version,
+    getSchemaByProject,
 )
-from src.schemas.project_types import ProjectType
-from src.lib.workbook_validator import validate_project_sheet
-from src.lib.s3_helper import upload_generated_file_to_s3, download_s3_object
-from src.lib.workbook_utils import convert_xlsx_to_csv
 
 OUTPUT_STARTING_ROW = 8
-OUTPUT_TEMPLATE = {
-    ProjectType._1A: "CPF1ABroadbandInfrastructureTemplate",
-    ProjectType._1B: "CPF1BDigitalConnectivityTechTemplate",
-    ProjectType._1C: "CPF1CMultiPurposeCommunityTemplate",
-}
 VERSION = Version.active_version()
 PROJECT_SHEET = "Project"
 
 
+class UploadObj(BaseModel):
+    objectKey: str
+    filename: str
+    createdAt: datetime
+
+
+type AgencyId = str
+
+
+class ProjectLambdaPayload(BaseModel):
+    organization: OrganizationObj
+    user: UserObj
+    outputTemplateId: int
+    ProjectType: str
+    uploadsToAdd: Dict[AgencyId, UploadObj]
+    uploadsToRemove: Dict[AgencyId, UploadObj]
+
+
 @reset_contextvars
-def handle(event: S3Event, context: Context):
+def handle(event: ProjectLambdaPayload, context: Context):
     """Lambda handler for generating Treasury Reports
 
     This function creates/outputs 3 files (all with the same name but different
@@ -46,6 +65,31 @@ def handle(event: S3Event, context: Context):
     - JSON Metadata which maps the {project_id}_{agency_id} to the row in the
         XLSX file to track duplicate entries.
 
+    Args:
+        event: S3 Lambda event of type `s3:ObjectCreated:*`
+        context: Lambda context
+    """
+    structlog.contextvars.bind_contextvars(lambda_event={"step_function": event})
+    logger = get_logger()
+    logger.info("received new invocation event from step function")
+
+    try:
+        payload = ProjectLambdaPayload.model_validate(event)
+    except Exception:
+        logger.exception("Exception parsing Project event payload")
+        return {"statusCode": 400, "body": "Bad Request"}
+
+    try:
+        process_event(payload, logger)
+    except Exception:
+        logger.exception("Exception processing Subrecipient file generation event")
+        return {"statusCode": 500, "body": "Internal Server Error"}
+
+    return {"statusCode": 200, "body": "Success"}
+
+
+def process_event(payload: ProjectLambdaPayload, logger):
+    """
     This function is structured as followed:
     1) Load the metadata
     2) Download the existing output XLSX file. If it doesn't exist, download
@@ -64,41 +108,26 @@ def handle(event: S3Event, context: Context):
         the new worksheet has the updated data.
     5) Save the XLSX sheet, convert it to CSV and upload it, save metadata to
         s3.
-
-    Args:
-        event: S3 Lambda event of type `s3:ObjectCreated:*`
-        context: Lambda context
     """
-    structlog.contextvars.bind_contextvars(lambda_event={"step_function": event})
-    logger = get_logger()
-    logger.info("received new invocation event from step function")
-
     s3_client: S3Client = boto3.client("s3")
 
-    project_code = event["ProjectType"]
-    if project_code == "1A":
-        project_use_code = ProjectType._1A
-    elif project_code == "1B":
-        project_use_code = ProjectType._1B
-    elif project_code == "1C":
-        project_use_code = ProjectType._1C
+    project_use_code = None
+    try:
+        project_use_code = ProjectType.from_project_name(payload.ProjectType)
+    except ValueError:
+        logger.error(
+            f"Project name '{payload.ProjectType}' is not a recognized project type."
+        )
+        return {"statusCode": 400, "body": "Invalid project name"}
+
     ProjectRowSchema = getSchemaByProject(VERSION, project_use_code)
 
-    organization: Dict[str, Any] = event["Records"][0]["organization"]
-    organization_id = organization.get("id")
-    current_reporting_period_id = organization.get("preferences").get(
-        "current_reporting_period_id"
+    organization = payload.organization
+    organization_id = payload.organization.id
+    current_reporting_period_id = (
+        payload.organization.preferences.current_reporting_period_id
     )
-    user: Dict[str, Any] = event["Records"][0]["user"]
-
-    uploadsByExpenditureCategory = event.get("uploadsByExpenditureCategory", {})
-    file_info_list = uploadsByExpenditureCategory.get(project_use_code, {})
-    outdatedUploadsByExpenditureCategory = event.get(
-        "outdatedUploadsByExpenditureCategory", {}
-    )
-    outdated_file_info_list = outdatedUploadsByExpenditureCategory.get(
-        project_use_code, {}
-    )
+    user = payload.user
 
     # If the treasury report file exists, download it and store the data
     # If it doesn't exist, download the output template
@@ -107,125 +136,144 @@ def handle(event: S3Event, context: Context):
     project_agency_id_to_row_map = get_existing_output_metadata(
         s3_client=s3_client,
         organization=organization,
-        user=user,
         project_use_code=project_use_code,
     )
 
     ### 2) Download the existing output XLSX file. If it doesn't exist, download
     #    the template file.
-    output_file = tempfile.NamedTemporaryFile()
+    with tempfile.NamedTemporaryFile() as output_file:
+        highest_row_num = download_output_file(
+            s3_client=s3_client,
+            organization=organization,
+            project_use_code=project_use_code,
+            project_agency_id_to_row_map=project_agency_id_to_row_map,
+            output_file=output_file,
+            output_template_id=payload.outputTemplateId,
+        )
+
+        output_workbook = load_workbook(filename=output_file, read_only=True)
+        output_sheet = output_workbook["Baseline"]
+
+        ### 3) Open files in the uploadsToRemove parameter.
+        # If outdated file info list is provided, grab the project id agency id to remove
+        project_agency_ids_to_remove = get_outdated_projects_to_remove(
+            s3_client=s3_client,
+            uploads_by_agency_id=payload.uploadsToRemove,
+            ProjectRowSchema=ProjectRowSchema,
+        )
+
+        # Delete rows corresponding to project_agency_ids_to_remove in the existing output file
+        # Also update project_agency_id_to_row_map with the new row numbers
+        highest_row_num = update_project_agency_ids_to_row_map(
+            project_agency_id_to_row_map=project_agency_id_to_row_map,
+            project_agency_ids_to_remove=project_agency_ids_to_remove,
+            sheet=output_sheet,
+            highest_row_num=highest_row_num,
+        )
+
+        ### 4) Open files in the uploadsByExpenditureCategory parameter.
+        # Get project data to add to the output
+        project_id_agency_id_to_upload_date: Dict[str, datetime] = {}
+        for agency_id, file_info in payload.uploadsToAdd.items():
+            with tempfile.NamedTemporaryFile() as file:
+                # Download projects from S3
+                created_at = file_info.createdAt
+                download_s3_object(
+                    s3_client,
+                    os.environ["REPORTING_DATA_BUCKET_NAME"],
+                    file_info.objectKey,
+                    file,
+                )
+                # Load workbook
+                wb = load_workbook(filename=file, read_only=True)
+                # Get and combine project rows
+                highest_row_num = combine_project_rows(
+                    project_workbook=wb,
+                    output_sheet=output_sheet,
+                    project_use_code=project_use_code,
+                    highest_row_num=highest_row_num,
+                    ProjectRowSchema=ProjectRowSchema,
+                    project_id_agency_id_to_upload_date=project_id_agency_id_to_upload_date,
+                    project_id_agency_id_to_row_num=project_agency_id_to_row_map,
+                    created_at=created_at,
+                    agency_id=agency_id,
+                )
+
+        ### 5) Save data
+        # Output XLSX file
+        file_destination_prefix = f"treasuryreports/{organization.id}/{organization.preferences.current_reporting_period_id}/{OUTPUT_TEMPLATE_FILENAME_BY_PROJECT[project_use_code]}"
+        with tempfile.NamedTemporaryFile("w") as new_output_file:
+            output_workbook.save(new_output_file.name)
+            upload_generated_file_to_s3(
+                client=s3_client,
+                bucket=os.environ["REPORTING_DATA_BUCKET_NAME"],
+                key=f"{file_destination_prefix}.xlsx",
+                file=new_output_file,
+            )
+        # Output CSV file for treasury
+        with tempfile.NamedTemporaryFile("w") as csv_file:
+            convert_xlsx_to_csv(csv_file, output_workbook, highest_row_num)
+            upload_generated_file_to_s3(
+                client=s3_client,
+                bucket=os.environ["REPORTING_DATA_BUCKET_NAME"],
+                key=f"{file_destination_prefix}.csv",
+                file=csv_file,
+            )
+        # Store project_id_agency_id to row number in a json file
+        with tempfile.NamedTemporaryFile("w") as json_file:
+            json_file = json.dump(project_agency_id_to_row_map)
+            upload_generated_file_to_s3(
+                client=s3_client,
+                bucket=os.environ["REPORTING_DATA_BUCKET_NAME"],
+                key=f"{file_destination_prefix}.json",
+                file=json_file,
+            )
+
+def download_output_file(
+    s3_client: S3Client,
+    output_file: IO[bytes],
+    project_agency_id_to_row_map: Dict[str, int],
+    organization: OrganizationObj,
+    project_use_code: str,
+    output_template_id: int,
+) -> int:
+    highest_row_num = None
     if project_agency_id_to_row_map:
+        """
+        Output file already exists, download it
+        """
         download_s3_object(
-            s3_client,
-            f"treasuryreports/{organization_id}/{current_reporting_period_id}",
-            f"{OUTPUT_TEMPLATE[project_use_code]}.xlsx",
-            output_file,
+            client=s3_client,
+            bucket=os.environ["REPORTING_DATA_BUCKET_NAME"],
+            key=f"treasuryreports/{organization.id}/{organization.preferences.current_reporting_period_id}/{OUTPUT_TEMPLATE_FILENAME_BY_PROJECT[project_use_code]}.xlsx",
+            destination=output_file,
         )
         highest_row_num = max(project_agency_id_to_row_map.values())
     else:
-        download_s3_object(
-            s3_client,
-            event["Records"][0]["s3"]["bucket"]["name"],
-            f"{OUTPUT_TEMPLATE[project_use_code]}.xlsx",
-            output_file,
+        """
+        Output file doesn't exist, download the empty template
+        """
+        get_output_template(
+            s3_client=s3_client,
+            output_template_id=output_template_id,
+            project=project_use_code,
+            destination=output_file,
         )
         highest_row_num = OUTPUT_STARTING_ROW - 1
-
-    workbook = load_workbook(filename=output_file, read_only=True)
-    sheet = workbook["Baseline"]
-
-    ### 3) Open files in the outdatedUploadsByExpenditureCategory parameter.
-    # If outdated file info list is provided, grab the project id agency id to remove
-    project_agency_ids_to_remove = get_outdated_projects_to_remove(
-        s3_client=s3_client,
-        outdated_file_info_list=outdated_file_info_list,
-        ProjectRowSchema=ProjectRowSchema,
-    )
-
-    # Delete rows corresponding to project_agency_ids_to_remove in the existing output file
-    # Also update project_agency_id_to_row_map with the new row numbers
-    highest_row_num = update_project_agency_ids_to_row_map(
-        project_agency_id_to_row_map=project_agency_id_to_row_map,
-        project_agency_ids_to_remove=project_agency_ids_to_remove,
-        sheet=sheet,
-        highest_row_num=highest_row_num,
-    )
-
-    ### 4) Open files in the uploadsByExpenditureCategory parameter.
-    # Get project data to add to the output
-    project_id_agency_id_to_upload_date: Dict[str, datetime] = {}
-    for agency_id, file_info in file_info_list.items():
-        with tempfile.NamedTemporaryFile() as file:
-            # Download projects from S3
-            objectKey = file_info.get("objectKey")
-            bucket = objectKey.split("/")[0]
-            filename = file_info.get("filename")
-            created_at = file_info.get("createdAt")
-            download_s3_object(
-                s3_client,
-                bucket,
-                filename,
-                file,
-            )
-            # Load workbook
-            wb = load_workbook(filename=file, read_only=True)
-            # Get and combine project rows
-            highest_row_num = combine_project_rows(
-                project_workbook=wb,
-                output_sheet=sheet,
-                project_use_code=project_use_code,
-                highest_row_num=highest_row_num,
-                ProjectRowSchema=ProjectRowSchema,
-                project_id_agency_id_to_upload_date=project_id_agency_id_to_upload_date,
-                project_id_agency_id_to_row_num=project_agency_id_to_row_map,
-                created_at=created_at,
-                agency_id=agency_id,
-            )
-
-    ### 5) Save data
-    # Output XLSX file
-    with tempfile.NamedTemporaryFile("w") as new_output_file:
-        workbook.save(new_output_file.name)
-        upload_generated_file_to_s3(
-            s3_client,
-            f"treasuryreports/{organization_id}/{current_reporting_period_id}",
-            f"{OUTPUT_TEMPLATE[project_use_code]}.xlsx",
-            new_output_file,
-        )
-    # Output CSV file for treasury
-    with tempfile.NamedTemporaryFile("w") as csv_file:
-        convert_xlsx_to_csv(csv_file, workbook, highest_row_num)
-        upload_generated_file_to_s3(
-            s3_client,
-            f"treasuryreports/{organization_id}/{current_reporting_period_id}",
-            f"{OUTPUT_TEMPLATE[project_use_code]}.csv",
-            csv_file,
-        )
-    # Store project_id_agency_id to row number in a json file
-    with tempfile.NamedTemporaryFile("w") as json_file:
-        json_file = json.dump(project_agency_id_to_row_map)
-        upload_generated_file_to_s3(
-            s3_client,
-            f"treasuryreports/{organization_id}/{current_reporting_period_id}",
-            f"{OUTPUT_TEMPLATE[project_use_code]}.json",
-            json_file,
-        )
-    output_file.close()
-
+    return highest_row_num
 
 def get_existing_output_metadata(
     s3_client,
-    organization: Dict[str, Any],
-    user: Dict[str, Any],
+    organization: OrganizationObj,
     project_use_code: str,
-):
+) -> Dict[str, int]:
     existing_project_agency_id_to_row_number = {}
     with tempfile.NamedTemporaryFile() as existing_file:
         try:
             download_s3_object(
                 s3_client,
-                f"treasuryreports/{organization.get("id")}/{organization.get("preferences").get("current_reporting_period_id")}",
-                f"{OUTPUT_TEMPLATE[project_use_code]}.json",
+                os.environ["REPORTING_DATA_BUCKET_NAME"],
+                f"treasuryreports/{organization.id}/{organization.preferences.current_reporting_period_id}/{OUTPUT_TEMPLATE_FILENAME_BY_PROJECT[project_use_code]}.json",
                 existing_file,
             )
         except Exception:
@@ -260,7 +308,7 @@ def get_projects_to_remove(
 
 def get_outdated_projects_to_remove(
     s3_client,
-    outdated_file_info_list: Dict[str, Any],
+    uploads_by_agency_id: Dict[AgencyId, UploadObj],
     ProjectRowSchema: Union[Project1ARow, Project1BRow, Project1CRow],
 ):
     """
@@ -268,16 +316,13 @@ def get_outdated_projects_to_remove(
     remove.
     """
     project_agency_ids_to_remove = set()
-    for agency_id, file_info in outdated_file_info_list.items():
+    for agency_id, file_info in uploads_by_agency_id.items():
         with tempfile.NamedTemporaryFile() as file:
             # Download projects from S3
-            objectKey = file_info.get("objectKey")
-            bucket = objectKey.split("/")[0]
-            filename = file_info.get("filename")
             download_s3_object(
                 s3_client,
-                bucket,
-                filename,
+                os.environ["REPORTING_DATA_BUCKET_NAME"],
+                file_info.objectKey,
                 file,
             )
             # Load workbook

--- a/python/src/functions/subrecipient_treasury_report_gen.py
+++ b/python/src/functions/subrecipient_treasury_report_gen.py
@@ -1,27 +1,49 @@
+import json
+import os
 import tempfile
-from typing import Any, Dict
+from datetime import datetime
 
 import boto3
 import structlog
-import json
 from aws_lambda_typing.context import Context
 from mypy_boto3_s3.client import S3Client
-from openpyxl import load_workbook, Workbook
-from datetime import datetime
+from openpyxl import Workbook, load_workbook
+from pydantic import BaseModel
 
-from src.lib.logging import reset_contextvars, get_logger
+from src.lib.constants import OUTPUT_TEMPLATE_FILENAME_BY_PROJECT
+from src.lib.logging import get_logger, reset_contextvars
 from src.lib.s3_helper import download_s3_object, upload_generated_file_to_s3
-from src.schemas.schema_versions import getSubrecipientRowClass
+from src.lib.treasury_generation_common import get_output_template
 from src.lib.workbook_utils import convert_xlsx_to_csv, find_last_populated_row
+from src.schemas.schema_versions import getSubrecipientRowClass
 
-BUCKET_NAME = "cpf-reporter"
 FIRST_BLANK_ROW_NUM = 8
 WORKSHEET_NAME = "Baseline"
 FIRST_DATA_COLUMN = "B"
 
 
+class PreferencesObj(BaseModel):
+    current_reporting_period_id: int
+
+
+class OrganizationObj(BaseModel):
+    id: int
+    preferences: PreferencesObj
+
+
+class UserObj(BaseModel):
+    id: int
+    email: str
+
+
+class SubrecipientLambdaPayload(BaseModel):
+    organization: OrganizationObj
+    user: UserObj
+    outputTemplateId: int
+
+
 @reset_contextvars
-def handle(event: Dict[str, Any], context: Context):
+def handle(event: SubrecipientLambdaPayload, context: Context):
     """Lambda handler for generating subrecipients file for treasury report
 
     Args:
@@ -33,12 +55,6 @@ def handle(event: Dict[str, Any], context: Context):
         }
         context: Lambda context
 
-    This function should:
-    1. Parse necessary inputs from the event
-    2. Download a file of recent subrecipients from S3 to put into the output template
-    3. Download the output template itself from S3
-    4. Iterate through recent subrecipients and put their information into the output template
-    5. Upload the output template, in both xlsx and csv formats, to S3
     """
     structlog.contextvars.bind_contextvars(
         lambda_event={"subrecipient_step_function": event}
@@ -49,18 +65,39 @@ def handle(event: Dict[str, Any], context: Context):
         logger.exception("Missing event or context")
         return
 
+    try:
+        payload = SubrecipientLambdaPayload.model_validate(event)
+    except Exception:
+        logger.exception("Exception parsing Subrecipient event payload")
+        return {"statusCode": 400, "body": "Bad Request"}
+
+    try:
+        process_event(payload, logger)
+    except Exception:
+        logger.exception("Exception processing Subrecipient file generation event")
+        return {"statusCode": 500, "body": "Internal Server Error"}
+
+    return {"statusCode": 200, "body": "Success"}
+
+
+def process_event(payload: SubrecipientLambdaPayload, logger):
+    """
+    This function should:
+    1. Parse necessary inputs from the event
+    2. Download a file of recent subrecipients from S3 to put into the output template
+    3. Download the output template itself from S3
+    4. Iterate through recent subrecipients and put their information into the output template
+    5. Upload the output template, in both xlsx and csv formats, to S3
+    """
     organization_id = ...
     reporting_period_id = ...
     output_template_id = ...
-    user_id = ...
-
     try:
-        reporting_period_id = event["organization"]["preferences"][
-            "current_reporting_period_id"
-        ]
-        organization_id = event["organization"]["id"]
-        output_template_id = event["outputTemplateId"]
-        user_id = event["user"]["id"]
+        reporting_period_id = (
+            payload.organization.preferences.current_reporting_period_id
+        )
+        organization_id = payload.organization.id
+        output_template_id = payload.outputTemplateId
     except KeyError as e:
         logger.exception(
             f"Exception getting reporting period or organization id from event -- missing field: {e}"
@@ -75,8 +112,8 @@ def handle(event: Dict[str, Any], context: Context):
         ):
             download_s3_object(
                 s3_client,
-                BUCKET_NAME,
-                f"/{organization_id}/{reporting_period_id}/subrecipients",
+                os.environ["REPORTING_DATA_BUCKET_NAME"],
+                f"treasuryreports/{organization_id}/{reporting_period_id}/subrecipients",
                 recent_subrecipients_file,
             )
 
@@ -98,12 +135,7 @@ def handle(event: Dict[str, Any], context: Context):
         return
 
     output_file = tempfile.NamedTemporaryFile()
-    download_s3_object(
-        s3_client,
-        BUCKET_NAME,
-        f"/treasuryreports/output-templates/{output_template_id}/CPFSubrecipientTemplate.xlsx",
-        output_file,
-    )
+    get_output_template(s3_client, output_template_id, "Subrecipient", output_file)
 
     workbook = load_workbook(filename=output_file)
     write_subrecipients_to_workbook(
@@ -112,7 +144,7 @@ def handle(event: Dict[str, Any], context: Context):
         logger=logger,
     )
 
-    upload_workbook(workbook, s3_client, user_id, organization_id, reporting_period_id)
+    upload_workbook(workbook, s3_client, organization_id, reporting_period_id)
 
     output_file.close()
     recent_subrecipients_file.close()
@@ -184,21 +216,21 @@ def get_most_recent_upload(subrecipient):
 def upload_workbook(
     workbook: Workbook,
     s3client: S3Client,
-    user_id: str,
-    organization_id: str,
-    reporting_period_id: str,
+    organization_id: int,
+    reporting_period_id: int,
 ):
     """
     Handles upload of workbook to S3, both in xlsx and csv formats
     """
-    upload_template_location_minus_filetype = f"/treasuryreports/{organization_id}/{reporting_period_id}/{user_id}/CPFSubrecipientTemplate"
-    upload_template_xlsx_key = f"{upload_template_location_minus_filetype}.xlsx"
-    upload_template_csv_key = f"{upload_template_location_minus_filetype}.csv"
+    filekey_without_extension = f"treasuryreports/{organization_id}/{reporting_period_id}/{OUTPUT_TEMPLATE_FILENAME_BY_PROJECT['Subrecipient']}"
 
     with tempfile.NamedTemporaryFile("w") as new_xlsx_file:
         workbook.save(new_xlsx_file.name)
         upload_generated_file_to_s3(
-            s3client, BUCKET_NAME, upload_template_xlsx_key, new_xlsx_file
+            s3client,
+            os.environ["REPORTING_DATA_BUCKET_NAME"],
+            f"{filekey_without_extension}.xlsx",
+            new_xlsx_file,
         )
 
     with tempfile.NamedTemporaryFile("w") as new_csv_file:
@@ -211,7 +243,7 @@ def upload_workbook(
         )
         upload_generated_file_to_s3(
             s3client,
-            BUCKET_NAME,
-            upload_template_csv_key,
+            os.environ["REPORTING_DATA_BUCKET_NAME"],
+            f"{filekey_without_extension}.csv",
             new_csv_file,
         )

--- a/python/src/functions/subrecipient_treasury_report_gen.py
+++ b/python/src/functions/subrecipient_treasury_report_gen.py
@@ -13,27 +13,17 @@ from pydantic import BaseModel
 from src.lib.constants import OUTPUT_TEMPLATE_FILENAME_BY_PROJECT
 from src.lib.logging import get_logger, reset_contextvars
 from src.lib.s3_helper import download_s3_object, upload_generated_file_to_s3
-from src.lib.treasury_generation_common import get_output_template
+from src.lib.treasury_generation_common import (
+    OrganizationObj,
+    UserObj,
+    get_output_template,
+)
 from src.lib.workbook_utils import convert_xlsx_to_csv, find_last_populated_row
 from src.schemas.schema_versions import getSubrecipientRowClass
 
 FIRST_BLANK_ROW_NUM = 8
 WORKSHEET_NAME = "Baseline"
 FIRST_DATA_COLUMN = "B"
-
-
-class PreferencesObj(BaseModel):
-    current_reporting_period_id: int
-
-
-class OrganizationObj(BaseModel):
-    id: int
-    preferences: PreferencesObj
-
-
-class UserObj(BaseModel):
-    id: int
-    email: str
 
 
 class SubrecipientLambdaPayload(BaseModel):

--- a/python/src/lib/constants.py
+++ b/python/src/lib/constants.py
@@ -1,0 +1,21 @@
+from enum import Enum
+
+from src.schemas.project_types import ProjectType
+
+
+class OutputTemplateFilename(Enum):
+    CPF1ABroadbandInfrastructureTemplate = "CPF1ABroadbandInfrastructureTemplate"
+    CPF1BDigitalConnectivityTechTemplate = "CPF1BDigitalConnectivityTechTemplate"
+    CPF1CMultiPurposeCommunityTemplate = "CPF1CMultiPurposeCommunityTemplate"
+    CPFSubrecipientTemplate = "CPFSubrecipientTemplate"
+
+    def __str__(self):
+        return self.value
+
+
+OUTPUT_TEMPLATE_FILENAME_BY_PROJECT = {
+    ProjectType._1A: OutputTemplateFilename.CPF1ABroadbandInfrastructureTemplate,
+    ProjectType._1B: OutputTemplateFilename.CPF1BDigitalConnectivityTechTemplate,
+    ProjectType._1C: OutputTemplateFilename.CPF1CMultiPurposeCommunityTemplate,
+    "Subrecipient": OutputTemplateFilename.CPFSubrecipientTemplate,
+}

--- a/python/src/lib/treasury_generation_common.py
+++ b/python/src/lib/treasury_generation_common.py
@@ -2,9 +2,24 @@ import os
 from typing import IO
 
 from mypy_boto3_s3.client import S3Client
+from pydantic import BaseModel
 
 from src.lib.constants import OUTPUT_TEMPLATE_FILENAME_BY_PROJECT
 from src.lib.logging import get_logger
+
+
+class PreferencesObj(BaseModel):
+    current_reporting_period_id: int
+
+
+class OrganizationObj(BaseModel):
+    id: int
+    preferences: PreferencesObj
+
+
+class UserObj(BaseModel):
+    id: int
+    email: str
 
 
 def get_output_template(

--- a/python/src/lib/treasury_generation_common.py
+++ b/python/src/lib/treasury_generation_common.py
@@ -1,0 +1,34 @@
+import os
+from typing import IO
+
+from mypy_boto3_s3.client import S3Client
+
+from src.lib.constants import OUTPUT_TEMPLATE_FILENAME_BY_PROJECT
+from src.lib.logging import get_logger
+
+
+def get_output_template(
+    s3_client: S3Client,
+    output_template_id: int,
+    project: str,
+    destination: IO[bytes],
+):
+    """Downloads an output template from S3.
+
+    Args:
+        output_template_id: ID of the output template to download
+        template_name: Name of the output template
+        destination: File-like object (in binary mode) where the output template will be written
+    """
+    logger = get_logger()
+    logger.debug("downloading output template from s3")
+
+    try:
+        s3_client.download_fileobj(
+            bucket=os.environ["REPORTING_DATA_BUCKET_NAME"],
+            key=f"treasuryreports/output-templates/{output_template_id}/{OUTPUT_TEMPLATE_FILENAME_BY_PROJECT[project]}.xlsx",
+            file=destination,
+        )
+    except:
+        logger.exception("failed to download output template from S3")
+        raise

--- a/python/src/schemas/schema_versions.py
+++ b/python/src/schemas/schema_versions.py
@@ -4,39 +4,19 @@ from typing import Type, Union
 from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
 from src.schemas.project_types import ProjectType
-from src.schemas.schema_V2024_04_01 import (
-    METADATA_BY_SHEET as V2024_04_01_Metadata,
-)
-from src.schemas.schema_V2024_04_01 import (
-    CoverSheetRow as V2024_04_01_CoverSheetRow,
-)
-from src.schemas.schema_V2024_04_01 import (
-    Project1ARow as V2024_04_01_Project1ARow,
-)
-from src.schemas.schema_V2024_04_01 import (
-    Project1BRow as V2024_04_01_Project1BRow,
-)
-from src.schemas.schema_V2024_04_01 import (
-    Project1CRow as V2024_04_01_Project1CRow,
-)
+from src.schemas.schema_V2024_04_01 import METADATA_BY_SHEET as V2024_04_01_Metadata
+from src.schemas.schema_V2024_04_01 import CoverSheetRow as V2024_04_01_CoverSheetRow
+from src.schemas.schema_V2024_04_01 import Project1ARow as V2024_04_01_Project1ARow
+from src.schemas.schema_V2024_04_01 import Project1BRow as V2024_04_01_Project1BRow
+from src.schemas.schema_V2024_04_01 import Project1CRow as V2024_04_01_Project1CRow
 from src.schemas.schema_V2024_04_01 import (
     SubrecipientRow as V2024_04_01_SubrecipientRow,
 )
-from src.schemas.schema_V2024_05_24 import (
-    METADATA_BY_SHEET as V2024_05_24_Metadata,
-)
-from src.schemas.schema_V2024_05_24 import (
-    CoverSheetRow as V2024_05_24_CoverSheetRow,
-)
-from src.schemas.schema_V2024_05_24 import (
-    Project1ARow as V2024_05_24_Project1ARow,
-)
-from src.schemas.schema_V2024_05_24 import (
-    Project1BRow as V2024_05_24_Project1BRow,
-)
-from src.schemas.schema_V2024_05_24 import (
-    Project1CRow as V2024_05_24_Project1CRow,
-)
+from src.schemas.schema_V2024_05_24 import METADATA_BY_SHEET as V2024_05_24_Metadata
+from src.schemas.schema_V2024_05_24 import CoverSheetRow as V2024_05_24_CoverSheetRow
+from src.schemas.schema_V2024_05_24 import Project1ARow as V2024_05_24_Project1ARow
+from src.schemas.schema_V2024_05_24 import Project1BRow as V2024_05_24_Project1BRow
+from src.schemas.schema_V2024_05_24 import Project1CRow as V2024_05_24_Project1CRow
 from src.schemas.schema_V2024_05_24 import (
     SubrecipientRow as V2024_05_24_SubrecipientRow,
 )
@@ -77,7 +57,7 @@ class Version(Enum):
     V2024_05_24 = "v:20240524"
 
     @classmethod
-    def active_version(cls):
+    def active_version(cls) -> "Version":
         return cls.V2024_05_24
 
     @classmethod
@@ -144,8 +124,8 @@ def getCoverSheetRowClass(version_string: str) -> CoverSheetRow:
 
 
 def getSchemaByProject(
-    version_string: str, project_type: ProjectType
-) -> Type[Union[Project1ARow, Project1BRow, Project1CRow]]:
+    version_string: Version, project_type: ProjectType
+) -> Union[Project1ARow, Project1BRow, Project1CRow]:
     version = getVersionFromString(version_string)
     match project_type:
         case ProjectType._1A:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -4,7 +4,10 @@ from typing import BinaryIO
 import openpyxl
 import pytest
 from aws_lambda_typing.context import Context
+
+from src.functions.subrecipient_treasury_report_gen import SubrecipientLambdaPayload
 from src.lib.output_template_comparator import CPFFileArchive
+from src.lib.treasury_generation_common import OrganizationObj, PreferencesObj, UserObj
 
 _SAMPLE_VALID_XLSM = "tests/data/sample_valid.xlsm"
 _SAMPLE_VALID_XLSM_V2024_05_24 = "tests/data/sample_valid_V2024_05_24.xlsm"
@@ -328,14 +331,23 @@ def valid_subrecipients_json_content():
 def sample_subrecipients_generation_event():
     return {
         "organization": {
-            "id": "org123",
-            "preferences": {"current_reporting_period_id": "reporting123"},
+            "id": 12,
+            "preferences": {"current_reporting_period_id": 34},
         },
-        "outputTemplateId": "template123",
-        "user": {
-            "id": 1,
-        },
+        "user": {"id": 56, "email": "a@example.com"},
+        "outputTemplateId": 78,
     }
+
+@pytest.fixture
+def sample_subrecipients_lambda_payload():
+    return SubrecipientLambdaPayload(
+        organization=OrganizationObj(
+            id=99,
+            preferences=PreferencesObj(current_reporting_period_id=123),
+        ),
+        user=UserObj(id=456, email="foo@example.com"),
+        outputTemplateId=789,
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
- Add reporting data bucket as environment variables to the python lambdas
- Update project-lambda from S3 event structure to custom Payload structure
- Update both Subrecipient and Project Lambda to have a schema/type-defined payload structure for easier structure creation
- Add ability to upload Output template files from the graphql lambda
- Ensure Graphql and python lambdas have put/get object permissions for files within treasuryreports/output-templates and treasury reports… namespace of s3 bucket.
- Update tests based on the above changes for all the lambdas.