### PR TITLE
fix: updates code to 404 rather than NoSuchKey

### DIFF
--- a/python/src/functions/subrecipient_treasury_report_gen.py
+++ b/python/src/functions/subrecipient_treasury_report_gen.py
@@ -103,7 +103,7 @@ def process_event(
                 )
             except ClientError as e:
                 error = e.response.get("Error") or {}
-                if error.get("Code") == "NoSuchKey":
+                if error.get("Code") == "404":
                     logger.info(
                         f"No subrecipients for organization {organization_id} and reporting period {reporting_period_id}"
                     )

--- a/python/src/lib/s3_helper.py
+++ b/python/src/lib/s3_helper.py
@@ -1,8 +1,9 @@
-from botocore.exceptions import ClientError
-from mypy_boto3_s3.client import S3Client
+import tempfile
 from typing import IO, Optional, Union
 from urllib.parse import unquote_plus
-import tempfile
+
+from botocore.exceptions import ClientError
+from mypy_boto3_s3.client import S3Client
 
 from src.lib.logging import get_logger
 
@@ -67,11 +68,11 @@ def get_presigned_url(
     logger = get_logger()
     try:
         response = s3_client.head_object(
-            bucket = bucket,
-            key = key,
+            Bucket=bucket,
+            Key=key,
         )
-    except ClientError as e:
-        logger.error(e)
+    except ClientError:
+        logger.exception(f"Unable to retrieve head object for key: {key}")
         return None
 
     try:
@@ -83,8 +84,8 @@ def get_presigned_url(
             },
             ExpiresIn=expiration_time
         )
-    except ClientError as e:
-        logger.error(e)
+    except ClientError:
+        logger.exception(f"Unable to retrieve presigned URL for key: {key}")
         return None
     
     return response

--- a/python/src/lib/treasury_generation_common.py
+++ b/python/src/lib/treasury_generation_common.py
@@ -61,7 +61,7 @@ def get_output_template(
         )
     except ClientError as e:
         error = e.response.get("Error") or {}
-        if error.get("Code") == "NoSuchKey":
+        if error.get("Code") == "404":
             logger.exception(
                 f"Cannot find any output template with ID: {output_template_id} and project: {project}"
             )


### PR DESCRIPTION
I initially expected `boto3` `ClientError` to have a `NoSuchKey` as part of the error-response. However, it appears that the code is "404" instead.

## Test Instructions

- Save the following code in a new file `s3_test.py`
- Run `python3 s3_test.py`
- Expect to see results with the following error message:
```
2024-09-17 07:54:42 [error    ] {'Code': '404', 'Message': 'Not Found'}
2024-09-17 07:54:42 [error    ] Expected to find an upload with key: foo/bar.txt
```


```py
from botocore.exceptions import ClientError
from mypy_boto3_s3.client import S3Client
from typing import IO, Optional, Union
from urllib.parse import unquote_plus
import tempfile
import structlog

import boto3
def get_logger(*args, **kwargs) -> structlog.stdlib.BoundLogger:
    return structlog.get_logger(*args, **kwargs)

def download_s3_object(client: S3Client, bucket: str, key: str, destination: IO[bytes]):
    """Downloads an S3 object to a local file.

    Args:
        client: Client facilitating download from S3
        bucket: Name of the S3 bucket containing the file
        key: S3 object key for the file to download
        destination: File-like object (in binary mode) where the S3 object will be written
    """
    logger = get_logger()
    logger.debug("downloading file from s3")

    try:
        client.download_fileobj(bucket, unquote_plus(key), destination)
    except:
        logger.exception("failed to download file from S3")
        raise


s3_client: S3Client = boto3.client("s3", endpoint_url='http://localhost:4566')
logger = get_logger()

with tempfile.NamedTemporaryFile() as output_file:
    # try:
    #     s3_client.head_object(Bucket='sample-bucket', Key=unquote_plus('foo/bar.txt'))
    # except Exception as e:
    #     pass
    try:
        download_s3_object(s3_client, 'sample-bucket', 'foo/bar.txt', output_file)
    except Exception as e:
        logger.error(e)
        logger.error(dir(e))
        error = e.response.get("Error") or {}
        logger.error(error)
        if error.get("Code") == "404":
            logger.exception(
                f"Expected to find an upload with key: foo/bar.txt"
            )
        else:
            raise
```