### PR TITLE
[fix][ci] adds `working-directory` default to the `mypy` job

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -291,6 +291,9 @@ jobs:
   mypy:
     name: Type-check python
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
     steps:
       - uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -306,10 +306,12 @@ jobs:
           persist-credentials: 'false'
       - name: Install poetry
         run: pipx install poetry
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version-file: 'python/pyproject.toml'
           cache: poetry
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-ansi
       - name: Get Python changed files
         id: changed-py-files
         uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf # v45.0.4
@@ -321,9 +323,7 @@ jobs:
         if: steps.changed-py-files.outputs.any_changed == 'true'
         env:
           CHANGED_PY_FILES: ${{ steps.changed-py-files.outputs.all_changed_files }}
-        run: |
-          poetry install --no-interaction --no-ansi
-          poetry run mypy $CHANGED_PY_FILES --ignore-missing-imports
+        run: poetry run mypy $CHANGED_PY_FILES --ignore-missing-imports
 
   tflint:
     name: Lint terraform


### PR DESCRIPTION
Poetry could not find the `pyproject.toml` file because the working directory was not set to `python`, see:

https://github.com/usdigitalresponse/cpf-reporter/actions/runs/12210717069/job/34067127836?pr=516

Changes:
* adds the `working-directory` default so that the poetry install should work
* aligns the `mypy` step to the python setup version + poetry install step from the `test-python` job