### PR TITLE
[treasury-report][frontend] Add force regenerate button

### DIFF
--- a/api/src/graphql/uploads.sdl.ts
+++ b/api/src/graphql/uploads.sdl.ts
@@ -43,6 +43,7 @@ export const schema = gql`
     updateUpload(id: Int!, input: UpdateUploadInput!): Upload! @requireAuth
     deleteUpload(id: Int!): Upload! @requireAuth
     downloadUploadFile(id: Int!): String! @requireAuth
+    generateTreasuryReport(regenerate: Boolean!): Boolean! @requireAuth
     sendTreasuryReport: Boolean! @requireAuth
   }
 `

--- a/api/src/services/uploads/uploads.test.ts
+++ b/api/src/services/uploads/uploads.test.ts
@@ -411,8 +411,8 @@ describe('treasury report', () => {
             },
           },
           uploadsToRemove: {},
-          ProjectType: '1A',
           forceRegenerate: true,
+          ProjectType: '1A',
         },
         '1B': {
           organization: {
@@ -428,8 +428,8 @@ describe('treasury report', () => {
           outputTemplateId: mockReportingPeriod.outputTemplateId,
           uploadsToAdd: {},
           uploadsToRemove: {},
-          ProjectType: '1B',
           forceRegenerate: true,
+          ProjectType: '1B',
         },
         '1C': {
           organization: {
@@ -445,8 +445,8 @@ describe('treasury report', () => {
           outputTemplateId: mockReportingPeriod.outputTemplateId,
           uploadsToAdd: {},
           uploadsToRemove: {},
-          ProjectType: '1C',
           forceRegenerate: true,
+          ProjectType: '1C',
         },
       }
       const subrecipientPayload: SubrecipientLambdaPayload = {
@@ -502,7 +502,7 @@ describe('treasury report', () => {
         ...zipPayload,
         ...emailPayload,
       })
-      const result = await generateTreasuryReport({regenerate: true})
+      const result = await generateTreasuryReport({ regenerate: true })
 
       expect(result).toBe(true)
       expect(startStepFunctionExecution).toHaveBeenCalledWith(
@@ -543,8 +543,8 @@ describe('treasury report', () => {
             },
           },
           uploadsToRemove: {},
-          ProjectType: '1A',
           forceRegenerate: false,
+          ProjectType: '1A',
         },
         '1B': {
           organization: {
@@ -560,8 +560,8 @@ describe('treasury report', () => {
           outputTemplateId: mockReportingPeriod.outputTemplateId,
           uploadsToAdd: {},
           uploadsToRemove: {},
-          ProjectType: '1B',
           forceRegenerate: false,
+          ProjectType: '1B',
         },
         '1C': {
           organization: {
@@ -577,8 +577,8 @@ describe('treasury report', () => {
           outputTemplateId: mockReportingPeriod.outputTemplateId,
           uploadsToAdd: {},
           uploadsToRemove: {},
-          ProjectType: '1C',
           forceRegenerate: false,
+          ProjectType: '1C',
         },
       }
       const subrecipientPayload: SubrecipientLambdaPayload = {

--- a/api/src/services/uploads/uploads.ts
+++ b/api/src/services/uploads/uploads.ts
@@ -186,6 +186,7 @@ type UploadInfoForProject = {
   ProjectType: string
   uploadsToAdd: Partial<Record<AgencyId, UploadPayload>>
   uploadsToRemove: Partial<Record<AgencyId, UploadPayload>>
+  forceRegenerate: boolean
 }
 type InfoForSubrecipient = {
   organization: OrganizationObj
@@ -216,7 +217,8 @@ export type EmailLambdaPayload = Record<'email', InfoForEmail>
 
 export const getUploadsByExpenditureCategory = async (
   organization: Organization,
-  reportingPeriod: ReportingPeriod
+  reportingPeriod: ReportingPeriod,
+  regenerate: boolean = false
 ): Promise<ProjectLambdaPayload> => {
   const validUploadsInPeriod: UploadsWithValidationsAndExpenditureCategory[] =
     await getValidUploadsInCurrentPeriod(organization, reportingPeriod)
@@ -236,6 +238,7 @@ export const getUploadsByExpenditureCategory = async (
     outputTemplateId: reportingPeriod.outputTemplateId,
     uploadsToAdd: {},
     uploadsToRemove: {},
+    forceRegenerate: regenerate,
   }
 
   const uploadsByEC: ProjectLambdaPayload = {
@@ -363,6 +366,58 @@ export const getEmailLambdaPayload = async (
     },
   }
 }
+
+export const generateTreasuryReport: MutationResolvers['generateTreasuryReport'] =
+  async ({ regenerate }) => {
+    try {
+      const organization = await db.organization.findFirst({
+        where: { id: context.currentUser.agency.organizationId },
+      })
+      const reportingPeriod = await db.reportingPeriod.findFirst({
+        where: { id: organization.preferences['current_reporting_period_id'] },
+      })
+      const projectLambdaPayload: ProjectLambdaPayload =
+        await getUploadsByExpenditureCategory(
+          organization,
+          reportingPeriod,
+          regenerate
+        )
+      const subrecipientLambdaPayload: SubrecipientLambdaPayload =
+        await getSubrecipientLambdaPayload(
+          organization,
+          context.currentUser,
+          reportingPeriod
+        )
+      const createArchiveLambdaPayload: CreateArchiveLambdaPayload =
+        await getCreateArchiveLambdaPayload(organization)
+
+      const emailLambdaPayload: EmailLambdaPayload =
+        await getEmailLambdaPayload(organization, context.currentUser)
+
+      const input = {
+        '1A': {},
+        '1B': {},
+        '1C': {},
+        Subrecipient: {},
+        zip: {},
+        email: {},
+        ...projectLambdaPayload,
+        ...subrecipientLambdaPayload,
+        ...createArchiveLambdaPayload,
+        ...emailLambdaPayload,
+      }
+
+      await startStepFunctionExecution(
+        process.env.TREASURY_STEP_FUNCTION_ARN,
+        `Force-kick-off-${uuidv4()}`,
+        JSON.stringify(input)
+      )
+      return true
+    } catch (error) {
+      logger.error(error, 'Error sending Treasury Report')
+      throw new RedwoodError(error.message)
+    }
+  }
 
 export const sendTreasuryReport: MutationResolvers['sendTreasuryReport'] =
   async () => {

--- a/api/src/services/uploads/uploads.ts
+++ b/api/src/services/uploads/uploads.ts
@@ -218,7 +218,7 @@ export type EmailLambdaPayload = Record<'email', InfoForEmail>
 export const getUploadsByExpenditureCategory = async (
   organization: Organization,
   reportingPeriod: ReportingPeriod,
-  regenerate: boolean = false
+  regenerate = false
 ): Promise<ProjectLambdaPayload> => {
   const validUploadsInPeriod: UploadsWithValidationsAndExpenditureCategory[] =
     await getValidUploadsInCurrentPeriod(organization, reportingPeriod)
@@ -406,7 +406,6 @@ export const generateTreasuryReport: MutationResolvers['generateTreasuryReport']
         ...createArchiveLambdaPayload,
         ...emailLambdaPayload,
       }
-
       await startStepFunctionExecution(
         process.env.TREASURY_STEP_FUNCTION_ARN,
         `Force-kick-off-${uuidv4()}`,

--- a/web/src/pages/Upload/UploadsPage/UploadsPage.tsx
+++ b/web/src/pages/Upload/UploadsPage/UploadsPage.tsx
@@ -12,6 +12,11 @@ const SEND_TREASURY_REPORT = gql`
     sendTreasuryReport
   }
 `
+const GENERATE_TREASURY_REPORT = gql`
+  mutation generateTreasuryReport($regenerate: Boolean!) {
+    generateTreasuryReport(regenerate: $regenerate)
+  }
+`
 
 const UploadsPage = () => {
   const { hasRole } = useAuth()
@@ -23,9 +28,21 @@ const UploadsPage = () => {
       toast.error('Error sending Treasury Report by email: ' + error.message)
     },
   })
+  const [generateTreasuryReport] = useMutation(GENERATE_TREASURY_REPORT, {
+    onCompleted: () => {
+      toast.success('Treasury Report has been generated')
+    },
+    onError: (error) => {
+      toast.error('Error genearting Treasury Report: ' + error.message)
+    },
+  })
 
   const handleSendTreasuryReportByEmail = () => {
     sendTreasuryReport()
+  }
+
+  const handleGenerateTreasuryReport = (regenerate) => {
+    generateTreasuryReport({ variables: { regenerate } })
   }
 
   return (
@@ -49,6 +66,26 @@ const UploadsPage = () => {
         >
           Upload Workbook
         </Button>
+        {(hasRole(ROLES.USDR_ADMIN) || hasRole(ROLES.ORGANIZATION_ADMIN)) && (
+          <Button
+            size="sm"
+            variant=""
+            className="btn-outline-primary"
+            onClick={() => handleGenerateTreasuryReport(false)}
+          >
+            Generate and Send Treasury Report
+          </Button>
+        )}
+        {(hasRole(ROLES.USDR_ADMIN) || hasRole(ROLES.ORGANIZATION_ADMIN)) && (
+          <Button
+            size="sm"
+            variant=""
+            className="btn-outline-primary"
+            onClick={() => handleGenerateTreasuryReport(true)}
+          >
+            Force Regenerate and Send Treasury Report
+          </Button>
+        )}
         {/* TODO: Remove USDR_ADMIN check when ready || 2024-05-13 Milestone */}
         {(hasRole(ROLES.USDR_ADMIN) || hasRole(ROLES.ORGANIZATION_ADMIN)) && (
           <Button


### PR DESCRIPTION
Follow-up to: https://github.com/usdigitalresponse/cpf-reporter/pull/515

Changes:
* Adds a generate and send  (there will be no button to generate post-https://github.com/usdigitalresponse/cpf-reporter/pull/516)
* Adds a force-regenerate and send button

![image](https://github.com/user-attachments/assets/40a56b8d-8287-43f0-98d5-0d39ba0038b8)
