### PR TITLE
fix: build pipeline error - typo in bash command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -449,7 +449,7 @@ jobs:
         run: yarn zip-it-and-ship-it $BUILD_OUTPUT_PATH/functions $ARTIFACTS_PATH
       - name: Add RDS CA bundle to zipped Lambda artifacts
         run: |
-          for $zipfile in $ARTIFACTS_PATH/*.zip; do
+          for zipfile in $ARTIFACTS_PATH/*.zip; do
             zip -ju $zipfile api/db/rds-global-bundle.pem
           done;
       - name: Compute build artifact checksums


### PR DESCRIPTION
Fixes error in pipeline: https://github.com/usdigitalresponse/cpf-reporter/actions/runs/10423030086/job/28868977444

```
Run for $zipfile in $ARTIFACTS_PATH/*.zip; do
  for $zipfile in $ARTIFACTS_PATH/*.zip; do
    zip -ju $zipfile api/db/rds-global-bundle.pem
  done;
  shell: /usr/bin/bash -e {0}
  env:
    ARTIFACTS_KEY: api-48c854[2](https://github.com/usdigitalresponse/cpf-reporter/actions/runs/10423030086/job/28868977444#step:9:2)ced6b0636fc7c2f9cda0bb8af1150d994
    BUILD_OUTPUT_PATH: /home/runner/work/cpf-reporter/cpf-reporter/api/dist
    ARTIFACTS_PATH: /home/runner/work/cpf-reporter/cpf-reporter/api/dist/zipballs
/home/runner/work/_temp/de90ed[3](https://github.com/usdigitalresponse/cpf-reporter/actions/runs/10423030086/job/28868977444#step:9:3)0-5c57-43fd-9b2c-a87e41dcc8ff.sh: line 3: `$zipfile': not a valid identifier
Error: Process completed with exit code 1.
```


To test locally save the following code in a file called `sample.sh` and run using command line `bash sample.sh`:
```

echo "CREATE ORIGINAL ZIP FILE"
touch original.txt
zip test.zip original.txt

echo "CREATE FILE TO ADD TO ZIPFILE"
touch file_to_add.txt

export ARTIFACTS_PATH=$PWD

echo "RUNNING SCRIPT TO ADD file_to_add.txt to ZIPFLE"
for zipfile in $ARTIFACTS_PATH/*.zip; do
  echo $ARTIFACTS_PATH
  echo $zipfile
  zip -ju $zipfile $PWD/file_to_add.txt
done;

echo "SCRIPT ENDED"
```
After running the script you will see `file_to_add.txt` available within the `test.zip` file created in the same directory as your script.