### PR TITLE
fix: ensure subrecipients option shows up in nav-bar

### DIFF
--- a/web/src/components/Navigation/Navigation.tsx
+++ b/web/src/components/Navigation/Navigation.tsx
@@ -32,7 +32,7 @@ const Navigation = () => {
             </NavLink>
           </Nav.Item>
         )}
-        {hasRole(ROLES.USDR_ADMIN) && (
+        {canViewAdminTabs && (
           <Nav.Item>
             <NavLink
               to={routes.subrecipients()}


### PR DESCRIPTION
#451 

## Before 
<img width="509" alt="image" src="https://github.com/user-attachments/assets/1f06126d-1935-40a2-b4d3-4275cea82686">


## After
<img width="415" alt="image" src="https://github.com/user-attachments/assets/4fbe6d62-6a56-4cbd-8b9e-152218e4d042">
