### PR TITLE
fix: ensure object-path is defined as a condition and not on the resource-name

### DIFF
--- a/terraform/treasury_generation_lambda_functions.tf
+++ b/terraform/treasury_generation_lambda_functions.tf
@@ -29,11 +29,11 @@ module "lambda_function-subrecipientTreasuryReportGen" {
       resources = [
         "${module.reporting_data_bucket.bucket_arn}",
       ]
+      # Path: /{organization_id}/{reporting_period_id}/*
       condition = {
-        StringEquals = {
-          # Path: /{organization_id}/{reporting_period_id}/*
-          "s3:prefix" = "*/*/*"
-        }
+        test = "StringLike"
+        variable = "s3:prefix"
+        values = "*/*/*"
       }
     }
     AllowDownloadSubrecipientsFile = {
@@ -189,11 +189,11 @@ module "lambda_function-treasuryProjectFileGeneration" {
       resources = [
         "${module.reporting_data_bucket.bucket_arn}",
       ]
+      # Path: treasuryreports/{organization_id}/{reporting_period_id}/*
       condition = {
-        StringEquals = {
-          # Path: treasuryreports/{organization_id}/{reporting_period_id}/*
-          "s3:prefix" = "treasuryreports/*/*/*"
-        }
+        test = "StringLike"
+        variable = "s3:prefix"
+        values = "treasuryreports/*/*/*"
       }
     }
     AllowUploadCSVReport = {
@@ -296,6 +296,7 @@ module "lambda_function-cpfCreateArchive" {
       resources = [
         "${module.reporting_data_bucket.bucket_arn}",
       ]
+      # Path: treasuryreports/{organization_id}/{reporting_period_id}/*
       condition = {
         test = "StringLike"
         variable = "s3:prefix"

--- a/terraform/treasury_generation_lambda_functions.tf
+++ b/terraform/treasury_generation_lambda_functions.tf
@@ -31,9 +31,9 @@ module "lambda_function-subrecipientTreasuryReportGen" {
       ]
       # Path: /{organization_id}/{reporting_period_id}/*
       condition = {
-        test = "StringLike"
+        test     = "StringLike"
         variable = "s3:prefix"
-        values = "*/*/*"
+        values   = "*/*/*"
       }
     }
     AllowDownloadSubrecipientsFile = {
@@ -191,9 +191,9 @@ module "lambda_function-treasuryProjectFileGeneration" {
       ]
       # Path: treasuryreports/{organization_id}/{reporting_period_id}/*
       condition = {
-        test = "StringLike"
+        test     = "StringLike"
         variable = "s3:prefix"
-        values = "treasuryreports/*/*/*"
+        values   = "treasuryreports/*/*/*"
       }
     }
     AllowUploadCSVReport = {
@@ -298,9 +298,9 @@ module "lambda_function-cpfCreateArchive" {
       ]
       # Path: treasuryreports/{organization_id}/{reporting_period_id}/*
       condition = {
-        test = "StringLike"
+        test     = "StringLike"
         variable = "s3:prefix"
-        values = "treasuryreports/*/*/*"
+        values   = "treasuryreports/*/*/*"
       }
     }
     AllowDownloadExcelObjects = {

--- a/terraform/treasury_generation_lambda_functions.tf
+++ b/terraform/treasury_generation_lambda_functions.tf
@@ -34,7 +34,7 @@ module "lambda_function-subrecipientTreasuryReportGen" {
         string_like_condition = {
           test     = "StringLike"
           variable = "s3:prefix"
-          values   = "*/*/*"
+          values   = ["*/*/*"]
         }
       }
     }
@@ -196,7 +196,7 @@ module "lambda_function-treasuryProjectFileGeneration" {
         string_like_condition = {
           test     = "StringLike"
           variable = "s3:prefix"
-          values   = "treasuryreports/*/*/*"
+          values   = ["treasuryreports/*/*/*"]
         }
       }
     }
@@ -305,7 +305,7 @@ module "lambda_function-cpfCreateArchive" {
         string_like_condition = {
           test     = "StringLike"
           variable = "s3:prefix"
-          values   = "treasuryreports/*/*/*"
+          values   = ["treasuryreports/*/*/*"]
         }
       }
     }

--- a/terraform/treasury_generation_lambda_functions.tf
+++ b/terraform/treasury_generation_lambda_functions.tf
@@ -27,10 +27,14 @@ module "lambda_function-subrecipientTreasuryReportGen" {
         "s3:ListBucket"
       ]
       resources = [
-        # This allows the function to check whether subrecipient data-file exists in the path.
-        # Path: /{organization_id}/{reporting_period_id}/*
-        "${module.reporting_data_bucket.bucket_arn}/*/*/*",
+        "${module.reporting_data_bucket.bucket_arn}",
       ]
+      condition = {
+        StringEquals = {
+          # Path: /{organization_id}/{reporting_period_id}/*
+          "s3:prefix" = "*/*/*"
+        }
+      }
     }
     AllowDownloadSubrecipientsFile = {
       effect = "Allow"
@@ -183,10 +187,14 @@ module "lambda_function-treasuryProjectFileGeneration" {
         "s3:ListBucket"
       ]
       resources = [
-        # This allows the function to check whether objects exist in the path.
-        # Path: treasuryreports/{organization_id}/{reporting_period_id}/*
-        "${module.reporting_data_bucket.bucket_arn}/treasuryreports/*/*/*",
+        "${module.reporting_data_bucket.bucket_arn}",
       ]
+      condition = {
+        StringEquals = {
+          # Path: treasuryreports/{organization_id}/{reporting_period_id}/*
+          "s3:prefix" = "treasuryreports/*/*/*"
+        }
+      }
     }
     AllowUploadCSVReport = {
       effect = "Allow"
@@ -286,9 +294,14 @@ module "lambda_function-cpfCreateArchive" {
         "s3:ListBucket"
       ]
       resources = [
-        # Path: treasuryreports/{organization_id}/{reporting_period_id}/*
-        "${module.reporting_data_bucket.bucket_arn}/treasuryreports/*/*/*",
+        "${module.reporting_data_bucket.bucket_arn}",
       ]
+      condition = {
+        StringEquals = {
+          # Path: treasuryreports/{organization_id}/{reporting_period_id}/*
+          "s3:prefix" = "treasuryreports/*/*/*"
+        }
+      }
     }
     AllowDownloadExcelObjects = {
       effect = "Allow"

--- a/terraform/treasury_generation_lambda_functions.tf
+++ b/terraform/treasury_generation_lambda_functions.tf
@@ -297,10 +297,9 @@ module "lambda_function-cpfCreateArchive" {
         "${module.reporting_data_bucket.bucket_arn}",
       ]
       condition = {
-        StringEquals = {
-          # Path: treasuryreports/{organization_id}/{reporting_period_id}/*
-          "s3:prefix" = "treasuryreports/*/*/*"
-        }
+        test = "StringLike"
+        variable = "s3:prefix"
+        values = "treasuryreports/*/*/*"
       }
     }
     AllowDownloadExcelObjects = {

--- a/terraform/treasury_generation_lambda_functions.tf
+++ b/terraform/treasury_generation_lambda_functions.tf
@@ -31,9 +31,11 @@ module "lambda_function-subrecipientTreasuryReportGen" {
       ]
       # Path: /{organization_id}/{reporting_period_id}/*
       condition = {
-        test     = "StringLike"
-        variable = "s3:prefix"
-        values   = "*/*/*"
+        string_like_condition = {
+          test     = "StringLike"
+          variable = "s3:prefix"
+          values   = "*/*/*"
+        }
       }
     }
     AllowDownloadSubrecipientsFile = {
@@ -191,9 +193,11 @@ module "lambda_function-treasuryProjectFileGeneration" {
       ]
       # Path: treasuryreports/{organization_id}/{reporting_period_id}/*
       condition = {
-        test     = "StringLike"
-        variable = "s3:prefix"
-        values   = "treasuryreports/*/*/*"
+        string_like_condition = {
+          test     = "StringLike"
+          variable = "s3:prefix"
+          values   = "treasuryreports/*/*/*"
+        }
       }
     }
     AllowUploadCSVReport = {
@@ -298,9 +302,11 @@ module "lambda_function-cpfCreateArchive" {
       ]
       # Path: treasuryreports/{organization_id}/{reporting_period_id}/*
       condition = {
-        test     = "StringLike"
-        variable = "s3:prefix"
-        values   = "treasuryreports/*/*/*"
+        string_like_condition = {
+          test     = "StringLike"
+          variable = "s3:prefix"
+          values   = "treasuryreports/*/*/*"
+        }
       }
     }
     AllowDownloadExcelObjects = {


### PR DESCRIPTION
We are continuing to see 403 errors on the treasury report generation similar to [this](https://app.datadoghq.com/logs?query=service%3Acpf-reporter&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZHEsFz7yNzgHAAAAAAAAAAYAAAAAEFaSEVzRjdUQUFCbjFXUC1WUFFvLVFBQwAAACQAAAAAMDE5MWM0YjAtNzdlNi00NjZmLWIyNDQtYmNiM2JhMjY1MzA0&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1725578260233&to_ts=1725581860233&live=true)

The reason for this is that the `ListBucket` operation must be defined on a resource-name rather than a resource-name plus path. In order to define the specific path, I need to add it as a condition.

I was able to test this working in my personal AWS account so feel much more confident about this change resolving these issues.