### PR TITLE
fix: add report.zip in the correct s3 path

### DIFF
--- a/python/src/functions/create_archive.py
+++ b/python/src/functions/create_archive.py
@@ -94,7 +94,7 @@ def create_archive(
             zipf.close()
             file.flush()
             logger.info(f"Created archive file: {file.name}")
-            upload_key = "report.zip"
+            upload_key = f"{target_key}report.zip"
             # upload the zip file to the target key
 
             s3_client.upload_file(file.name, S3_BUCKET, upload_key)

--- a/python/tests/src/lib/test_create_archive.py
+++ b/python/tests/src/lib/test_create_archive.py
@@ -30,7 +30,7 @@ def test_create_archive_creates_zip():
 
     # Assert that the file was attempted to be created
     s3_client.upload_file.assert_called_with(
-        ANY, "test_bucket", "report.zip"
+        ANY, "test_bucket", "treasuryreports/1234/5678/report.zip"
     )
 
 


### PR DESCRIPTION
## Current State
- `create_archive` lambda function is attempting to add the zip-archive to the root of `cpf-reporter` bucket.

## Expected State (after this change)
- `create_archive` lambda function uploads the newly created zip-archive to `cpf-reporter/treasuryreports/{org_id}/{reporting_period_id}/report.zip` file.