### PR TITLE
fix: ensure passage-app-id is accessible by graphql lambda

### DIFF
--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -374,6 +374,7 @@ module "lambda_function-graphql" {
     PASSAGE_API_KEY_SECRET_ARN         = data.aws_ssm_parameter.passage_api_key_secret_arn.value
     AUTH_PROVIDER                      = "passage"
     TREASURY_STEP_FUNCTION_ARN         = module.treasury_generation_step_function.state_machine_arn
+    PASSAGE_APP_ID                     = var.passage_app_id
   })
 
   // Triggers


### PR DESCRIPTION

This PR fixes the following error recorded in [datadog](https://app.datadoghq.com/logs?query=service%3Acpf-reporter&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZGaVLG8YiXzvwAAAAAAAAAYAAAAAEFaR2FWTEs3QUFEbWpMRXhFQy1ZTUFBRwAAACQAAAAAMDE5MTlhOTItYzY2MC00MDI0LTk4ODgtZjg5MzhhMjJjYTI1&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1724843625484&to_ts=1724930025484&live=true) when attempting to create/activate/inactivate users in the staging environment.
```
Error: A Passage appID is required. Please include {appID: YOUR_APP_ID}.
    at new Passage (/var/task/node_modules/@passageidentity/passage-node/lib/cjs/classes/Passage.js:44:19)
    at getPassageClient (/var/task/api/dist/services/passage/passage.js:44:12)
    at async createPassageUser (/var/task/api/dist/services/passage/passage.js:52:21)
    at async /var/task/api/dist/services/users/users.js:230:27
```

The `PASSAGE_APP_ID` variable is necessary to be set in order to be able to perform any of the actions within Passage. Previously it appears that we setup the variable correctly for the client-side code, but not for the server/graphql-side.
