### PR TITLE
[fix][ci] remove 'python/' from changed files that are passed in

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -323,7 +323,8 @@ jobs:
         if: steps.changed-py-files.outputs.any_changed == 'true'
         env:
           CHANGED_PY_FILES: ${{ steps.changed-py-files.outputs.all_changed_files }}
-        run: poetry run mypy $CHANGED_PY_FILES --ignore-missing-imports
+        # Remove the python/ that is prepended
+        run: poetry run mypy ${CHANGED_PY_FILES//python\/} --ignore-missing-imports
 
   tflint:
     name: Lint terraform


### PR DESCRIPTION
The changed file step had `python/` prepended to the python files, but the working directory is already `python`

E: confirmed that this runs locally
```
$ poetry run mypy ${CHANGED_PY_FILES//python\/} --ignore-missing-imports
Success: no issues found in 2 source files
```