### PR TITLE
fix: ensure that when files are missing in s3 the client receives a 404 instead of a 403

### DIFF
--- a/terraform/treasury_generation_lambda_functions.tf
+++ b/terraform/treasury_generation_lambda_functions.tf
@@ -21,6 +21,17 @@ module "lambda_function-subrecipientTreasuryReportGen" {
   policy_jsons                      = local.lambda_default_execution_policies
   attach_policy_statements          = true
   policy_statements = {
+    AllowListSubrecipientData = {
+      effect = "Allow"
+      actions = [
+        "s3:ListBucket"
+      ]
+      resources = [
+        # This allows the function to check whether subrecipient data-file exists in the path.
+        # Path: /{organization_id}/{reporting_period_id}/*
+        "${module.reporting_data_bucket.bucket_arn}/*/*/*",
+      ]
+    }
     AllowDownloadSubrecipientsFile = {
       effect = "Allow"
       actions = [

--- a/terraform/treasury_generation_lambda_functions.tf
+++ b/terraform/treasury_generation_lambda_functions.tf
@@ -166,6 +166,17 @@ module "lambda_function-treasuryProjectFileGeneration" {
         "${module.reporting_data_bucket.bucket_arn}/treasuryreports/output-templates/*/*.xlsx",
       ]
     }
+    AllowListReportObjects = {
+      effect = "Allow"
+      actions = [
+        "s3:ListBucket"
+      ]
+      resources = [
+        # This allows the function to check whether objects exist in the path.
+        # Path: treasuryreports/{organization_id}/{reporting_period_id}/*
+        "${module.reporting_data_bucket.bucket_arn}/treasuryreports/*/*/*",
+      ]
+    }
     AllowUploadCSVReport = {
       effect = "Allow"
       actions = [
@@ -258,6 +269,16 @@ module "lambda_function-cpfCreateArchive" {
   policy_jsons                      = local.lambda_default_execution_policies
   attach_policy_statements          = true
   policy_statements = {
+    AllowListReportObjects = {
+      effect = "Allow"
+      actions = [
+        "s3:ListBucket"
+      ]
+      resources = [
+        # Path: treasuryreports/{organization_id}/{reporting_period_id}/*
+        "${module.reporting_data_bucket.bucket_arn}/treasuryreports/*/*/*",
+      ]
+    }
     AllowDownloadExcelObjects = {
       effect = "Allow"
       actions = [


### PR DESCRIPTION
Currently when the various lambda functions are attempting to retrieve non-existent files from s3, the client receives a 403-permission denied. This is because when files do not exist and the client does not have listObject permissions, then s3 will default to a permissions error.

Ideally we would like the functionality to fail gracefully with a 404 object not found for which the business-logic has mechanism to work around.

This PR ensures that the various lambda functions have the correct `listObject` permissions.