### PR TITLE
CPF-408 Implement Reporting Period Certification Storage

### DIFF
--- a/api/db/migrations/20240904164008_add_reporting_period_certification_model/migration.sql
+++ b/api/db/migrations/20240904164008_add_reporting_period_certification_model/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "ReportingPeriodCertification" (
+    "id" SERIAL NOT NULL,
+    "organizationId" INTEGER NOT NULL,
+    "reportingPeriodId" INTEGER NOT NULL,
+    "certifiedById" INTEGER NOT NULL,
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ReportingPeriodCertification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ReportingPeriodCertification_organizationId_reportingPeriod_key" ON "ReportingPeriodCertification"("organizationId", "reportingPeriodId");
+
+-- AddForeignKey
+ALTER TABLE "ReportingPeriodCertification" ADD CONSTRAINT "ReportingPeriodCertification_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ReportingPeriodCertification" ADD CONSTRAINT "ReportingPeriodCertification_reportingPeriodId_fkey" FOREIGN KEY ("reportingPeriodId") REFERENCES "ReportingPeriod"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ReportingPeriodCertification" ADD CONSTRAINT "ReportingPeriodCertification_certifiedById_fkey" FOREIGN KEY ("certifiedById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -22,27 +22,29 @@ model Agency {
 }
 
 model Organization {
-  id                Int                 @id @default(autoincrement())
-  agencies          Agency[]
-  name              String
-  subrecipients     Subrecipient[]
-  projects          Project[]
-  preferences       Json?
+  id                            Int                            @id @default(autoincrement())
+  agencies                      Agency[]
+  name                          String
+  subrecipients                 Subrecipient[]
+  projects                      Project[]
+  preferences                   Json?
+  reportingPeriodCertifications ReportingPeriodCertification[]
 }
 
 model User {
-  id             Int                 @id @default(autoincrement())
-  email          String              @unique
-  name           String
-  agencyId       Int
-  createdAt      DateTime            @default(now()) @db.Timestamptz(6)
-  updatedAt      DateTime            @default(now()) @db.Timestamptz(6) @updatedAt
-  role           Role
-  isActive       Boolean             @default(true)
-  passageId      String?
-  agency         Agency              @relation(fields: [agencyId], references: [id])
-  uploaded       Upload[]
-  initiated      UploadValidation[]
+  id                        Int                            @id @default(autoincrement())
+  email                     String                         @unique
+  name                      String
+  agencyId                  Int
+  createdAt                 DateTime                       @default(now()) @db.Timestamptz(6)
+  updatedAt                 DateTime                       @default(now()) @updatedAt @db.Timestamptz(6)
+  role                      Role
+  isActive                  Boolean                        @default(true)
+  passageId                 String?
+  agency                    Agency                         @relation(fields: [agencyId], references: [id])
+  uploaded                  Upload[]
+  initiated                 UploadValidation[]
+  certifiedReportingPeriods ReportingPeriodCertification[]
 
   @@index(fields: [passageId])
 }
@@ -90,6 +92,21 @@ model ReportingPeriod {
   updatedAt         DateTime       @default(now()) @db.Timestamptz(6) @updatedAt
   uploads           Upload[]
   projects          Project[]
+  certifications    ReportingPeriodCertification[]
+}
+
+model ReportingPeriodCertification {
+  id                 Int             @id @default(autoincrement())
+  organizationId     Int
+  organization       Organization    @relation(fields: [organizationId], references: [id])
+  reportingPeriodId  Int
+  reportingPeriod    ReportingPeriod @relation(fields: [reportingPeriodId], references: [id])
+  certifiedById      Int
+  certifiedBy        User            @relation(fields: [certifiedById], references: [id])
+  createdAt          DateTime        @default(now()) @db.Timestamptz(6)
+  updatedAt          DateTime        @default(now()) @db.Timestamptz(6) @updatedAt
+
+  @@unique([organizationId, reportingPeriodId])
 }
 
 model ExpenditureCategory {

--- a/api/src/graphql/organizations.sdl.ts
+++ b/api/src/graphql/organizations.sdl.ts
@@ -7,6 +7,7 @@ export const schema = gql`
     subrecipients: [Subrecipient]!
     projects: [Project]!
     preferences: JSON
+    reportingPeriodCertifications: [ReportingPeriodCertification]!
   }
 
   type Query {

--- a/api/src/graphql/reportingPeriodCertifications.sdl.ts
+++ b/api/src/graphql/reportingPeriodCertifications.sdl.ts
@@ -38,5 +38,6 @@ export const schema = gql`
       input: UpdateReportingPeriodCertificationInput!
     ): ReportingPeriodCertification! @requireAuth
     deleteReportingPeriodCertification(id: Int!): ReportingPeriodCertification!
+      @requireAuth
   }
 `

--- a/api/src/graphql/reportingPeriodCertifications.sdl.ts
+++ b/api/src/graphql/reportingPeriodCertifications.sdl.ts
@@ -1,0 +1,42 @@
+export const schema = gql`
+  type ReportingPeriodCertification {
+    id: Int!
+    organizationId: Int!
+    organization: Organization!
+    reportingPeriodId: Int!
+    reportingPeriod: ReportingPeriod!
+    certifiedById: Int!
+    certifiedBy: User!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+  }
+
+  type Query {
+    reportingPeriodCertifications: [ReportingPeriodCertification!]! @requireAuth
+    reportingPeriodCertification(id: Int!): ReportingPeriodCertification
+      @requireAuth
+  }
+
+  input CreateReportingPeriodCertificationInput {
+    organizationId: Int!
+    reportingPeriodId: Int!
+    certifiedById: Int!
+  }
+
+  input UpdateReportingPeriodCertificationInput {
+    organizationId: Int
+    reportingPeriodId: Int
+    certifiedById: Int
+  }
+
+  type Mutation {
+    createReportingPeriodCertification(
+      input: CreateReportingPeriodCertificationInput!
+    ): ReportingPeriodCertification! @requireAuth
+    updateReportingPeriodCertification(
+      id: Int!
+      input: UpdateReportingPeriodCertificationInput!
+    ): ReportingPeriodCertification! @requireAuth
+    deleteReportingPeriodCertification(id: Int!): ReportingPeriodCertification!
+  }
+`

--- a/api/src/graphql/reportingPeriods.sdl.ts
+++ b/api/src/graphql/reportingPeriods.sdl.ts
@@ -14,6 +14,7 @@ export const schema = gql`
     projects: [Project]!
     validationRulesId: Int
     validationRules: ValidationRules
