### PR TITLE
CPF-447 Subrecipient upload links redirect to upload detail

### DIFF
--- a/web/src/components/Subrecipient/SubrecipientTableUploadLinksDisplay/SubrecipientTableUploadLinksDisplay.tsx
+++ b/web/src/components/Subrecipient/SubrecipientTableUploadLinksDisplay/SubrecipientTableUploadLinksDisplay.tsx
@@ -1,12 +1,6 @@
 import { Subrecipient } from 'types/graphql'
 
-import { useMutation } from '@redwoodjs/web'
-
-const DOWNLOAD_UPLOAD_FILE = gql`
-  mutation downloadUploadFile($id: Int!) {
-    downloadUploadFile(id: $id)
-  }
-`
+import { Link, routes } from '@redwoodjs/router'
 
 interface SubrecipientTableUploadLinksDisplayProps {
   validSubrecipientUploads: Subrecipient['validSubrecipientUploads']
@@ -17,18 +11,16 @@ const SubrecipientTableUploadLinksDisplay = ({
   validSubrecipientUploads,
   invalidSubrecipientUploads,
 }: SubrecipientTableUploadLinksDisplayProps) => {
-  const [downloadUploadFile] = useMutation(DOWNLOAD_UPLOAD_FILE, {
-    onCompleted: ({ downloadUploadFile }) => {
-      window.open(downloadUploadFile, '_blank').focus()
-    },
-    onError: (error) => {
-      console.error('Error downloading upload file', error)
-    },
-  })
-
-  const handleFileDownload = (id: number) => {
-    downloadUploadFile({ variables: { id } })
-  }
+  const renderUploadLink = (upload) => (
+    <Link
+      key={upload.id}
+      to={routes.upload({ id: upload.upload.id })}
+      title={`Show upload ${upload.upload.id} detail`}
+      className="link-underline link-underline-opacity-0"
+    >
+      Upload {upload.id}
+    </Link>
+  )
 
   return (
     <>
@@ -37,15 +29,7 @@ const SubrecipientTableUploadLinksDisplay = ({
           <>
             <div className="fw-bold">Latest Valid Upload:</div>
             <div className="mb-3">
-              <button
-                onClick={() =>
-                  handleFileDownload(validSubrecipientUploads[0].upload.id)
-                }
-                title={`Download upload ${validSubrecipientUploads[0].upload.id}`}
-                className="btn btn-link p-0"
-              >
-                {validSubrecipientUploads[0].upload.filename}.xlsm
-              </button>
+              {renderUploadLink(validSubrecipientUploads[0]).upload}
             </div>
           </>
         )}
@@ -54,15 +38,9 @@ const SubrecipientTableUploadLinksDisplay = ({
         <>
           <div className="fw-bold">Other Valid Uploads:</div>
           <div className="mb-3">
-            {validSubrecipientUploads.slice(1).map((upload) => (
-              <button
-                key={upload.id}
-                onClick={() => handleFileDownload(upload.upload.id)}
-                className="btn btn-link p-0"
-              >
-                {upload.upload.filename}.xlsm
-              </button>
-            ))}
+            {validSubrecipientUploads
+              .slice(1)
+              .map((upload) => renderUploadLink(upload))}
           </div>
         </>
       )}
@@ -71,15 +49,9 @@ const SubrecipientTableUploadLinksDisplay = ({
         <>
           <div className="fw-bold">Invalid Uploads:</div>
           <div>
-            {invalidSubrecipientUploads.map((upload) => (
-              <button
-                key={upload.id}
-                onClick={() => handleFileDownload(upload.upload.id)}
-                className="btn btn-link p-0"
-              >
-                {upload.upload.filename}.xlsm
-              </button>
-            ))}
+            {invalidSubrecipientUploads.map((upload) =>
+              renderUploadLink(upload)
+            )}
           </div>
         </>
       )}

--- a/web/src/components/Subrecipient/SubrecipientTableUploadLinksDisplay/SubrecipientTableUploadLinksDisplay.tsx
+++ b/web/src/components/Subrecipient/SubrecipientTableUploadLinksDisplay/SubrecipientTableUploadLinksDisplay.tsx
@@ -2,6 +2,10 @@ import { Subrecipient } from 'types/graphql'
 
 import { Link, routes } from '@redwoodjs/router'
 
+type SubrecipientUpload =
+  | Subrecipient['validSubrecipientUploads'][number]
+  | Subrecipient['invalidSubrecipientUploads'][number]
+
 interface SubrecipientTableUploadLinksDisplayProps {
   validSubrecipientUploads: Subrecipient['validSubrecipientUploads']
   invalidSubrecipientUploads: Subrecipient['invalidSubrecipientUploads']
@@ -11,50 +15,43 @@ const SubrecipientTableUploadLinksDisplay = ({
   validSubrecipientUploads,
   invalidSubrecipientUploads,
 }: SubrecipientTableUploadLinksDisplayProps) => {
-  const renderUploadLink = (upload) => (
-    <Link
-      key={upload.id}
-      to={routes.upload({ id: upload.upload.id })}
-      title={`Show upload ${upload.upload.id} detail`}
-      className="link-underline link-underline-opacity-0"
-    >
-      Upload {upload.id}
-    </Link>
+  const renderUploadLink = (subrecipientUpload: SubrecipientUpload) => {
+    const { id, upload } = subrecipientUpload
+    return (
+      <Link
+        key={id}
+        to={routes.upload({ id: upload.id })}
+        title={`Show upload ${upload.id} detail`}
+        className="d-block link-underline link-underline-opacity-0"
+      >
+        Upload {upload.id}
+      </Link>
+    )
+  }
+
+  const renderUploadSection = (
+    title: string,
+    uploads: SubrecipientUpload[]
+  ) => (
+    <>
+      <div className="fw-bold">{title}</div>
+      <div className="mb-3">{uploads.map(renderUploadLink)}</div>
+    </>
   )
 
   return (
     <>
       {validSubrecipientUploads.length > 0 &&
-        validSubrecipientUploads[0].upload && (
-          <>
-            <div className="fw-bold">Latest Valid Upload:</div>
-            <div className="mb-3">
-              {renderUploadLink(validSubrecipientUploads[0]).upload}
-            </div>
-          </>
+        renderUploadSection('Latest Valid Upload:', [
+          validSubrecipientUploads[0],
+        ])}
+      {validSubrecipientUploads.length > 1 &&
+        renderUploadSection(
+          'Other Valid Uploads:',
+          validSubrecipientUploads.slice(1)
         )}
-
-      {validSubrecipientUploads.length > 1 && (
-        <>
-          <div className="fw-bold">Other Valid Uploads:</div>
-          <div className="mb-3">
-            {validSubrecipientUploads
-              .slice(1)
-              .map((upload) => renderUploadLink(upload))}
-          </div>
-        </>
-      )}
-
-      {invalidSubrecipientUploads.length > 0 && (
-        <>
-          <div className="fw-bold">Invalid Uploads:</div>
-          <div>
-            {invalidSubrecipientUploads.map((upload) =>
-              renderUploadLink(upload)
-            )}
-          </div>
-        </>
-      )}
+      {invalidSubrecipientUploads.length > 0 &&
+        renderUploadSection('Invalid Uploads:', invalidSubrecipientUploads)}
     </>
   )
 }

--- a/web/src/components/Subrecipient/SubrecipientsCell/SubrecipientsCell.tsx
+++ b/web/src/components/Subrecipient/SubrecipientsCell/SubrecipientsCell.tsx
@@ -28,7 +28,6 @@ export const QUERY = gql`
         }
         upload {
           id
-          filename
         }
         createdAt
         updatedAt
@@ -37,7 +36,6 @@ export const QUERY = gql`
         id
         upload {
           id
-          filename
         }
         createdAt
         updatedAt


### PR DESCRIPTION
# Ticket #447 

# Overview
- Changed subrecipient upload links to lead to upload detail page (previously triggered download)
- Upload links now display "Upload {upload.id}" instead of "{upload.name}"

<img width="1509" alt="upload-link-redirect" src="https://github.com/user-attachments/assets/e1a79c6a-8082-44e9-ac9b-04295fd9590e">
