### PR TITLE
fix: ensure encryption-config is passed to s3 upload-file

### DIFF
--- a/python/src/functions/create_archive.py
+++ b/python/src/functions/create_archive.py
@@ -97,5 +97,10 @@ def create_archive(
             upload_key = f"{target_key}report.zip"
             # upload the zip file to the target key
 
-            s3_client.upload_file(file.name, S3_BUCKET, upload_key)
+            s3_client.upload_file(
+                file.name,
+                S3_BUCKET,
+                upload_key,
+                ExtraArgs={"ServerSideEncryption": "AES256"},
+            )
             logger.info(f"Uploaded archive file to {upload_key}")

--- a/python/tests/src/lib/test_create_archive.py
+++ b/python/tests/src/lib/test_create_archive.py
@@ -30,7 +30,10 @@ def test_create_archive_creates_zip():
 
     # Assert that the file was attempted to be created
     s3_client.upload_file.assert_called_with(
-        ANY, "test_bucket", "treasuryreports/1234/5678/report.zip"
+        ANY,
+        "test_bucket",
+        "treasuryreports/1234/5678/report.zip",
+        ExtraArgs={"ServerSideEncryption": "AES256"},
     )
 
 


### PR DESCRIPTION
#431 

Resolves the following [datadog error](https://app.datadoghq.com/logs?query=host%3A%22arn%3Aaws%3Alambda%3Aus-west-2%3A357150818708%3Afunction%3Acpfreporter-cpfcreatearchive%22%20service%3Acpf-reporter%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&context_event=AZJJ8uZwAACDhiIzgxRTkQAL&event=AgAAAZJJ8uTNz8Kq9gAAAAAAAAAYAAAAAEFaSko4dVp3QUFDRGhpSXpneFJUa1FBTAAAACQAAAAAMDE5MjQ5ZmEtNTBhMy00MDRhLTk5ZTAtYjcxNzBiN2IzNGEx&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&to_event=AgAAAZJJ8udNZ1QveAAAAAAAAAAYAAAAAEFaSkotUXFVQUFEazl1bngwaVpqOEFBQQAAACQAAAAAMDE5MjQ5ZmEtNTBhMy00MDRhLTk5ZTAtYjcxNzBiN2IzNGEx&viz=&from_ts=1727817208045&to_ts=1727817508686&live=false)

```
Failed to upload /tmp/tmpbc6embt1 to cpfreporter-reportingdata-357150818708-us-west-2/treasuryreports/2/1/report.zip: An error occurred (AccessDenied) when calling the PutObject operation: User: arn:aws:sts::357150818708:assumed-role/cpfreporter-cpfCreateArchive/cpfreporter-cpfCreateArchive is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::cpfreporter-reportingdata-357150818708-us-west-2/treasuryreports/2/1/report.zip" with an explicit deny in a resource-based policy
```