+    certifications: [ReportingPeriodCertification]!
   }
 
   type Query {

--- a/api/src/graphql/users.sdl.ts
+++ b/api/src/graphql/users.sdl.ts
@@ -16,6 +16,7 @@ export const schema = gql`
     role: RoleEnum!
     isActive: Boolean!
     uploaded: [Upload]!
+    certifiedReportingPeriods: [ReportingPeriodCertification]!
   }
 
   type Query {

--- a/api/src/services/organizations/organizations.ts
+++ b/api/src/services/organizations/organizations.ts
@@ -226,4 +226,9 @@ export const Organization: OrganizationRelationResolvers = {
   projects: (_obj, { root }) => {
     return db.organization.findUnique({ where: { id: root?.id } }).projects()
   },
+  reportingPeriodCertifications: (_obj, { root }) => {
+    return db.organization
+      .findUnique({ where: { id: root?.id } })
+      .reportingPeriodCertifications()
+  },
 }

--- a/api/src/services/reportingPeriodCertifications/reportingPeriodCertifications.scenarios.ts
+++ b/api/src/services/reportingPeriodCertifications/reportingPeriodCertifications.scenarios.ts
@@ -1,0 +1,84 @@
+// File: api/src/services/reportingPeriodCertifications/reportingPeriodCertifications.scenarios.ts
+
+import type { Prisma, ReportingPeriodCertification } from '@prisma/client'
+
+import type { ScenarioData } from '@redwoodjs/testing/api'
+
+export const standard =
+  defineScenario<Prisma.ReportingPeriodCertificationCreateArgs>({
+    reportingPeriodCertification: {
+      one: {
+        data: {
+          organization: { create: { name: 'Org One' } },
+          reportingPeriod: {
+            create: {
+              name: 'Period One',
+              startDate: '2024-09-04T17:17:49.871Z',
+              endDate: '2024-09-04T17:17:49.871Z',
+              inputTemplate: {
+                create: {
+                  name: 'Input Template One',
+                  version: '1.0',
+                  effectiveDate: '2024-09-04T17:17:49.871Z',
+                },
+              },
+              outputTemplate: {
+                create: {
+                  name: 'Output Template One',
+                  version: '1.0',
+                  effectiveDate: '2024-09-04T17:17:49.871Z',
+                },
+              },
+            },
+          },
+          certifiedBy: {
+            create: {
+              email: 'user1@example.com',
+              name: 'User One',
+              role: 'USDR_ADMIN',
+              agency: { create: { name: 'Agency One', code: 'A1' } },
+            },
+          },
+        },
+      },
+      two: {
+        data: {
+          organization: { create: { name: 'Org Two' } },
+          reportingPeriod: {
+            create: {
+              name: 'Period Two',
+              startDate: '2024-09-04T17:17:49.871Z',
+              endDate: '2024-09-04T17:17:49.871Z',
+              inputTemplate: {
+                create: {
+                  name: 'Input Template Two',
+                  version: '1.0',
+                  effectiveDate: '2024-09-04T17:17:49.871Z',
+                },
+              },
+              outputTemplate: {
+                create: {
+                  name: 'Output Template Two',
+                  version: '1.0',
+                  effectiveDate: '2024-09-04T17:17:49.871Z',
+                },
+              },
+            },
+          },
+          certifiedBy: {
+            create: {
+              email: 'user2@example.com',
+              name: 'User Two',
+              role: 'USDR_ADMIN',
+              agency: { create: { name: 'Agency Two', code: 'A2' } },
+            },
+          },
+        },
+      },
+    },
+  })
+
+export type StandardScenario = ScenarioData<
+  ReportingPeriodCertification,
+  'reportingPeriodCertification'
+>

--- a/api/src/services/reportingPeriodCertifications/reportingPeriodCertifications.test.ts
+++ b/api/src/services/reportingPeriodCertifications/reportingPeriodCertifications.test.ts
@@ -1,0 +1,118 @@
+import type { ReportingPeriodCertification } from '@prisma/client'
+
+import { db } from 'src/lib/db'
+
+import {
+  reportingPeriodCertifications,
+  reportingPeriodCertification,
+  createReportingPeriodCertification,
+  updateReportingPeriodCertification,
+  deleteReportingPeriodCertification,
+} from './reportingPeriodCertifications'
+import type { StandardScenario } from './reportingPeriodCertifications.scenarios'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float.
+//           Please refer to the RedwoodJS Testing Docs:
+//       https://redwoodjs.com/docs/testing#testing-services
+// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+
+describe('reportingPeriodCertifications', () => {
+  scenario(
+    'returns all reportingPeriodCertifications',
+    async (scenario: StandardScenario) => {
+      const result = await reportingPeriodCertifications()
+
+      expect(result.length).toEqual(
+        Object.keys(scenario.reportingPeriodCertification).length
+      )
+    }
+  )
+
+  scenario(
+    'returns a single reportingPeriodCertification',
+    async (scenario: StandardScenario) => {
+      const result = await reportingPeriodCertification({
+        id: scenario.reportingPeriodCertification.one.id,
+      })
+
+      expect(result).toEqual(scenario.reportingPeriodCertification.one)
+    }
+  )
+
+  scenario(
+    'creates a reportingPeriodCertification',
+    async (scenario: StandardScenario) => {
+      // Create a new organization and reporting period for this test
+      const newOrg = await db.organization.create({ data: { name: 'New Org' } })
+      const newReportingPeriod = await db.reportingPeriod.create({
+        data: {
+          name: 'New Period',
+          startDate: new Date(),
+          endDate: new Date(),
+          inputTemplate: {
+            create: {
+              name: 'New Input Template',
+              version: '1.0',
+              effectiveDate: new Date(),
+            },
+          },
+          outputTemplate: {
+            create: {
+              name: 'New Output Template',
+              version: '1.0',
+              effectiveDate: new Date(),
+            },
+          },
+        },
+      })
+
+      const result = await createReportingPeriodCertification({
+        input: {
+          organizationId: newOrg.id,
+          reportingPeriodId: newReportingPeriod.id,
+          certifiedById:
+            scenario.reportingPeriodCertification.one.certifiedById,
+        },
+      })
+
+      expect(result.organizationId).toEqual(newOrg.id)
+      expect(result.reportingPeriodId).toEqual(newReportingPeriod.id)
+      expect(result.certifiedById).toEqual(
+        scenario.reportingPeriodCertification.one.certifiedById
+      )
+    }
+  )
+
+  scenario(
+    'updates a reportingPeriodCertification',
+    async (scenario: StandardScenario) => {
+      const original = (await reportingPeriodCertification({
+        id: scenario.reportingPeriodCertification.one.id,
+      })) as ReportingPeriodCertification
+      const result = await updateReportingPeriodCertification({
+        id: original.id,
+        input: {
+          organizationId:
+            scenario.reportingPeriodCertification.two.organizationId,
+        },
+      })
+
+      expect(result.organizationId).toEqual(
+        scenario.reportingPeriodCertification.two.organizationId
+      )
+    }
+  )
+
+  scenario(
+    'deletes a reportingPeriodCertification',
+    async (scenario: StandardScenario) => {
+      const original = (await deleteReportingPeriodCertification({
+        id: scenario.reportingPeriodCertification.one.id,
+      })) as ReportingPeriodCertification
+      const result = await reportingPeriodCertification({ id: original.id })
+
+      expect(result).toEqual(null)
+    }
+  )
+})

--- a/api/src/services/reportingPeriodCertifications/reportingPeriodCertifications.ts
+++ b/api/src/services/reportingPeriodCertifications/reportingPeriodCertifications.ts
@@ -1,0 +1,37 @@
+import type { QueryResolvers, MutationResolvers } from 'types/graphql'
+
+import { db } from 'src/lib/db'
+
+export const reportingPeriodCertifications: QueryResolvers['reportingPeriodCertifications'] =
+  () => {
+    return db.reportingPeriodCertification.findMany()
+  }
+
+export const reportingPeriodCertification: QueryResolvers['reportingPeriodCertification'] =
+  ({ id }) => {
+    return db.reportingPeriodCertification.findUnique({
+      where: { id },
+    })
+  }
+
+export const createReportingPeriodCertification: MutationResolvers['createReportingPeriodCertification'] =
+  ({ input }) => {
+    return db.reportingPeriodCertification.create({
+      data: input,
+    })
+  }
+
+export const updateReportingPeriodCertification: MutationResolvers['updateReportingPeriodCertification'] =
+  ({ id, input }) => {
+    return db.reportingPeriodCertification.update({
+      data: input,
+      where: { id },
+    })
+  }
+
+export const deleteReportingPeriodCertification: MutationResolvers['deleteReportingPeriodCertification'] =
+  ({ id }) => {
+    return db.reportingPeriodCertification.delete({
+      where: { id },
+    })
+  }

--- a/api/src/services/reportingPeriods/reportingPeriods.ts
+++ b/api/src/services/reportingPeriods/reportingPeriods.ts
@@ -122,4 +122,9 @@ export const ReportingPeriod: ReportingPeriodRelationResolvers = {
       .findUnique({ where: { id: root?.id } })
       .outputTemplate()
   },
+  certifications: (_obj, { root }) => {
+    return db.reportingPeriod
+      .findUnique({ where: { id: root?.id } })
+      .certifications()
+  },
 }

--- a/api/src/services/users/users.test.ts
+++ b/api/src/services/users/users.test.ts
@@ -354,7 +354,9 @@ describe('user writes', () => {
         roles: ['USDR_ADMIN'],
       })
       await deleteUser({ id: scenario.user.one.id })
-      expect(mockPassageUser.delete).toHaveBeenCalledWith(scenario.user.one.passageId)
+      expect(mockPassageUser.delete).toHaveBeenCalledWith(
+        scenario.user.one.passageId
+      )
     })
   })
 })

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -373,4 +373,9 @@ export const User: UserRelationResolvers = {
   uploaded: (_obj, { root }) => {
     return db.user.findUnique({ where: { id: root?.id } }).uploaded()
   },
+  certifiedReportingPeriods: (_obj, { root }) => {
+    return db.user
+      .findUnique({ where: { id: root?.id } })
+      .certifiedReportingPeriods()
+  },
 }


### PR DESCRIPTION
## Ticket #408

## Changes
- Adds `ReportingPeriodCertification` model with a unique constraint on the combination of `organizationId` and `reportingPeriodId`
- Creates a database migration for the new model
- Adds `reportingPeriodCertifications` service, GraphQL schema, and associated tests
- Updates existing services and GraphQL schemas to include relations to reporting period certifications

## Details

### New Model: ReportingPeriodCertification
Added a new model in `schema.prisma`:
```prisma
model ReportingPeriodCertification {
  id                 Int             @id @default(autoincrement())
  organizationId     Int
  organization       Organization    @relation(fields: [organizationId], references: [id])
  reportingPeriodId  Int
  reportingPeriod    ReportingPeriod @relation(fields: [reportingPeriodId], references: [id])
  certifiedById      Int
  certifiedBy        User            @relation(fields: [certifiedById], references: [id])
  createdAt          DateTime        @default(now()) @db.Timestamptz(6)
  updatedAt          DateTime        @default(now()) @db.Timestamptz(6) @updatedAt

  @@unique([organizationId, reportingPeriodId])
}
```

### New Service and GraphQL Schema
- Created `reportingPeriodCertifications.ts` service file with CRUD operations
- Added `reportingPeriodCertifications.sdl.ts` GraphQL schema file
- Implemented test file `reportingPeriodCertifications.test.ts`
- Added scenario file `reportingPeriodCertifications.scenarios.ts`

### Updates to Existing Services and Schemas
- Updated `organizations.sdl.ts`, `reportingPeriods.sdl.ts`, and `users.sdl.ts` to include the new relations
- Modified corresponding service files to implement the new relations