### PR TITLE
fix: ensure CSV and JSON files are written as text but read as binary for s3 upload

### DIFF
--- a/python/src/functions/generate_treasury_report.py
+++ b/python/src/functions/generate_treasury_report.py
@@ -230,7 +230,7 @@ def process_event(payload: ProjectLambdaPayload, logger: structlog.stdlib.BoundL
             )
         # Output CSV file for treasury
         with tempfile.NamedTemporaryFile(
-            mode="r+t", encoding="utf-8", delete_on_close=False
+            mode="wt", encoding="utf-8", delete_on_close=False
         ) as csv_file:
             convert_xlsx_to_csv(csv_file, output_workbook, highest_row_num)
             csv_file.close()
@@ -247,7 +247,7 @@ def process_event(payload: ProjectLambdaPayload, logger: structlog.stdlib.BoundL
                 )
         # Store project_id_agency_id to row number in a json file
         with tempfile.NamedTemporaryFile(
-            "r+t", encoding="utf-8", delete_on_close=False
+            "wt", encoding="utf-8", delete_on_close=False
         ) as json_file:
             json.dump(project_agency_id_to_row_map, fp=json_file)
             json_file.close()

--- a/python/src/functions/subrecipient_treasury_report_gen.py
+++ b/python/src/functions/subrecipient_treasury_report_gen.py
@@ -237,7 +237,9 @@ def upload_workbook(
             new_xlsx_file,
         )
 
-    with tempfile.NamedTemporaryFile("r+") as new_csv_file:
+    with tempfile.NamedTemporaryFile(
+        mode="r+t", encoding="utf-8", delete_on_close=False
+    ) as new_csv_file:
         convert_xlsx_to_csv(
             new_csv_file,
             workbook,
@@ -245,13 +247,16 @@ def upload_workbook(
                 workbook[WORKSHEET_NAME], FIRST_BLANK_ROW_NUM, FIRST_DATA_COLUMN
             ),
         )
-        upload_generated_file_to_s3(
-            s3client,
-            os.environ["REPORTING_DATA_BUCKET_NAME"],
-            get_generated_output_file_key(
-                file_type=OutputFileType.CSV,
-                project="Subrecipient",
-                organization=organization,
-            ),
-            new_csv_file,
-        )
+        new_csv_file.close()
+
+        with open(new_csv_file.name, mode="rb") as binary_csv_file:
+            upload_generated_file_to_s3(
+                s3client,
+                os.environ["REPORTING_DATA_BUCKET_NAME"],
+                get_generated_output_file_key(
+                    file_type=OutputFileType.CSV,
+                    project="Subrecipient",
+                    organization=organization,
+                ),
+                binary_csv_file,
+            )

--- a/python/src/functions/subrecipient_treasury_report_gen.py
+++ b/python/src/functions/subrecipient_treasury_report_gen.py
@@ -238,7 +238,7 @@ def upload_workbook(
         )
 
     with tempfile.NamedTemporaryFile(
-        mode="r+t", encoding="utf-8", delete_on_close=False
+        mode="wt", encoding="utf-8", delete_on_close=False
     ) as new_csv_file:
         convert_xlsx_to_csv(
             new_csv_file,


### PR DESCRIPTION
Fixes #431

```
client.put_object(
TypeError: Strings must be encoded before hashing
```
## Explanation of the issue
When writing CSV or JSON files the `json` and `csv` libraries require a file-like object that is opened in text-mode. However, when uploading to S3, the `boto3` library requires all files to be opened in binary-mode.

## How was the issue fixed?
The issue is resolved by doing the following:
1. Open the temporary file in text-mode and perform the appropriate CSV/JSON writes and close the file. Note: we set `delete_on_close=False` to ensure that the temporary file does not get deleted at this point.
2. Open the temporary file again in binary-mode specifically for the purpose of uploading the file to s3.
