### PR TITLE
Fix: Error related to saving subrecipients for treasury-report generation

### DIFF
--- a/api/src/functions/processValidationJson/processValidationJson.ts
+++ b/api/src/functions/processValidationJson/processValidationJson.ts
@@ -223,7 +223,7 @@ export const processRecord = async (
       }
 
       try {
-        const subrecipientKey = `treasuryreports/${organizationId}/${reportingPeriod.id}/subrecipients`
+        const subrecipientKey = `treasuryreports/${organizationId}/${reportingPeriod.id}/subrecipients.json`
         const { startDate, endDate } = reportingPeriod
         const subrecipientsWithUploads = await db.subrecipient.findMany({
           where: { createdAt: { lte: endDate, gte: startDate } },

--- a/python/src/functions/subrecipient_treasury_report_gen.py
+++ b/python/src/functions/subrecipient_treasury_report_gen.py
@@ -98,7 +98,7 @@ def process_event(
                 download_s3_object(
                     client=s3_client,
                     bucket=os.environ["REPORTING_DATA_BUCKET_NAME"],
-                    key=f"treasuryreports/{organization_id}/{reporting_period_id}/subrecipients",
+                    key=f"treasuryreports/{organization_id}/{reporting_period_id}/subrecipients.json",
                     destination=recent_subrecipients_file,
                 )
             except ClientError as e:
@@ -224,7 +224,7 @@ def upload_workbook(
     Handles upload of workbook to S3, both in xlsx and csv formats
     """
 
-    with tempfile.NamedTemporaryFile("w") as new_xlsx_file:
+    with tempfile.NamedTemporaryFile("rb+") as new_xlsx_file:
         workbook.save(new_xlsx_file.name)
         upload_generated_file_to_s3(
             s3client,
@@ -237,7 +237,7 @@ def upload_workbook(
             new_xlsx_file,
         )
 
-    with tempfile.NamedTemporaryFile("w") as new_csv_file:
+    with tempfile.NamedTemporaryFile("r+") as new_csv_file:
         convert_xlsx_to_csv(
             new_csv_file,
             workbook,

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -438,6 +438,17 @@ module "lambda_function-processValidationJson" {
         "${module.reporting_data_bucket.bucket_arn}/uploads/*/*/*/*/*.json",
       ]
     }
+    AllowUploadSubrecipientsFile = {
+      effect = "Allow"
+      actions = [
+        "s3:PutObject",
+      ]
+      resources = [
+        # These are temporary files shared across services containing subrecipient data.
+        # Path: treasuryreports/{organization_id}/{reporting_period_id}/subrecipients.json
+        "${module.reporting_data_bucket.bucket_arn}/treasuryreports/*/*/subrecipients.json",
+      ]
+    }
   }
 
   // Artifacts

--- a/terraform/treasury_generation_lambda_functions.tf
+++ b/terraform/treasury_generation_lambda_functions.tf
@@ -46,8 +46,8 @@ module "lambda_function-subrecipientTreasuryReportGen" {
       ]
       resources = [
         # These are temporary files shared across services containing subrecipient data.
-        # Path: /{organization_id}/{reporting_period_id}/subrecipients
-        "${module.reporting_data_bucket.bucket_arn}/*/*/subrecipients",
+        # Path: treasuryreports/{organization_id}/{reporting_period_id}/subrecipients.json
+        "${module.reporting_data_bucket.bucket_arn}/treasuryreports/*/*/subrecipients.json",
       ]
     }
     AllowDownloadTreasuryOutputTemplates = {


### PR DESCRIPTION
This PR fixes the following [datadog error](https://app.datadoghq.com/logs?query=host%3A169.254.121.205%20service%3Acpf-reporter%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&context_event=AZI0koHZAAAmlwrO7PZWPwAI&event=AgAAAZI0koBV8E6WUwAAAAAAAAAYAAAAAEFaSTBrb0haQUFBbWx3ck83UFpXUHdBSQAAACQAAAAAMDE5MjM0OWQtODM1OC00MzY4LTljZTktYjNhMWFiOTdiMTA1&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&to_event=AgAAAZI0koBZ8E6WVAAAAAAAAAAYAAAAAEFaSTBrb0haQUFBbWx3ck83UFpXUHdBSgAAACQAAAAAMDE5MjM0OWQtODM1OC00MzY4LTljZTktYjNhMWFiOTdiMTA1&viz=&from_ts=1727458569333&to_ts=1727458869338&live=false)
```
Error saving subrecipients JSON file to S3: AccessDenied: User: arn:aws:sts::357150818708:assumed-role/cpfreporter-processValidationJson/cpfreporter-processValidationJson is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::cpfreporter-reportingdata-357150818708-us-west-2/treasuryreports/2/2/subrecipients" because no identity-based policy allows the s3:PutObject action
```