### PR TITLE
chore: hide invalidate button from all users except usdr-admins

### DIFF
--- a/web/src/components/Upload/UploadValidationButtonGroup/UploadValidationButtonGroup.tsx
+++ b/web/src/components/Upload/UploadValidationButtonGroup/UploadValidationButtonGroup.tsx
@@ -1,4 +1,6 @@
+import { ROLES } from 'api/src/lib/constants'
 import Button from 'react-bootstrap/Button'
+import { useAuth } from 'web/src/auth'
 
 import { Severity } from 'src/components/Upload/UploadValidationResultsTable/UploadValidationResultsTable'
 
@@ -32,6 +34,7 @@ const UploadValidationButtonGroup = ({
   handleForceInvalidate,
   savingUpload,
 }: UploadValidationButtonGroupProps) => {
+  const { hasRole } = useAuth()
   /*
     If the upload has been validated, renders "Invalidate" and "Re-validate" buttons
     If the upload has been invalidated, renders the "Validate" button
@@ -41,7 +44,7 @@ const UploadValidationButtonGroup = ({
 
     return (
       <>
-        {passed && (
+        {passed && hasRole(ROLES.USDR_ADMIN) && (
           <Button
             variant="outline-primary"
             size="sm"


### PR DESCRIPTION
As seen on the screenshots below this PR ensures that the Invalidate button is hidden for organization admins and only appears for USDR admins.

## Before 
<img width="1533" alt="image" src="https://github.com/user-attachments/assets/10fdcb3d-3149-434c-81f9-b1dc6945a7be">


## After
<img width="1547" alt="image" src="https://github.com/user-attachments/assets/2904be17-4699-4939-833d-63fb6ac98feb">
