### PR TITLE
Configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,10 @@ version: 2
 updates:
   - package-ecosystem: npm
     versioning-strategy: lockfile-only
-    directory: /
+    directories:
+      - /
+      - /api
+      - /web
     schedule:
       interval: daily
       time: "03:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
+
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    versioning-strategy: lockfile-only
+    directory: /
+    schedule:
+      interval: daily
+      time: "03:00"
+      timezone: America/New_York
+    commit-message:
+      prefix: 'Chore [deps:npm]'
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+      time: "03:00"
+      timezone: America/New_York
+    commit-message:
+      prefix: 'Chore [deps:github-actions]'
+  - package-ecosystem: terraform
+    directory: /terraform
+    schedule:
+      interval: daily
+      time: "03:00"
+      timezone: America/New_York
+    commit-message:
+      prefix: 'Chore [deps:terraform]'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,14 @@ updates:
       timezone: America/New_York
     commit-message:
       prefix: 'Chore [deps:npm]'
+  - package-ecosystem: pip
+    directory: /python
+    schedule:
+      interval: daily
+      time: "03:00"
+      timezone: America/New_York
+    commit-message:
+      prefix: 'Chore [deps:pip]'
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,0 +1,40 @@
+# Automatically approves pull requests if:
+#   1. The PR was opened by Dependabot
+#   2. The dependency's semantic versioning change is either minor or patch (not major)
+name: Dependabot auto-approve
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@dbb049abf0d677abbd7f7eee0375145b417fdd34 # v2.2.0
+      - name: Approve a PR if dependency semver changes are minor or patch
+        if: ${{ contains(fromJson('["version-update:semver-patch", "version-update:semver-minor"]'), steps.dependabot-metadata.outputs.update-type) }}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge if dependency semver changes are minor or patch
+        if: ${{ contains(fromJson('["version-update:semver-patch", "version-update:semver-minor"]'), steps.dependabot-metadata.outputs.update-type) }}
+        run: |
+          echo "Enabling auto-merge for Dependabot $UPDATE_TYPE"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATE_TYPE: ${{ steps.dependabot-metadata.outputs.update-type }}


### PR DESCRIPTION
This PR adds configuration for dependency management via [Dependabot](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide), which is currently only configured in repository to respond to security updates. The new configuration will enable automatic dependency management for the following Dependabot ecosystems:
- `npm` (includes [support for yarn](https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories#yarn)). This is a multi-directory setup that includes `api/package.json`, `web/package.json`, and the shared `/yarn.lock` files.
- [`pip`](https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories#pip-and-pip-compile) (includes poetry support)
- [`terraform`](https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories#terraform) (note this provides top-/project-level support only; should be fine since our terraform defines no custom module subdirectories)
- [`github-actions`](https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories#github-actions)

All ecosystems share the same schedule, which will run Dependabot daily at 3am Eastern (`America/New_York`).

Finally, this PR also includes a new GitHub Actions workflow, `Dependabot auto-approve`, which has identical behavior to the workflows with the same name that already exist in [usdigitalresponse/usdr-gost](https://github.com/usdigitalresponse/usdr-gost) and [usdigitalresponse/grants-ingest](https://github.com/usdigitalresponse/grants-ingest) repositories. As the name suggests, the purpose of this workflow is to automatically approve and merge pull requests from Dependabot where possible and sensible – in particular, auto-approval/-merge will only be enabled for `minor` and `patch` Semver changes (not for `major` version upgrades). Additionally, other repository rules, such as `CODEOWNERS` configuration, may require extra approval steps – unfortunately, this means that GitHub Actions dependency updates will not be automatically merged.
