### PR TITLE
Fix: Missing poetry in "Type-check python" GHA job

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -318,8 +318,9 @@ jobs:
         if: steps.changed-py-files.outputs.any_changed == 'true'
         env:
           CHANGED_PY_FILES: ${{ steps.changed-py-files.outputs.all_changed_files }}
-        run: mypy $CHANGED_PY_FILES --ignore-missing-imports
-
+        run: |
+          poetry install --no-interaction --no-ansi
+          poetry run mypy $CHANGED_PY_FILES --ignore-missing-imports
 
   tflint:
     name: Lint terraform

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -301,6 +301,8 @@ jobs:
           ref: ${{ inputs.ref }}
           show-progress: 'false'
           persist-credentials: 'false'
+      - name: Install poetry
+        run: pipx install poetry
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version-file: 'python/pyproject.toml'


### PR DESCRIPTION
This PR is a fast-follow to #509, where we'd agreed to use Poetry to manage the `mypy` installation, but neglected to install poetry and incorporate it into the `mypy` execution. Currently the "Type-check python" job introduced in #509 is failing  ([example](https://github.com/usdigitalresponse/cpf-reporter/actions/runs/11977494138/job/33395495614?pr=518)) during the `actions/setup-python` step with the following error:
> Error: Unable to locate executable file: poetry. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.

This PR fixes the issue by adding `pipx install poetry` prior to running `actions/setup-python` (which is a bit unintuitive, but is in fact correct according to `actions/setup-poetry` [documentation](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages)), and then modifies the conditional step of running `mypy` in the following ways:
- Install dependencies via poetry
- Run `mypy` via poetry, as `poetry run mypy ...`

**Note:** approval is needed, but this PR will need to be merged even though the "Type-check python" check will report as failing – this is because the changes from this PR won't take effect in GitHub actions until after this PR is merged.